### PR TITLE
feat(component): c-text-block 新設（見出し + 本文のペアを Component 化、Portability Test 合格スタイル移譲）

### DIFF
--- a/src/assets/css/component/c-text-block.css
+++ b/src/assets/css/component/c-text-block.css
@@ -1,0 +1,13 @@
+.c-text-block {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.c-text-block__title {
+  /* スタイルなし（HTML クラスとの対応を維持） */
+}
+
+.c-text-block__text {
+  color: var(--color-text-light);
+}

--- a/src/assets/css/project/p-cta.css
+++ b/src/assets/css/project/p-cta.css
@@ -21,10 +21,6 @@
   max-inline-size: var(--_title-max);
 }
 
-.p-cta__text {
-  color: var(--color-text-light);
-}
-
 .p-cta__button {
   margin-block-start: var(--space-sm);
 }

--- a/src/assets/css/project/p-problem.css
+++ b/src/assets/css/project/p-problem.css
@@ -31,12 +31,3 @@
   background-color: var(--color-bg-secondary);
   border-radius: var(--radius-md);
 }
-
-.p-problem__item-title {
-  /* スタイルなし（HTML クラスとの対応を維持） */
-}
-
-.p-problem__item-text {
-  margin-block-start: var(--space-sm);
-  color: var(--color-text-light);
-}

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -31,6 +31,7 @@
 @import './component/c-section-heading.css' layer(component);
 @import './component/c-accordion.css' layer(component);
 @import './component/c-blockquote.css' layer(component);
+@import './component/c-text-block.css' layer(component);
 @import './component/c-icon.css' layer(component);
 @import './component/c-back-to-top.css' layer(component);
 @import './component/c-skip-link.css' layer(component);

--- a/src/index.html
+++ b/src/index.html
@@ -141,21 +141,21 @@
               <h2 id="problem-heading">こんな日々、続いていませんか？</h2>
             </hgroup>
             <ul class="p-problem__list" data-stagger="fade-in-slide-up">
-              <li class="p-problem__item">
-                <h3 class="p-problem__item-title">朝起きても疲れが抜けない</h3>
-                <p class="p-problem__item-text">
+              <li class="p-problem__item c-text-block">
+                <h3 class="c-text-block__title">朝起きても疲れが抜けない</h3>
+                <p class="c-text-block__text">
                   睡眠時間は取っているのに、目覚めがすっきりしない。週末に寝溜めしても月曜にはもう重い。
                 </p>
               </li>
-              <li class="p-problem__item">
-                <h3 class="p-problem__item-title">肩や腰が常に張っている</h3>
-                <p class="p-problem__item-text">
+              <li class="p-problem__item c-text-block">
+                <h3 class="c-text-block__title">肩や腰が常に張っている</h3>
+                <p class="c-text-block__text">
                   デスクワークが続くと夕方には限界。マッサージに行っても翌日には戻っている。
                 </p>
               </li>
-              <li class="p-problem__item">
-                <h3 class="p-problem__item-title">自分のための時間がない</h3>
-                <p class="p-problem__item-text">
+              <li class="p-problem__item c-text-block">
+                <h3 class="c-text-block__title">自分のための時間がない</h3>
+                <p class="c-text-block__text">
                   仕事、家事、育児。気づけば一日が終わっていて、自分のことは後回しになっている。
                 </p>
               </li>
@@ -364,9 +364,9 @@
 
       <!-- CTA -->
       <section class="l-section p-cta" id="cta" aria-labelledby="cta-heading">
-        <div class="l-inner p-cta__inner" data-stagger="fade-in-slide-up">
-          <h2 id="cta-heading" class="p-cta__title">まずは一度、からだの声を聴いてみませんか？</h2>
-          <p class="p-cta__text">初回体験は 60分 4,400円。カウンセリング込み。無理な勧誘はいたしません。</p>
+        <div class="l-inner p-cta__inner c-text-block" data-stagger="fade-in-slide-up">
+          <h2 id="cta-heading" class="p-cta__title c-text-block__title">まずは一度、からだの声を聴いてみませんか？</h2>
+          <p class="c-text-block__text">初回体験は 60分 4,400円。カウンセリング込み。無理な勧誘はいたしません。</p>
           <a href="/contact/" class="c-button -primary -large p-cta__button">初回体験を予約する</a>
         </div>
       </section>


### PR DESCRIPTION
## Summary

- `c-text-block` Component 新設：「見出し + 本文」ペアの汎用スタイル（flex column + gap + color-text-light）を Component 層に抽出
- problem セクション（3 項目）と cta セクションの HTML を Component クラスに移行
- `p-problem.css` から `__item-title` / `__item-text`、`p-cta.css` から `__text` を削除（Portability Test 合格スタイルの Project 層記述を解消）

## 設計判断

- **spec §5.6 SHOULD NOT 違反の解消**: 「見出し + 本文」のスタイル（gap, color）は文脈非依存 → Portability Test 合格 → Component 層が適切
- **Project Block と Component の併記パターン**: `c-button` / `c-badge` と同様、同一要素に Project + Component クラスを付与。無駄なラッパー要素なし
- **CTA の `gap` 上書き**: `p-cta__inner` の `gap: var(--space-lg)` が project 層で `c-text-block` の `gap: var(--space-sm)` を上書き → レイアウト変化なし

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/assets/css/component/c-text-block.css` | 新規作成 |
| `src/assets/css/style.css` | import 追加 |
| `src/index.html` | problem 3 項目 + cta を Component クラスに移行 |
| `src/assets/css/project/p-problem.css` | `__item-title` / `__item-text` 削除 |
| `src/assets/css/project/p-cta.css` | `__text` 削除（`__title` の `--_title-max` は維持）|

## Test plan

- [ ] ビルド成功（✅ 確認済み）
- [ ] Stylelint エラーなし（✅ 確認済み）
- [ ] problem の 3 カードが正常表示、本文の色が薄グレー
- [ ] cta のタイトル + 本文が正常表示
- [ ] レイアウト変化なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)