### PR TITLE
fix: tokens/structure.css のコメントから Sass 関数名を削除

### DIFF
--- a/src/css/tokens/structure.css
+++ b/src/css/tokens/structure.css
@@ -18,7 +18,7 @@
     --content-max: 1200;
     --gutter: 20;
 
-    /* clamp-linear() 代替用ヘルパー */
+    /* clamp() 用ヘルパー */
     --px: calc(1rem / 16);
     --vp-range: calc(var(--viewport-max) - var(--viewport-min));
     --vp-offset: calc(100vi - var(--viewport-min) * var(--px));


### PR DESCRIPTION
## Summary
- `/* clamp-linear() 代替用ヘルパー */` → `/* clamp() 用ヘルパー */` に修正
- Sass 移行時の残留コメントをクリーンアップ

Closes #9

## Test plan
- [ ] コメント変更のみなのでビルド・表示に影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)