### PR TITLE
refactor: デザイントークン粒度統一

### DIFF
--- a/src/css/foundation/base.css
+++ b/src/css/foundation/base.css
@@ -14,7 +14,7 @@
   }
 
   :where(a) {
-    color: var(--color-main);
+    color: var(--color-link);
     text-decoration: none;
   }
 

--- a/src/css/project/p-contact-form.css
+++ b/src/css/project/p-contact-form.css
@@ -32,7 +32,7 @@
 
     &:focus {
       border-color: var(--color-main);
-      outline: 2px solid oklch(from var(--color-main) l c h / 25%);
+      outline: 2px solid var(--color-focus-ring);
       outline-offset: 1px;
     }
   }

--- a/src/css/theme/color.css
+++ b/src/css/theme/color.css
@@ -1,5 +1,6 @@
 @layer theme {
   :root {
+    /* 役割（グローバルセマンティック） */
     --color-main: var(--blue-600);
     --color-accent: var(--orange-500);
     --color-bg: var(--gray-50);
@@ -9,5 +10,10 @@
     --color-border: var(--gray-300);
     --color-white: var(--white);
     --color-shadow: oklch(0% 0 0deg / 10%);
+
+    /* 用途（コンテキストセマンティック） */
+    --color-link: var(--color-main);
+    --color-heading: var(--color-text);
+    --color-focus-ring: oklch(from var(--color-main) l c h / 25%);
   }
 }

--- a/src/css/theme/dark.css
+++ b/src/css/theme/dark.css
@@ -1,6 +1,7 @@
 @layer theme {
   @media (prefers-color-scheme: dark) {
     :root {
+      /* 役割 */
       --color-main: var(--blue-400);
       --color-accent: var(--orange-400);
       --color-bg: var(--gray-900);
@@ -9,6 +10,9 @@
       --color-text-light: var(--gray-400);
       --color-border: var(--gray-600);
       --color-shadow: oklch(100% 0 0deg / 8%);
+
+      /* 用途（ダークモードで上書きが必要なもののみ） */
+      --color-focus-ring: oklch(from var(--color-main) l c h / 30%);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Theme 層に用途レベルのセマンティック変数を追加（--color-link, --color-heading, --color-focus-ring）
- Foundation/Project 層を用途変数で参照するよう修正
- Tokens→役割→用途 の3層参照チェーンを確立

## Test plan
- [x] pnpm dev で4ページ表示確認
- [x] ダークモード切替確認
- [x] フォーカスリングの色が正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)