### PR TITLE
docs: README コード例を実コードに合わせて修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,12 @@ src/css/
 
 ```css
 /* foundation/index.css — ここで layer(foundation) が適用されるのはこのファイルの直接の内容のみ */
-@layer foundation.reset, foundation.base;
+@layer reset, base;
 
 /* 内部の @import には layer() が伝播しないため、明示的にサブレイヤーを指定する */
-@import './reset.css' layer(foundation.reset);
-@import './base.css' layer(foundation.base);
+@import './reset.css' layer(reset);
+@import './base.css' layer(base);
+@import './form.css' layer(base);
 ```
 
 この挙動はネスト構造を持つ場合に注意が必要です。サブレイヤーを使う場合は、中間ファイル（index.css）で明示的に `layer()` を指定してください。


### PR DESCRIPTION
## Summary
- README の foundation/index.css コード例を実コードに合わせて修正
- `layer(foundation.reset)` → `layer(reset)` に統一（相対名）
- `form.css` の `@import` 行を追加

## Test plan
- [x] コード例と実ファイル（`src/css/foundation/index.css`）の一致を確認
- [x] AR 完了（懸念0件で早期終了）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
