### PR TITLE
feat(token): fluid 中間 space tokens を追加（--space-xl-2xl, --space-2xl-3xl で SP/PC 補間）

### DIFF
--- a/src/assets/css/project/p-contact.css
+++ b/src/assets/css/project/p-contact.css
@@ -23,7 +23,7 @@
   flex-direction: column;
   gap: var(--space-lg);
   max-inline-size: var(--_form-max);
-  margin-block-start: var(--space-2xl);
+  margin-block-start: var(--space-xl-2xl);
   margin-inline: auto;
 }
 

--- a/src/assets/css/project/p-faq.css
+++ b/src/assets/css/project/p-faq.css
@@ -12,7 +12,7 @@
 
 .p-faq__list {
   max-inline-size: var(--content-width-narrow);
-  margin-block-start: var(--space-2xl);
+  margin-block-start: var(--space-xl-2xl);
   margin-inline: auto;
 }
 

--- a/src/assets/css/project/p-features.css
+++ b/src/assets/css/project/p-features.css
@@ -17,8 +17,8 @@
 .p-features__list {
   display: flex;
   flex-direction: column;
-  gap: var(--space-3xl);
-  margin-block-start: var(--space-2xl);
+  gap: var(--space-2xl-3xl);
+  margin-block-start: var(--space-xl-2xl);
 }
 
 .p-features__item {

--- a/src/assets/css/project/p-numbers.css
+++ b/src/assets/css/project/p-numbers.css
@@ -20,7 +20,7 @@
 .p-numbers__list {
   display: grid;
   gap: var(--space-lg);
-  margin-block-start: var(--space-2xl);
+  margin-block-start: var(--space-xl-2xl);
   text-align: center;
 
   @container (inline-size >= 40rem) {

--- a/src/assets/css/project/p-problem.css
+++ b/src/assets/css/project/p-problem.css
@@ -18,7 +18,7 @@
 .p-problem__list {
   display: grid;
   gap: var(--space-lg);
-  margin-block-start: var(--space-2xl);
+  margin-block-start: var(--space-xl-2xl);
 
   @container (inline-size >= 56rem) {
     grid-template-columns: repeat(3, 1fr);

--- a/src/assets/css/project/p-voice.css
+++ b/src/assets/css/project/p-voice.css
@@ -17,7 +17,7 @@
 .p-voice__list {
   display: grid;
   gap: var(--space-xl);
-  margin-block-start: var(--space-2xl);
+  margin-block-start: var(--space-xl-2xl);
 
   @container (inline-size >= 40rem) {
     grid-template-columns: repeat(2, 1fr);

--- a/src/assets/css/token/space.css
+++ b/src/assets/css/token/space.css
@@ -7,4 +7,8 @@
   --space-xl: calc(32 * var(--px));
   --space-2xl: calc(48 * var(--px));
   --space-3xl: calc(64 * var(--px));
+
+  /* fluid 中間 tokens（SP/PC で値が変わる場面で使用。viewport 400→1440 で線形補間） */
+  --space-xl-2xl: clamp(var(--space-xl), 1.538vi + 1.615rem, var(--space-2xl));
+  --space-2xl-3xl: clamp(var(--space-2xl), 1.538vi + 2.615rem, var(--space-3xl));
 }


### PR DESCRIPTION
## Summary

- `token/space.css` に fluid 中間 tokens `--space-xl-2xl` / `--space-2xl-3xl` を追加（viewport 400→1440 で線形補間）
- Project CSS 6 ファイルの見出し下 `margin-block-start` を `--space-2xl` → `--space-xl-2xl` に置換（SP で 32px、PC で 48px に収束）
- `p-features__list` の `gap` を `--space-3xl` → `--space-2xl-3xl` に置換（SP で 48px、PC で 64px に収束）

## 設計意図

大きめ spacing（32-64px）は SP/PC で値を変える恩恵が大きい。固定値だと SP で広すぎるか PC で狭すぎるかのトレードオフが生じるため、`clamp()` による fluid 中間 tokens で解決する。

小さい spacing（xs〜lg）は SP/PC の差分が小さく fluid 化の恩恵が薄いため現状維持。Component 層は固定寸法がデフォルトのため変更なし。

## 変更しなかった箇所

- `p-footer.css` の `padding-block: var(--space-3xl)` — footer の padding は section-padding と別の文脈のため現状維持

## Test plan

- [ ] viewport 375px（SP）: section 内見出し下 spacing が 32px
- [ ] viewport 1280px（PC）: section 内見出し下 spacing が 48px 近く
- [ ] viewport 400〜1440 で滑らかに補間されること
- [ ] p-features の item 間 gap が SP で 48px、PC で 64px
- [ ] Stylelint エラーなし ✅
- [ ] ビルド成功 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)