### PR TITLE
feat: ハンバーガーメニューを実装

### DIFF
--- a/src/contact/index.html
+++ b/src/contact/index.html
@@ -11,7 +11,16 @@
     <header class="p-header">
       <div class="p-header__inner">
         <a href="/" class="p-header__logo">mFLOCSS</a>
-        <nav aria-label="メインナビゲーション">
+        <button
+          type="button"
+          class="p-header__hamburger"
+          aria-expanded="false"
+          aria-controls="global-nav"
+          aria-label="メニューを開く"
+        >
+          <span class="p-header__hamburger-icon" aria-hidden="true"></span>
+        </button>
+        <nav id="global-nav" class="p-header__nav" aria-label="メインナビゲーション">
           <ul class="p-header__nav-list">
             <li><a href="/" class="p-header__nav-link">Top</a></li>
             <li>

--- a/src/css/project/p-header.css
+++ b/src/css/project/p-header.css
@@ -9,6 +9,7 @@
 
   .p-header__inner {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
     max-inline-size: calc(var(--content-width) / 16 * 1rem);
@@ -22,23 +23,131 @@
     color: var(--color-text);
   }
 
+  /* ハンバーガーボタン — モバイルのみ表示 */
+  .p-header__hamburger {
+    display: grid;
+    place-items: center;
+    inline-size: 2.75rem;
+    block-size: 2.75rem;
+    order: 2;
+
+    @media (width >= 768px) {
+      display: none;
+    }
+  }
+
+  /* 3本線アイコン（CSS のみ） */
+  .p-header__hamburger-icon,
+  .p-header__hamburger-icon::before,
+  .p-header__hamburger-icon::after {
+    display: block;
+    inline-size: 1.25rem;
+    block-size: 2px;
+    background-color: var(--color-text);
+    border-radius: 1px;
+    transition: transform 0.3s var(--ease-out-cubic);
+  }
+
+  .p-header__hamburger-icon {
+    position: relative;
+  }
+
+  .p-header__hamburger-icon::before,
+  .p-header__hamburger-icon::after {
+    content: "";
+    position: absolute;
+    inset-inline-start: 0;
+  }
+
+  .p-header__hamburger-icon::before {
+    transform: translateY(-6px);
+  }
+
+  .p-header__hamburger-icon::after {
+    transform: translateY(6px);
+  }
+
+  /* 開いた状態: ×アイコンに変形 */
+  [aria-expanded="true"] .p-header__hamburger-icon {
+    background-color: transparent;
+  }
+
+  [aria-expanded="true"] .p-header__hamburger-icon::before {
+    transform: rotate(45deg);
+  }
+
+  [aria-expanded="true"] .p-header__hamburger-icon::after {
+    transform: rotate(-45deg);
+  }
+
+  /* ナビゲーション */
+  .p-header__nav {
+    order: 3;
+    inline-size: 100%;
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows 0.3s var(--ease-out-cubic);
+
+    @media (width >= 768px) {
+      order: unset;
+      inline-size: auto;
+      display: block;
+    }
+  }
+
+  .p-header__nav.is-open {
+    grid-template-rows: 1fr;
+  }
+
   .p-header__nav-list {
+    overflow: hidden;
     display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem 1.5rem;
-    list-style: none;
-    padding: 0;
-    margin: 0;
+    flex-direction: column;
+    gap: 0;
+    padding-block: 0;
+
+    @media (width >= 768px) {
+      overflow: visible;
+      flex-flow: row wrap;
+      gap: 0.75rem 1.5rem;
+    }
   }
 
   .p-header__nav-link {
-    padding-block-end: 0.25rem;
-    border-block-end: 2px solid transparent;
+    display: block;
+    padding-block: 0.75rem;
+    border-block-end: 1px solid var(--color-border);
     transition: border-color 0.2s var(--ease-out-cubic);
+
+    @media (width >= 768px) {
+      padding-block: 0 0.25rem;
+      border-block-end: 2px solid transparent;
+    }
 
     &.is-current {
       color: var(--color-main);
       border-block-end-color: var(--color-main);
+    }
+  }
+
+  /* reduced-motion */
+  @media (prefers-reduced-motion: reduce) {
+    .p-header__nav,
+    .p-header__hamburger-icon,
+    .p-header__hamburger-icon::before,
+    .p-header__hamburger-icon::after {
+      transition: none;
+    }
+  }
+
+  /* JS 無効時: nav を常時表示 */
+  @media (scripting: none) {
+    .p-header__hamburger {
+      display: none;
+    }
+
+    .p-header__nav {
+      display: block;
     }
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,16 @@
     <header class="p-header">
       <div class="p-header__inner">
         <a href="/" class="p-header__logo">mFLOCSS</a>
-        <nav aria-label="メインナビゲーション">
+        <button
+          type="button"
+          class="p-header__hamburger"
+          aria-expanded="false"
+          aria-controls="global-nav"
+          aria-label="メニューを開く"
+        >
+          <span class="p-header__hamburger-icon" aria-hidden="true"></span>
+        </button>
+        <nav id="global-nav" class="p-header__nav" aria-label="メインナビゲーション">
           <ul class="p-header__nav-list">
             <li><a href="/" class="p-header__nav-link">Top</a></li>
             <li>

--- a/src/layers/index.html
+++ b/src/layers/index.html
@@ -11,7 +11,16 @@
     <header class="p-header">
       <div class="p-header__inner">
         <a href="/" class="p-header__logo">mFLOCSS</a>
-        <nav aria-label="メインナビゲーション">
+        <button
+          type="button"
+          class="p-header__hamburger"
+          aria-expanded="false"
+          aria-controls="global-nav"
+          aria-label="メニューを開く"
+        >
+          <span class="p-header__hamburger-icon" aria-hidden="true"></span>
+        </button>
+        <nav id="global-nav" class="p-header__nav" aria-label="メインナビゲーション">
           <ul class="p-header__nav-list">
             <li><a href="/" class="p-header__nav-link">Top</a></li>
             <li>

--- a/src/philosophy/index.html
+++ b/src/philosophy/index.html
@@ -11,7 +11,16 @@
     <header class="p-header">
       <div class="p-header__inner">
         <a href="/" class="p-header__logo">mFLOCSS</a>
-        <nav aria-label="メインナビゲーション">
+        <button
+          type="button"
+          class="p-header__hamburger"
+          aria-expanded="false"
+          aria-controls="global-nav"
+          aria-label="メニューを開く"
+        >
+          <span class="p-header__hamburger-icon" aria-hidden="true"></span>
+        </button>
+        <nav id="global-nav" class="p-header__nav" aria-label="メインナビゲーション">
           <ul class="p-header__nav-list">
             <li><a href="/" class="p-header__nav-link">Top</a></li>
             <li>

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -42,8 +42,26 @@ const markCurrentNav = () => {
   });
 };
 
+const initMobileNav = () => {
+  const button = document.querySelector('.p-header__hamburger');
+  const nav = document.querySelector('.p-header__nav');
+
+  if (!button || !nav) return;
+
+  button.addEventListener('click', () => {
+    const isOpen = button.getAttribute('aria-expanded') === 'true';
+    button.setAttribute('aria-expanded', String(!isOpen));
+    button.setAttribute(
+      'aria-label',
+      isOpen ? 'メニューを開く' : 'メニューを閉じる',
+    );
+    nav.classList.toggle('is-open');
+  });
+};
+
 document.addEventListener('DOMContentLoaded', () => {
   markCurrentNav();
+  initMobileNav();
   initStaggerDelays();
   observeAnimations();
 });


### PR DESCRIPTION
## Summary
- CSS: `grid-template-rows: 0fr → 1fr` アコーディオンで高さ不定の開閉アニメーション
- HTML: 全4ページに `aria-expanded`/`aria-controls`/`aria-label` を追加
- JS: `initMobileNav()` で開閉ロジックを追加
- `prefers-reduced-motion: reduce` でアニメーション無効化
- `@media (scripting: none)` で JS 無効時のフォールバック

Closes #16

## Test plan
- [x] `pnpm lint:css` + `pnpm lint:js` パス
- [x] 全4ページ × モバイル (400px) / デスクトップ (1440px) 表示確認
- [x] ハンバーガーボタンの開閉アニメーション（3本線 → × アイコン）
- [x] メニュー開閉時の grid-template-rows アコーディオン
- [x] Tab キーでのフォーカス移動
- [x] デスクトップ幅でハンバーガーボタン非表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)