### PR TITLE
refactor: Layer Identity トークンをプリミティブ名に変更

### DIFF
--- a/src/css/component/c-badge.css
+++ b/src/css/component/c-badge.css
@@ -11,35 +11,35 @@
     border-radius: 100vmax;
 
     &.-tokens {
-      background-color: var(--layer-tokens);
+      background-color: var(--color-layer-tokens);
     }
 
     &.-theme {
-      background-color: var(--layer-theme);
+      background-color: var(--color-layer-theme);
     }
 
     &.-foundation {
-      background-color: var(--layer-foundation);
+      background-color: var(--color-layer-foundation);
     }
 
     &.-layout {
-      background-color: var(--layer-layout);
+      background-color: var(--color-layer-layout);
     }
 
     &.-component {
-      background-color: var(--layer-component);
+      background-color: var(--color-layer-component);
     }
 
     &.-project {
-      background-color: var(--layer-project);
+      background-color: var(--color-layer-project);
     }
 
     &.-animation {
-      background-color: var(--layer-animation);
+      background-color: var(--color-layer-animation);
     }
 
     &.-utility {
-      background-color: var(--layer-utility);
+      background-color: var(--color-layer-utility);
     }
   }
 }

--- a/src/css/theme/color.css
+++ b/src/css/theme/color.css
@@ -18,6 +18,16 @@
     --color-link: var(--color-main);
     --color-heading: var(--color-text);
     --color-focus-ring: light-dark(oklch(from var(--color-main) l c h / 25%), oklch(from var(--color-main) l c h / 30%));
+
+    /* 層バッジ */
+    --color-layer-tokens: var(--violet-500);
+    --color-layer-theme: var(--indigo-500);
+    --color-layer-foundation: var(--blue-500);
+    --color-layer-layout: var(--teal-500);
+    --color-layer-component: var(--green-500);
+    --color-layer-project: var(--amber-500);
+    --color-layer-animation: var(--orange-500);
+    --color-layer-utility: var(--rose-500);
   }
 
 }

--- a/src/css/tokens/color.css
+++ b/src/css/tokens/color.css
@@ -52,16 +52,15 @@
     --black: oklch(0% 0 0deg);
 
     /* ============================================
-       Layer Identity — 層バッジ用カラー
-       各層のアイデンティティを示す装飾色。
+       Accent Hues — 装飾用の単色トークン
        ============================================ */
-    --layer-tokens: oklch(55% 0.18 290deg);
-    --layer-theme: oklch(55% 0.20 250deg);
-    --layer-foundation: oklch(50% 0.18 210deg);
-    --layer-layout: oklch(50% 0.16 170deg);
-    --layer-component: oklch(55% 0.18 130deg);
-    --layer-project: oklch(55% 0.20 65deg);
-    --layer-animation: oklch(55% 0.22 30deg);
-    --layer-utility: oklch(55% 0.22 10deg);
+    --violet-500:  oklch(55% 0.18 290deg);
+    --indigo-500:  oklch(55% 0.20 250deg);
+    --blue-500:    oklch(50% 0.18 210deg);
+    --teal-500:    oklch(50% 0.16 170deg);
+    --green-500:   oklch(55% 0.18 130deg);
+    --amber-500:   oklch(55% 0.20 65deg);
+    --orange-500:  oklch(55% 0.22 30deg);
+    --rose-500:    oklch(55% 0.22 10deg);
   }
 }


### PR DESCRIPTION
## Summary

- Tokens 層の `--layer-tokens` 等のセマンティック名を hue ベースのプリミティブ名に変更
- Theme 層にセマンティックマッピング（`--color-layer-*`）を追加
- c-badge.css の参照先を Theme 変数に変更

| 変更前 (Tokens) | 変更後 (Tokens) | Theme マッピング |
|----------------|----------------|-----------------|
| `--layer-tokens` | `--violet-500` | `--color-layer-tokens` |
| `--layer-theme` | `--indigo-500` | `--color-layer-theme` |
| `--layer-foundation` | `--blue-500` | `--color-layer-foundation` |
| `--layer-layout` | `--teal-500` | `--color-layer-layout` |
| `--layer-component` | `--green-500` | `--color-layer-component` |
| `--layer-project` | `--amber-500` | `--color-layer-project` |
| `--layer-animation` | `--orange-500` | `--color-layer-animation` |
| `--layer-utility` | `--rose-500` | `--color-layer-utility` |

Closes #40

## Test plan

- [x] バッジの色が変更前と同一であること（視覚的変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)