### PR TITLE
feat(component): c-stat 新設（統計数値表示を Component 化）

### DIFF
--- a/src/assets/css/component/c-stat.css
+++ b/src/assets/css/component/c-stat.css
@@ -1,0 +1,24 @@
+.c-stat {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  text-align: center;
+}
+
+.c-stat__value {
+  --_line-height: 1.2;
+
+  font-size: var(--font-size-display);
+  font-weight: var(--font-weight-heading);
+  line-height: var(--_line-height);
+  color: var(--color-main);
+}
+
+.c-stat__unit {
+  font-size: 0.5em;
+}
+
+.c-stat__label {
+  font-size: var(--font-size-caption);
+  color: var(--color-text-light);
+}

--- a/src/assets/css/project/p-numbers.css
+++ b/src/assets/css/project/p-numbers.css
@@ -21,7 +21,6 @@
   display: grid;
   gap: var(--space-lg);
   margin-block-start: var(--space-xl-2xl);
-  text-align: center;
 
   @container (inline-size >= 40rem) {
     grid-template-columns: repeat(3, 1fr);
@@ -30,25 +29,5 @@
 }
 
 .p-numbers__item {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xs);
-}
-
-.p-numbers__value {
-  --_line-height: 1.2;
-
-  font-size: var(--font-size-display);
-  font-weight: var(--font-weight-heading);
-  line-height: var(--_line-height);
-  color: var(--color-main);
-}
-
-.p-numbers__unit {
-  font-size: 0.5em;
-}
-
-.p-numbers__label {
-  font-size: var(--font-size-caption);
-  color: var(--color-text-light);
+  /* スタイルなし（HTML クラスとの対応を維持、将来の grid アイテム配置制御の拡張点） */
 }

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -28,6 +28,7 @@
 @import './component/c-button.css' layer(component);
 @import './component/c-card.css' layer(component);
 @import './component/c-media-card.css' layer(component);
+@import './component/c-stat.css' layer(component);
 @import './component/c-badge.css' layer(component);
 @import './component/c-section-heading.css' layer(component);
 @import './component/c-accordion.css' layer(component);

--- a/src/index.html
+++ b/src/index.html
@@ -239,17 +239,17 @@
               <h2 id="numbers-heading">実績</h2>
             </hgroup>
             <ul class="p-numbers__list" data-stagger="fade-in-slide-up">
-              <li class="p-numbers__item">
-                <span class="p-numbers__value" translate="no">1,200<span class="p-numbers__unit">+</span></span>
-                <span class="p-numbers__label">施術実績（年間）</span>
+              <li class="c-stat p-numbers__item">
+                <span class="c-stat__value" translate="no">1,200<span class="c-stat__unit">+</span></span>
+                <span class="c-stat__label">施術実績（年間）</span>
               </li>
-              <li class="p-numbers__item">
-                <span class="p-numbers__value" translate="no">96.2<span class="p-numbers__unit">%</span></span>
-                <span class="p-numbers__label">リピート率</span>
+              <li class="c-stat p-numbers__item">
+                <span class="c-stat__value" translate="no">96.2<span class="c-stat__unit">%</span></span>
+                <span class="c-stat__label">リピート率</span>
               </li>
-              <li class="p-numbers__item">
-                <span class="p-numbers__value" translate="no">+15<span class="p-numbers__unit">min</span></span>
-                <span class="p-numbers__label">初回カウンセリングの充実度</span>
+              <li class="c-stat p-numbers__item">
+                <span class="c-stat__value" translate="no">+15<span class="c-stat__unit">min</span></span>
+                <span class="c-stat__label">初回カウンセリングの充実度</span>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
## 概要

p-numbers__item（統計の数字 + 単位 + ラベル表示）が Portability Test に合格するため、Component 化（`c-stat`）として抽出。4/20 の c-text-block / c-media-card 抽出と同じ論理。

## Portability Test

`.p-numbers__item` の中身（数字 + 単位 + ラベル）:
- CSS: flex column + gap + text-align + font-size + color（全てセマンティック変数）
- HTML: iluha 固有要素なし

**「別のサイトにそのまま持っていけるか？」→ Yes**（統計表示は LP / ダッシュボード / ポートフォリオ等で普遍的）

## 変更内容

### component/c-stat.css 新規作成
- `.c-stat`: display: flex column / gap / text-align
- `.c-stat__value`: 大きなフォントサイズ / 色 / line-height
- `.c-stat__unit`: 0.5em（数字より小さい単位表示）
- `.c-stat__label`: caption サイズ / light テキスト色

### project/p-numbers.css
- `__value` / `__unit` / `__label` 削除（c-stat へ移譲）
- `__item` を空ルールセット化（c-stat へ移譲、**将来の grid アイテム配置制御の拡張点として維持**）
- `__list` から `text-align: center` 削除（c-stat 内部で持つ）

### index.html
- `<li class="p-numbers__item">` → `<li class="c-stat p-numbers__item">`（**Component + Project Element 併記**）
- 子要素の `p-numbers__*` → `c-stat__*`（3 要素 × 3 項目 = 9 箇所）

### style.css
- c-media-card の後に c-stat.css import 追加

## 責任分担（4/20 原則遵守）

| 責任 | 所属 |
|---|---|
| 数字 / 単位 / ラベルの視覚表現 | c-stat（内部配置） |
| grid 内の個別配置（将来の grid-column 等） | p-numbers__item（外部配置拡張点） |
| 3 カラム grid レイアウト | p-numbers__list |
| セクション全体（背景、padding） | p-numbers |

## 副次効果

- c-text-block / c-media-card に続く 3 つ目の Component 抽出で 4/20 大刷新の流れを踏襲
- starter がより「リファレンス実装らしく」なる
- 書籍 v1.1 の参考実装に c-stat を追加できる

## 変更規模

- 4 files changed, 35 insertions(+), 31 deletions(-)
- 新規 1 ファイル（c-stat.css）+ 既存 3 ファイル修正