### PR TITLE
docs(html): ドロワー前に <!-- Drawer --> 区切りコメントを追加

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -74,6 +74,8 @@
         </button>
       </div>
     </header>
+
+    <!-- Drawer -->
     <div class="c-overlay" data-drawer-overlay hidden></div>
     <dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title" aria-modal="true">
       <div class="p-drawer__inner">


### PR DESCRIPTION
## 変更内容

`c-overlay` + `p-drawer` の直前に `<!-- Drawer -->` セクション区切りコメントを追加（+1 行、空行 1 行で区切りを明確化）。

既存の `<!-- Header -->` `<!-- Hero -->` `<!-- Problem -->` `<!-- Features -->` `<!-- Voice -->` `<!-- FAQ -->` `<!-- CTA -->` `<!-- Footer -->` と同様の形式で構造の可読性を向上。

## 背景

Drawer は header に付随する構造（ハンバーガーから開く）だが、`<dialog>` の top-layer を使うため DOM 位置は header の外（main の前）に配置されている。セクション区切りコメントを入れることで、この意図的配置を読者が理解しやすくなる。

## スコープ

- v1.2 ブランチに追加コミット（mFLOCSS v1.0 リリース時に [#83](https://github.com/mflocss/starter/pull/83) 経由で統合）