### PR TITLE
fix: Foundation 層のリセット CSS を改善

### DIFF
--- a/src/css/foundation/form.css
+++ b/src/css/foundation/form.css
@@ -1,9 +1,4 @@
 @layer foundation {
-  :where(input, textarea, select, button) {
-    font: inherit;
-    color: inherit;
-  }
-
   :where(button) {
     cursor: pointer;
     border: none;

--- a/src/css/foundation/reset.css
+++ b/src/css/foundation/reset.css
@@ -21,6 +21,7 @@
     text-size-adjust: 100%;
     scrollbar-gutter: stable;
     -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
   }
 
   :where(body) {
@@ -99,8 +100,8 @@
   :where(button, input, select, textarea) {
     border: 1px solid;
     border-radius: unset;
-    color: unset;
-    font: unset;
+    color: inherit;
+    font: inherit;
     letter-spacing: unset;
   }
 
@@ -132,6 +133,7 @@
   }
 
   :where(:focus-visible) {
+    outline: 2px solid var(--color-main);
     outline-offset: 3px;
   }
 


### PR DESCRIPTION
## Summary
- `:where(:root)` に `touch-action: manipulation` 追加（300ms tap delay 排除）
- `:where(:focus-visible)` にデザイントークンベースの `outline` 追加
- Forms セクションの `font`/`color` を `unset` → `inherit` に変更（意図の明確化）
- `form.css` から `reset.css` との重複（font/color inherit）を削除

Closes #15

## Test plan
- [x] `pnpm lint:css` パス
- [x] 全4ページ × ライト/ダーク表示確認
- [x] Tab キーでフォーカスリング確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)