### PR TITLE
refactor: CSS 品質改善 — 参照チェーン・:where()・!important 統一

### DIFF
--- a/src/css/component/c-badge.css
+++ b/src/css/component/c-badge.css
@@ -11,35 +11,35 @@
     border-radius: 100vmax;
 
     &.-tokens {
-      background-color: oklch(55% 0.18 290deg);
+      background-color: var(--layer-tokens);
     }
 
     &.-theme {
-      background-color: oklch(55% 0.20 250deg);
+      background-color: var(--layer-theme);
     }
 
     &.-foundation {
-      background-color: oklch(50% 0.18 210deg);
+      background-color: var(--layer-foundation);
     }
 
     &.-layout {
-      background-color: oklch(50% 0.16 170deg);
+      background-color: var(--layer-layout);
     }
 
     &.-component {
-      background-color: oklch(55% 0.18 130deg);
+      background-color: var(--layer-component);
     }
 
     &.-project {
-      background-color: oklch(55% 0.20 65deg);
+      background-color: var(--layer-project);
     }
 
     &.-animation {
-      background-color: oklch(55% 0.22 30deg);
+      background-color: var(--layer-animation);
     }
 
     &.-utility {
-      background-color: oklch(55% 0.22 10deg);
+      background-color: var(--layer-utility);
     }
   }
 }

--- a/src/css/component/c-code-block.css
+++ b/src/css/component/c-code-block.css
@@ -24,6 +24,6 @@
     background-color: var(--color-bg);
     white-space: pre;
     tab-size: 2;
-    font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+    font-family: var(--font-family-code);
   }
 }

--- a/src/css/foundation/reset.css
+++ b/src/css/foundation/reset.css
@@ -4,9 +4,7 @@
  */
 @layer foundation {
   /* Universal */
-  *,
-  ::before,
-  ::after {
+  :where(*, ::before, ::after) {
     box-sizing: border-box;
   }
 
@@ -117,7 +115,7 @@
     resize: block;
   }
 
-  ::placeholder {
+  :where(::placeholder) {
     opacity: unset;
   }
 
@@ -141,7 +139,7 @@
     cursor: default;
   }
 
-  [hidden]:not([hidden="until-found" i]) {
+  :where([hidden]:not([hidden="until-found" i])) {
     display: none !important;
   }
 }

--- a/src/css/theme/color.css
+++ b/src/css/theme/color.css
@@ -10,7 +10,7 @@
     --color-text-light: var(--neutral-600);
     --color-border: var(--neutral-300);
     --color-white: var(--white);
-    --color-shadow: oklch(0% 0 0deg / 10%);
+    --color-shadow: oklch(from var(--black) l c h / 10%);
 
     /* 用途（コンテキストセマンティック） */
     --color-link: var(--color-main);

--- a/src/css/theme/dark.css
+++ b/src/css/theme/dark.css
@@ -10,7 +10,7 @@
       --color-text: var(--neutral-50);
       --color-text-light: var(--neutral-400);
       --color-border: var(--neutral-600);
-      --color-shadow: oklch(100% 0 0deg / 8%);
+      --color-shadow: oklch(from var(--white) l c h / 8%);
 
       /* 用途（ダークモードで上書きが必要なもののみ） */
       --color-focus-ring: oklch(from var(--color-main) l c h / 30%);

--- a/src/css/theme/typography.css
+++ b/src/css/theme/typography.css
@@ -1,6 +1,7 @@
 @layer theme {
   :root {
     --font-family-ja: var(--font-ja);
+    --font-family-code: var(--font-code);
     --font-weight-regular: var(--weight-regular);
     --font-weight-bold: var(--weight-bold);
     --line-height-base: var(--leading-relaxed);

--- a/src/css/tokens/color.css
+++ b/src/css/tokens/color.css
@@ -49,5 +49,19 @@
     --neutral-900: oklch(17% 0.008 240deg);
     --neutral-950: oklch(10% 0.005 240deg);
     --white: oklch(100% 0 0deg);
+    --black: oklch(0% 0 0deg);
+
+    /* ============================================
+       Layer Identity — 層バッジ用カラー
+       各層のアイデンティティを示す装飾色。
+       ============================================ */
+    --layer-tokens: oklch(55% 0.18 290deg);
+    --layer-theme: oklch(55% 0.20 250deg);
+    --layer-foundation: oklch(50% 0.18 210deg);
+    --layer-layout: oklch(50% 0.16 170deg);
+    --layer-component: oklch(55% 0.18 130deg);
+    --layer-project: oklch(55% 0.20 65deg);
+    --layer-animation: oklch(55% 0.22 30deg);
+    --layer-utility: oklch(55% 0.22 10deg);
   }
 }

--- a/src/css/tokens/typography.css
+++ b/src/css/tokens/typography.css
@@ -2,6 +2,7 @@
   :root {
     --font-ja: 'Noto Sans JP', 'Hiragino Sans',
       'Hiragino Kaku Gothic ProN', meiryo, sans-serif;
+    --font-code: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
     --weight-regular: 400;
     --weight-bold: 700;
     --leading-relaxed: 1.8;

--- a/src/css/utility/u-hidden.css
+++ b/src/css/utility/u-hidden.css
@@ -32,11 +32,11 @@
       margin: 0 !important;
       overflow: visible !important;
       clip-path: none !important;
-      font-size: 0.875rem;
-      font-weight: var(--font-weight-bold);
-      color: var(--color-white);
-      background-color: var(--color-main);
-      z-index: var(--z-fixed);
+      font-size: 0.875rem !important;
+      font-weight: var(--font-weight-bold) !important;
+      color: var(--color-white) !important;
+      background-color: var(--color-main) !important;
+      z-index: var(--z-fixed) !important;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Tokens → Theme → 各層 の参照チェーンを統一（`--color-shadow` 直値解消、`--font-family-code` 新設、`c-badge` 8色トークン化）
- Foundation 層の `:where()` を全セレクタで統一（`*`, `::placeholder`, `[hidden]`）
- Utility 層の `!important` を全プロパティで統一（`u-visually-hidden:focus` 内5プロパティ）

mflocss.dev 側: mflocss/mflocss.dev#17

## Test plan
- [x] `pnpm build` でビルドエラーなし
- [ ] ブラウザで表示確認
- [ ] 層バッジの色が変わっていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)