### PR TITLE
chore: Zenn Book URL と公式サイトリンクを追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ src/css/
 
 ## この本について
 
-<!-- TODO: 公開後に URL を追加 -->
-「そのFLOCSS、なぜそこに書いた？ —— mFLOCSS で迷わない CSS 設計の判断基準」
+[そのFLOCSS、なぜそこに書いた？ —— mFLOCSS で迷わない CSS 設計の判断基準](https://zenn.dev/shunei/books/mflocss-design)
+
+公式サイト: [mflocss.dev](https://mflocss.dev)
 
 ## ライセンス
 


### PR DESCRIPTION
## Summary
- README「この本について」セクションに Zenn Book URL を追加
- 公式サイト mflocss.dev へのリンクを追加

## Test plan
- [x] Zenn Book URL が `zenn.dev/shunei/books/mflocss-design` で正しい
- [x] TODO コメント削除済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)