### PR TITLE
fix: reset.css の :focus-visible を Theme 層から独立させる

### DIFF
--- a/src/css/foundation/reset.css
+++ b/src/css/foundation/reset.css
@@ -133,7 +133,7 @@
   }
 
   :where(:focus-visible) {
-    outline: 2px solid var(--color-main);
+    outline: 2px solid currentcolor;
     outline-offset: 3px;
   }
 


### PR DESCRIPTION
## Summary
- reset.css の `:focus-visible` が `var(--color-main)` で Theme 層に依存していたバグを修正
- `currentcolor` に変更し、reset.css を完全独立に

## Changes
- `src/css/foundation/reset.css`: `var(--color-main)` → `currentcolor`

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)