### PR TITLE
fix: CSS クリティカルバグ修正 v1.0.1

### DIFF
--- a/src/css/foundation/reset.css
+++ b/src/css/foundation/reset.css
@@ -4,7 +4,9 @@
  */
 @layer foundation {
   /* Universal */
-  :where(*, ::before, ::after) {
+  *,
+  ::before,
+  ::after {
     box-sizing: border-box;
   }
 
@@ -115,7 +117,7 @@
     resize: block;
   }
 
-  :where(::placeholder) {
+  ::placeholder {
     opacity: unset;
   }
 

--- a/src/css/project/p-layer-showcase.css
+++ b/src/css/project/p-layer-showcase.css
@@ -34,6 +34,7 @@
 
   .p-layer-showcase__description {
     grid-column: 1 / -1;
+    min-inline-size: 0;
     color: var(--color-text-light);
     line-height: var(--line-height-base);
 


### PR DESCRIPTION
## Summary
- reset.css: `:where(*, ::before, ::after)` の疑似要素が forgiving selector list で無視されるバグを修正
- reset.css: `:where(::placeholder)` の同様のバグを修正
- p-layer-showcase.css: モバイルでの横スクロール問題を `min-inline-size: 0` で修正

Closes #42

## Test plan
- [x] 全4ページ（Top / Philosophy / Layers / Contact）の表示確認
- [x] モバイル（375px）で横スクロールが発生しないこと
- [x] ダークモードの表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)