### PR TITLE
docs: 「文脈」→ 具体表現に統一（v1.1 用語整備）

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -136,9 +136,9 @@
                 <article class="c-card">
                   <div class="c-card__body">
                     <span class="c-badge">Project</span>
-                    <h3 class="c-card__title">サイト固有のパーツと文脈</h3>
+                    <h3 class="c-card__title">サイト固有のパーツとデザイン要件</h3>
                     <p class="c-card__text">
-                      サイト固有のデザインに依存するパーツ。Component を組み合わせ、文脈に応じた配置・装飾を担う。
+                      サイト固有のデザインに依存するパーツ。Component を組み合わせ、ページの要件に合わせた配置・装飾を担う。
                     </p>
                   </div>
                 </article>

--- a/src/layers/index.html
+++ b/src/layers/index.html
@@ -207,12 +207,12 @@
             <div class="p-layer-showcase__item -project a-fade-in-slide-up">
               <div class="p-layer-showcase__header">
                 <span class="c-badge">Project</span>
-                <h2 class="p-layer-showcase__name">サイト固有のパーツと文脈</h2>
+                <h2 class="p-layer-showcase__name">サイト固有のパーツとデザイン要件</h2>
               </div>
               <div class="p-layer-showcase__description">
                 <div class="p-layer-showcase__content">
                   <p>
-                    <strong>サイト固有の文脈を持つパーツか？</strong> これが Project の判断基準です。
+                    <strong>サイト固有のデザイン要件を持つパーツか？</strong> これが Project の判断基準です。
                     ヘッダー、フッター、ヒーローセクション——これらは mFLOCSS サイト固有のデザインなので Project です。
                   </p>
 
@@ -223,7 +223,7 @@
                   <p>
                     例えば、このサイトのヒーローセクション（<code>p-hero</code>）は、
                     中に <code>c-button-cta</code>（Component）を含んでいます。
-                    Project は Component を組み合わせて、サイト固有の文脈を作ります。
+                    Project は Component を組み合わせて、サイト固有のデザイン要件に合わせた配置を実現します。
                   </p>
                   <p class="p-layer-showcase__criteria">
                     <strong>State クラス:</strong> <code>.is-current</code> のような動的な状態変化は State クラスで管理。

--- a/src/philosophy/index.html
+++ b/src/philosophy/index.html
@@ -220,7 +220,7 @@
                         <td class="p-philosophy__layer -project"><span class="c-badge">Project</span></td>
                         <td>Object 配下</td>
                         <td>トップレベル化</td>
-                        <td>サイト固有のパーツと文脈</td>
+                        <td>サイト固有のパーツとデザイン要件</td>
                       </tr>
                       <tr>
                         <td class="p-philosophy__layer -animation"><span class="c-badge">Animation</span></td>


### PR DESCRIPTION
## Summary
- HTML内の「文脈」を mFLOCSS v1.1 仕様に合わせた具体表現に置き換え
- 「サイト固有のパーツと文脈」→「サイト固有のパーツとデザイン要件」
- 「文脈に応じた」→「ページの要件に合わせた」
- 対象: src/index.html, src/layers/index.html, src/philosophy/index.html（計6箇所）

## Test plan
- [x] 「文脈」がリポジトリ内に残っていないことを確認（Grep で0件）
- [x] テキスト変更のみであり、HTML構造・CSSクラスの変更がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)