### PR TITLE
refactor: c-skip-link コンポーネント分離

### DIFF
--- a/src/contact/index.html
+++ b/src/contact/index.html
@@ -9,7 +9,7 @@
     <script type="module" src="/scripts/main.js"></script>
   </head>
   <body>
-    <a href="#main" class="u-visually-hidden">コンテンツへスキップ</a>
+    <a href="#main" class="c-skip-link">コンテンツへスキップ</a>
     <header class="p-header">
       <div class="l-inner p-header__inner">
         <a href="/" class="p-header__logo">mFLOCSS</a>

--- a/src/css/component/c-skip-link.css
+++ b/src/css/component/c-skip-link.css
@@ -1,0 +1,30 @@
+@layer component {
+  .c-skip-link {
+    position: absolute;
+    inline-size: 1px;
+    block-size: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+
+    &:focus {
+      position: fixed;
+      inset-block-start: 0;
+      inset-inline-start: 0;
+      inline-size: auto;
+      block-size: auto;
+      padding: 0.75em 1.5em;
+      margin: 0;
+      overflow: visible;
+      clip-path: none;
+      font-size: 0.875rem;
+      font-weight: var(--font-weight-bold);
+      color: var(--color-white);
+      background-color: var(--color-main);
+      z-index: var(--z-fixed);
+    }
+  }
+}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -33,6 +33,7 @@
 @import './component/c-badge.css';
 @import './component/c-table.css';
 @import './component/c-blockquote.css';
+@import './component/c-skip-link.css';
 
 /* Project */
 @import './project/p-header.css';

--- a/src/css/utility/u-hidden.css
+++ b/src/css/utility/u-hidden.css
@@ -21,22 +21,5 @@
     clip-path: inset(50%) !important;
     white-space: nowrap !important;
     border: 0 !important;
-
-    &:focus {
-      position: fixed !important;
-      inset-block-start: 0 !important;
-      inset-inline-start: 0 !important;
-      inline-size: auto !important;
-      block-size: auto !important;
-      padding: 0.75em 1.5em !important;
-      margin: 0 !important;
-      overflow: visible !important;
-      clip-path: none !important;
-      font-size: 0.875rem !important;
-      font-weight: var(--font-weight-bold) !important;
-      color: var(--color-white) !important;
-      background-color: var(--color-main) !important;
-      z-index: var(--z-fixed) !important;
-    }
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -9,7 +9,7 @@
     <script type="module" src="/scripts/main.js"></script>
   </head>
   <body>
-    <a href="#main" class="u-visually-hidden">コンテンツへスキップ</a>
+    <a href="#main" class="c-skip-link">コンテンツへスキップ</a>
     <header class="p-header">
       <div class="l-inner p-header__inner">
         <a href="/" class="p-header__logo">mFLOCSS</a>

--- a/src/layers/index.html
+++ b/src/layers/index.html
@@ -9,7 +9,7 @@
     <script type="module" src="/scripts/main.js"></script>
   </head>
   <body>
-    <a href="#main" class="u-visually-hidden">コンテンツへスキップ</a>
+    <a href="#main" class="c-skip-link">コンテンツへスキップ</a>
     <header class="p-header">
       <div class="l-inner p-header__inner">
         <a href="/" class="p-header__logo">mFLOCSS</a>

--- a/src/philosophy/index.html
+++ b/src/philosophy/index.html
@@ -9,7 +9,7 @@
     <script type="module" src="/scripts/main.js"></script>
   </head>
   <body>
-    <a href="#main" class="u-visually-hidden">コンテンツへスキップ</a>
+    <a href="#main" class="c-skip-link">コンテンツへスキップ</a>
     <header class="p-header">
       <div class="l-inner p-header__inner">
         <a href="/" class="p-header__logo">mFLOCSS</a>


### PR DESCRIPTION
## Summary

- `.u-visually-hidden`（Utility 層）から skip link 用の `:focus` スタイルを `c-skip-link`（Component 層）に分離
- Utility は「汎用の非表示」、Component は「フォーカス時に表示する skip link」と責務を明確化
- table caption 等は `.u-visually-hidden` のまま（変更なし）

## 設計判断

- `!important` なし — Component 層なので不要。Utility と違い「上書き」ではなく「コンポーネント自身のスタイル」
- 非表示スタイルを自己完結で持つ — `.u-visually-hidden` に依存しない。Component は Utility に依存すべきでない
- 「別サイトにそのまま持っていけるか？」→ Yes → Component 層が適切

## 変更ファイル

| ファイル | 変更 |
|---------|------|
| `src/css/component/c-skip-link.css` | 新規作成 |
| `src/css/utility/u-hidden.css` | `:focus` ブロック削除 |
| `src/css/style.css` | @import 追加 |
| `src/index.html` | class 変更 |
| `src/philosophy/index.html` | class 変更（skip link のみ。caption は据え置き） |
| `src/layers/index.html` | class 変更 |
| `src/contact/index.html` | class 変更 |

## Test plan

- [x] `pnpm build` でビルドエラーなし
- [x] Tab キー押下 → skip link が画面左上に表示される
- [x] table caption にフォーカスしても何も表示されない

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)