### PR TITLE
refactor: トークン体系・レイアウト・ホバーの改善

### DIFF
--- a/src/contact/index.html
+++ b/src/contact/index.html
@@ -11,7 +11,7 @@
   <body>
     <a href="#main" class="u-visually-hidden">コンテンツへスキップ</a>
     <header class="p-header">
-      <div class="p-header__inner">
+      <div class="l-inner p-header__inner">
         <a href="/" class="p-header__logo">mFLOCSS</a>
         <button
           type="button"
@@ -41,9 +41,9 @@
 
     <main id="main">
       <section class="l-section">
-        <div class="l-section__inner">
+        <div class="l-inner">
           <h1 class="c-section-heading a-fade-in-activate">Contact</h1>
-          <p class="u-text-center a-fade-in-slide-up" style="margin-block-start: 1rem">
+          <p class="a-fade-in-slide-up" style="text-align: center; margin-block-start: 1rem">
             お問い合わせフォームのサンプルです。<br />
             Foundation 層のフォームリセットと Project 層の <code>p-contact-form</code> の組み合わせを確認できます。
           </p>
@@ -104,7 +104,7 @@
     </main>
 
     <footer class="p-footer">
-      <div class="p-footer__inner">
+      <div class="l-inner p-footer__inner">
         <nav class="p-footer__nav" aria-label="フッターナビゲーション">
           <div class="p-footer__nav-group">
             <p class="p-footer__nav-heading">Learn</p>

--- a/src/css/component/c-button-cta.css
+++ b/src/css/component/c-button-cta.css
@@ -13,13 +13,13 @@
       background-color 0.3s var(--ease-out-cubic),
       translate 0.3s var(--ease-out-cubic);
 
-    &:hover {
-      background-color: oklch(from var(--color-main) calc(l - 0.05) c h);
-      translate: 0 -1px;
-    }
-
     &:active {
       translate: 0 0;
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-focus-ring);
+      outline-offset: 2px;
     }
 
     &.-large {
@@ -30,10 +30,17 @@
 
     &.-accent {
       background-color: var(--color-accent);
+    }
+  }
 
-      &:hover {
-        background-color: oklch(from var(--color-accent) calc(l - 0.05) c h);
-      }
+  @media (any-hover: hover) {
+    .c-button-cta:hover:not(:disabled) {
+      background-color: oklch(from var(--color-main) calc(l - 0.05) c h);
+      translate: 0 -1px;
+    }
+
+    .c-button-cta.-accent:hover:not(:disabled) {
+      background-color: oklch(from var(--color-accent) calc(l - 0.05) c h);
     }
   }
 

--- a/src/css/component/c-card.css
+++ b/src/css/component/c-card.css
@@ -10,7 +10,14 @@
       box-shadow 0.3s var(--ease-out-cubic),
       translate 0.3s var(--ease-out-cubic);
 
-    &:hover {
+    &:focus-visible {
+      outline: 2px solid var(--color-focus-ring);
+      outline-offset: 2px;
+    }
+  }
+
+  @media (any-hover: hover) {
+    .c-card:hover {
       box-shadow: 0 8px 24px var(--color-shadow);
       translate: 0 -2px;
     }

--- a/src/css/layout/l-grid.css
+++ b/src/css/layout/l-grid.css
@@ -1,18 +1,18 @@
 @layer layout {
   .l-grid {
-    --_columns: 3;
-    --_gap: 1.5rem;
+    --_columns: 1;
+    --_gap: calc(24 * var(--px));
 
     display: grid;
     grid-template-columns: repeat(var(--_columns), 1fr);
     gap: var(--_gap);
 
-    @media (width < 768px) {
-      --_columns: 1;
+    @media (width >= 768px) {
+      --_columns: 2;
     }
 
-    @media (768px <= width < 1024px) {
-      --_columns: 2;
+    @media (width >= 1024px) {
+      --_columns: 3;
     }
   }
 }

--- a/src/css/layout/l-inner.css
+++ b/src/css/layout/l-inner.css
@@ -1,0 +1,8 @@
+@layer layout {
+  .l-inner {
+    box-sizing: content-box;
+    max-inline-size: calc(var(--content-width) * var(--px));
+    padding-inline: var(--content-padding-inline);
+    margin-inline: auto;
+  }
+}

--- a/src/css/layout/l-section.css
+++ b/src/css/layout/l-section.css
@@ -9,10 +9,4 @@
       calc(var(--_max) * var(--px))
     );
   }
-
-  .l-section__inner {
-    max-inline-size: calc(var(--content-width) / 16 * 1rem);
-    margin-inline: auto;
-    padding-inline: calc(var(--content-padding-inline) / 16 * 1rem);
-  }
 }

--- a/src/css/layout/l-stack.css
+++ b/src/css/layout/l-stack.css
@@ -1,6 +1,6 @@
 @layer layout {
   .l-stack {
-    --_gap: 1.5rem;
+    --_gap: calc(24 * var(--px));
 
     display: flex;
     flex-direction: column;

--- a/src/css/project/p-footer.css
+++ b/src/css/project/p-footer.css
@@ -5,9 +5,7 @@
   }
 
   .p-footer__inner {
-    max-inline-size: calc(var(--content-width) / 16 * 1rem);
-    margin-inline: auto;
-    padding-inline: calc(var(--content-padding-inline) / 16 * 1rem);
+    display: contents;
   }
 
   .p-footer__nav {
@@ -36,7 +34,14 @@
     color: var(--color-text-light);
     transition: color 0.2s var(--ease-out-cubic);
 
-    &:hover {
+    &:focus-visible {
+      outline: 2px solid var(--color-focus-ring);
+      outline-offset: 2px;
+    }
+  }
+
+  @media (any-hover: hover) {
+    .p-footer__nav-link:hover {
       color: var(--color-text);
     }
   }

--- a/src/css/project/p-header.css
+++ b/src/css/project/p-header.css
@@ -12,9 +12,6 @@
     flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
-    max-inline-size: calc(var(--content-width) / 16 * 1rem);
-    margin-inline: auto;
-    padding-inline: calc(var(--content-padding-inline) / 16 * 1rem);
   }
 
   .p-header__logo {

--- a/src/css/project/p-hero.css
+++ b/src/css/project/p-hero.css
@@ -12,12 +12,6 @@
     background: radial-gradient(ellipse at 50% 0%, oklch(from var(--color-main) l c h / 6%) 0%, transparent 70%);
   }
 
-  .p-hero__inner {
-    max-inline-size: calc(var(--content-width) / 16 * 1rem);
-    margin-inline: auto;
-    padding-inline: calc(var(--content-padding-inline) / 16 * 1rem);
-  }
-
   .p-hero__title {
     --_min: 28;
     --_max: 48;

--- a/src/css/project/p-layer-showcase.css
+++ b/src/css/project/p-layer-showcase.css
@@ -7,7 +7,7 @@
 
   .p-layer-showcase__item {
     display: grid;
-    grid-template-columns: auto 1fr;
+    grid-template-columns: 1fr;
     gap: 1rem 1.5rem;
     align-items: start;
     padding: 1.5rem;
@@ -15,8 +15,8 @@
     border: 1px solid var(--color-border);
     border-radius: 0.5rem;
 
-    @media (width < 768px) {
-      grid-template-columns: 1fr;
+    @media (width >= 768px) {
+      grid-template-columns: auto 1fr;
     }
   }
 
@@ -33,12 +33,12 @@
   }
 
   .p-layer-showcase__description {
-    grid-column: 2 / -1;
+    grid-column: 1 / -1;
     color: var(--color-text-light);
     line-height: var(--line-height-base);
 
-    @media (width < 768px) {
-      grid-column: 1 / -1;
+    @media (width >= 768px) {
+      grid-column: 2 / -1;
     }
   }
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -21,6 +21,7 @@
 
 /* Layout */
 @import './layout/l-section.css';
+@import './layout/l-inner.css';
 @import './layout/l-grid.css';
 @import './layout/l-stack.css';
 
@@ -49,4 +50,3 @@
 
 /* Utility */
 @import './utility/u-hidden.css';
-@import './utility/u-text.css';

--- a/src/css/theme/structure.css
+++ b/src/css/theme/structure.css
@@ -1,6 +1,14 @@
 @layer theme {
   :root {
     --content-width: var(--content-max);
-    --content-padding-inline: var(--gutter);
+    --content-padding-inline: clamp(
+      calc(var(--gutter-min) * var(--px)),
+      calc(
+        (var(--gutter-max) - var(--gutter-min))
+        / var(--vp-range) * var(--vp-offset)
+        + var(--gutter-min) * var(--px)
+      ),
+      calc(var(--gutter-max) * var(--px))
+    );
   }
 }

--- a/src/css/tokens/structure.css
+++ b/src/css/tokens/structure.css
@@ -2,7 +2,7 @@
 @property --viewport-min {
   syntax: '<number>';
   inherits: true;
-  initial-value: 390;
+  initial-value: 400;
 }
 
 @property --viewport-max {
@@ -13,10 +13,11 @@
 
 @layer tokens {
   :root {
-    --viewport-min: 390;
+    --viewport-min: 400;
     --viewport-max: 1440;
-    --content-max: 1200;
-    --gutter: 20;
+    --content-max: 1280;
+    --gutter-min: 16;
+    --gutter-max: 80;
 
     /* clamp() 用ヘルパー */
     --px: calc(1rem / 16);

--- a/src/css/utility/u-text.css
+++ b/src/css/utility/u-text.css
@@ -1,9 +1,0 @@
-@layer utility {
-  .u-text-center {
-    text-align: center !important;
-  }
-
-  .u-text-small {
-    font-size: 0.875rem !important;
-  }
-}

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
   <body>
     <a href="#main" class="u-visually-hidden">コンテンツへスキップ</a>
     <header class="p-header">
-      <div class="p-header__inner">
+      <div class="l-inner p-header__inner">
         <a href="/" class="p-header__logo">mFLOCSS</a>
         <button
           type="button"
@@ -42,7 +42,7 @@
     <main id="main">
       <!-- Project: Hero — サイト固有のデザインに依存するため Project 層 -->
       <section class="p-hero">
-        <div class="p-hero__inner">
+        <div class="l-inner">
           <h1 class="p-hero__title a-fade-in-activate">
             その FLOCSS、<br />なぜそこに書いた？
           </h1>
@@ -64,11 +64,11 @@
 
       <!-- 8層カード — Layout(l-grid) + Component(c-card, c-badge) の組み合わせ -->
       <section class="l-section">
-        <div class="l-section__inner">
+        <div class="l-inner">
           <h2 class="c-section-heading a-fade-in-activate">
             8層アーキテクチャ
           </h2>
-          <p class="u-text-center a-fade-in-slide-up">
+          <p class="a-fade-in-slide-up" style="text-align: center">
             mFLOCSS は CSS を 8 つのフラットな層に分類します。<br />
             各層は <code>@layer</code> で優先順位が固定され、詳細度の衝突が起きません。
           </p>
@@ -159,7 +159,7 @@
 
       <!-- @layer コード例 -->
       <section class="l-section">
-        <div class="l-section__inner">
+        <div class="l-inner">
           <h2 class="c-section-heading a-fade-in-activate">
             @layer で詳細度を制御する
           </h2>
@@ -204,7 +204,7 @@
 
       <!-- CTA -->
       <section class="l-section">
-        <div class="l-section__inner u-text-center">
+        <div class="l-inner" style="text-align: center">
           <h2 class="c-section-heading a-fade-in-activate">
             設計思想を身につけよう
           </h2>
@@ -222,7 +222,7 @@
     </main>
 
     <footer class="p-footer">
-      <div class="p-footer__inner">
+      <div class="l-inner p-footer__inner">
         <nav class="p-footer__nav" aria-label="フッターナビゲーション">
           <div class="p-footer__nav-group">
             <p class="p-footer__nav-heading">Learn</p>

--- a/src/layers/index.html
+++ b/src/layers/index.html
@@ -11,7 +11,7 @@
   <body>
     <a href="#main" class="u-visually-hidden">コンテンツへスキップ</a>
     <header class="p-header">
-      <div class="p-header__inner">
+      <div class="l-inner p-header__inner">
         <a href="/" class="p-header__logo">mFLOCSS</a>
         <button
           type="button"
@@ -41,11 +41,11 @@
 
     <main id="main">
       <section class="l-section">
-        <div class="l-section__inner">
+        <div class="l-inner">
           <h1 class="c-section-heading a-fade-in-activate">
             8層を理解する
           </h1>
-          <p class="u-text-center a-fade-in-slide-up" style="margin-block-start: 1rem">
+          <p class="a-fade-in-slide-up" style="text-align: center; margin-block-start: 1rem">
             各層の「なぜ」を知ることで、「どこに書くか」の判断基準が身につきます。<br />
             このサイト自身の実装コードを例に解説します。
           </p>
@@ -54,7 +54,7 @@
 
       <!-- Tokens + Theme -->
       <section class="l-section" style="padding-block-start: 0">
-        <div class="l-section__inner">
+        <div class="l-inner">
           <div class="p-layer-showcase a-fade-in-slide-up">
             <div class="p-layer-showcase__item">
               <div class="p-layer-showcase__header">
@@ -78,7 +78,7 @@
   }
 }</code></pre>
                   </div>
-                  <p class="u-text-small">
+                  <p style="font-size: 0.875rem">
                     <strong>判断基準:</strong> 値に意味を持たせない。<code>--slate-600</code> は「スレートの 600 番」であり、「メインカラー」ではない。
                   </p>
                 </div>
@@ -148,7 +148,7 @@
   }
 }</code></pre>
                   </div>
-                  <p class="u-text-small">
+                  <p style="font-size: 0.875rem">
                     <strong>判断基準:</strong> 「クラスなしの HTML 要素に適用すべきスタイルか？」 → Yes なら Foundation。
                   </p>
                 </div>
@@ -170,15 +170,15 @@
                     <div class="c-code-block__header">layout/l-grid.css — このサイトの実装</div>
                     <pre class="c-code-block__body"><code>@layer layout {
   .l-grid {
-    --_columns: 3;
-    --_gap: 1.5rem;
+    --_columns: 1;
+    --_gap: calc(24 * var(--px));
     display: grid;
     grid-template-columns: repeat(var(--_columns), 1fr);
     gap: var(--_gap);
   }
 }</code></pre>
                   </div>
-                  <p class="u-text-small">
+                  <p style="font-size: 0.875rem">
                     <strong>判断基準:</strong> 「色やフォントに触れているか？」 → 触れているなら Layout ではない。
                   </p>
                 </div>
@@ -207,7 +207,7 @@
   }
 }</code></pre>
                   </div>
-                  <p class="u-text-small">
+                  <p style="font-size: 0.875rem">
                     <strong>Modifier</strong> は <code>.-large</code> のようにハイフン始まりの短縮記法。
                     BEM の <code>--modifier</code> より簡潔で、HTML の可読性が向上します。
                   </p>
@@ -236,7 +236,7 @@
                     中に <code>c-button-cta</code>（Component）を含んでいます。
                     Project は Component を組み合わせて、サイト固有の文脈を作ります。
                   </p>
-                  <p class="u-text-small">
+                  <p style="font-size: 0.875rem">
                     <strong>State クラス:</strong> <code>.is-current</code> のような動的な状態変化は State クラスで管理。
                     Modifier（静的なバリエーション）とは区別します。
                   </p>
@@ -270,7 +270,7 @@
   }
 }</code></pre>
                   </div>
-                  <p class="u-text-small">
+                  <p style="font-size: 0.875rem">
                     <strong>判断基準:</strong> アニメーションのロジックは Animation 層に集約。Component や Project には書かない。
                   </p>
                 </div>
@@ -306,7 +306,7 @@
   }
 }</code></pre>
                   </div>
-                  <p class="u-text-small">
+                  <p style="font-size: 0.875rem">
                     <strong>判断基準:</strong> 「Utility でないと解決できないか？」 → Component や Project で対応できるなら、そちらに書く。
                   </p>
                 </div>
@@ -318,7 +318,7 @@
 
       <!-- まとめ CTA -->
       <section class="l-section">
-        <div class="l-section__inner u-text-center">
+        <div class="l-inner" style="text-align: center">
           <h2 class="c-section-heading a-fade-in-activate">
             判断基準を身につけたら
           </h2>
@@ -331,7 +331,7 @@
     </main>
 
     <footer class="p-footer">
-      <div class="p-footer__inner">
+      <div class="l-inner p-footer__inner">
         <nav class="p-footer__nav" aria-label="フッターナビゲーション">
           <div class="p-footer__nav-group">
             <p class="p-footer__nav-heading">Learn</p>

--- a/src/philosophy/index.html
+++ b/src/philosophy/index.html
@@ -11,7 +11,7 @@
   <body>
     <a href="#main" class="u-visually-hidden">コンテンツへスキップ</a>
     <header class="p-header">
-      <div class="p-header__inner">
+      <div class="l-inner p-header__inner">
         <a href="/" class="p-header__logo">mFLOCSS</a>
         <button
           type="button"
@@ -41,7 +41,7 @@
 
     <main id="main">
       <section class="l-section">
-        <div class="l-section__inner">
+        <div class="l-inner">
           <h1 class="c-section-heading a-fade-in-activate">
             なぜ「設計思想」が先なのか
           </h1>
@@ -262,7 +262,7 @@
     </main>
 
     <footer class="p-footer">
-      <div class="p-footer__inner">
+      <div class="l-inner p-footer__inner">
         <nav class="p-footer__nav" aria-label="フッターナビゲーション">
           <div class="p-footer__nav-group">
             <p class="p-footer__nav-heading">Learn</p>


### PR DESCRIPTION
## Summary

zenn-content PR #17 のレビュー対応（リファレンス実装側）。

- **トークン体系**: viewport-min 400, content-max 1280, gutter 流体 16→80px
- **l-inner 新設**: l-section__inner を Layout 層に昇格。content-box パターンで幅制約を統一
- **SP ファースト統一**: l-grid, p-layer-showcase のメディアクエリを書き換え
- **hover 改善**: `@media (any-hover: hover)` + `:not(:disabled)` でタッチ端末対応
- **:focus-visible**: c-button-cta, c-card, p-footer__nav-link に統一的なフォーカスリング追加
- **gap 統一**: l-stack, l-grid の gap を `calc(24 * var(--px))` に
- **u-text.css 削除**: Utility 層のスコープを「表示制御 + アクセシビリティ」に限定

## Test plan

- [x] `pnpm dev` で SP / 768px / 1024px の動作確認
- [x] l-inner のコンテンツ幅制約が header / hero / section / footer で統一されていること
- [x] hover がタッチ端末で発火しないこと（DevTools のタッチモードで確認）
- [x] :focus-visible がキーボード操作時に表示されること
- [x] 流体 gutter が SP(16px) ↔ DT(80px) でスムーズにスケールすること

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)