### PR TITLE
feat(v1.0): Layer 2 観点追加 (sitemap / robots / 404)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,8 @@
+# CUSTOMIZE: 本番 URL を正しいドメインに差し替えてください
+# NOTE: 組み込み時は既存の robots.txt が優先されます。
+#       既存サイトに mFLOCSS を導入する場合、このファイルを削除してください。
+# NOTE: Allow: / は省略可（デフォルトで全許可）。教育用途で意図を明示するため記載
+User-agent: *
+Allow: /
+
+Sitemap: https://example.com/sitemap.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,6 +2,11 @@
 # NOTE: 組み込み時は既存の robots.txt が優先されます。
 #       既存サイトに mFLOCSS を導入する場合、このファイルを削除してください。
 # NOTE: Allow: / は省略可（デフォルトで全許可）。教育用途で意図を明示するため記載
+# CUSTOMIZE: 管理画面・API・下書きなど検索対象外にしたいパスがあれば Disallow を追加
+#   例:
+#     Disallow: /admin/
+#     Disallow: /api/
+#     Disallow: /drafts/
 User-agent: *
 Allow: /
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  CUSTOMIZE: 本番 URL と lastmod を自サイトに合わせて更新してください。
+  NOTE: 組み込み時（既存サイトに mFLOCSS を導入）は、
+        既存の sitemap.xml に統合後、このファイルを削除してください。
+-->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/</loc>
+    <lastmod>2026-04-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://example.com/privacy/</loc>
+    <lastmod>2026-04-22</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://example.com/contact/</loc>
+    <lastmod>2026-04-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>

--- a/src/404.html
+++ b/src/404.html
@@ -58,6 +58,8 @@
         </button>
       </div>
     </header>
+
+    <!-- Drawer -->
     <div class="c-overlay" data-drawer-overlay hidden></div>
     <dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title" aria-modal="true">
       <div class="p-drawer__inner">

--- a/src/404.html
+++ b/src/404.html
@@ -1,4 +1,8 @@
 <!doctype html>
+<!--
+  CUSTOMIZE: このファイルは mFLOCSS starter 単体運用時の参考実装です。
+             組み込み時は既存サイトの 404 を使用し、このファイルは削除してください。
+-->
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
@@ -135,8 +139,5 @@
         <use href="/assets/images/icons/chevron-up.svg#icon" />
       </svg>
     </a>
-
-    <!-- CUSTOMIZE: 組み込み時は既存サイトの 404 を使用してください。
-         このファイルは mFLOCSS starter 単体運用時の参考実装です。 -->
   </body>
 </html>

--- a/src/404.html
+++ b/src/404.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="/scripts/viewport.js"></script>
+    <meta name="format-detection" content="telephone=no,address=no,email=no" />
+    <!-- CUSTOMIZE: ダークモード不要なら content="light" に -->
+    <meta name="color-scheme" content="light dark" />
+    <meta name="robots" content="noindex,follow" />
+    <!-- CUSTOMIZE: ページタイトル・説明文を差し替え -->
+    <title>ページが見つかりません — iluha</title>
+    <meta
+      name="description"
+      content="お探しのページは移動または削除された可能性があります。iluha のトップページから目的のページをお探しください。"
+    />
+    <!-- CUSTOMIZE: token/color.css のメインカラーに合わせて変更 -->
+    <meta name="theme-color" content="#5b7a5e" />
+    <!-- NOTE: 404 ページは canonical / OGP 不要（noindex のため） -->
+    <!-- Favicon -->
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="icon" href="/favicon.ico" sizes="32x32" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <!-- Styles -->
+    <link rel="stylesheet" href="/assets/css/style.css" />
+    <!-- Scripts -->
+    <script type="module" src="/assets/scripts/main.js"></script>
+  </head>
+  <body id="top">
+    <!-- Skip Link -->
+    <a href="#main" class="c-skip-link u-visually-hidden" data-drawer-inert>本文へスキップ</a>
+
+    <!-- NOTE: ヘッダー・フッターは全ページ共通。変更時は全ファイルに反映すること -->
+    <!-- Header -->
+    <header class="l-header p-header">
+      <div class="l-inner p-header__inner">
+        <a href="/" class="p-header__logo" translate="no">iluha</a>
+
+        <nav class="p-header__nav" aria-label="メインナビゲーション">
+          <ul class="p-header__nav-list">
+            <li><a href="/#features" class="p-header__nav-link">特徴</a></li>
+            <li><a href="/#voice" class="p-header__nav-link">お客様の声</a></li>
+            <li><a href="/#faq" class="p-header__nav-link">よくある質問</a></li>
+            <li><a href="/contact/" class="p-header__nav-link">ご予約</a></li>
+          </ul>
+          <a href="/contact/" class="c-button -primary p-header__cta">初回体験を予約する</a>
+        </nav>
+
+        <button
+          class="c-hamburger p-header__hamburger"
+          type="button"
+          aria-expanded="false"
+          aria-controls="drawer"
+          aria-label="メニュー"
+          data-hamburger
+        >
+          <span class="c-hamburger__line" aria-hidden="true"></span>
+        </button>
+      </div>
+    </header>
+    <div class="c-overlay" data-drawer-overlay hidden></div>
+    <dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title" aria-modal="true">
+      <div class="p-drawer__inner">
+        <span id="drawer-title" class="u-visually-hidden">ナビゲーションメニュー</span>
+        <nav class="p-drawer__nav" aria-label="ドロワーナビゲーション">
+          <ul class="p-drawer__nav-list">
+            <li>
+              <a href="/#features" class="p-drawer__nav-link">特徴</a>
+            </li>
+            <li>
+              <a href="/#voice" class="p-drawer__nav-link">お客様の声</a>
+            </li>
+            <li>
+              <a href="/#faq" class="p-drawer__nav-link">よくある質問</a>
+            </li>
+            <li>
+              <a href="/contact/" class="p-drawer__nav-link">ご予約</a>
+            </li>
+          </ul>
+        </nav>
+        <a href="/contact/" class="c-button -primary p-drawer__cta">初回体験を予約する</a>
+      </div>
+    </dialog>
+
+    <main id="main" data-drawer-inert>
+      <section class="l-section p-not-found" aria-labelledby="not-found-heading">
+        <div class="l-inner p-not-found__inner">
+          <div class="c-section-heading p-not-found__heading">
+            <p>404</p>
+            <h1 id="not-found-heading">ページが見つかりません</h1>
+          </div>
+          <p class="p-not-found__lead">
+            お探しのページは移動または削除された可能性があります。<br />
+            お手数ですが、トップページから目的のページをお探しください。
+          </p>
+          <div class="p-not-found__actions">
+            <a href="/" class="c-button -primary -large p-not-found__action">トップページへ戻る</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="l-footer p-footer" data-drawer-inert>
+      <div class="l-inner p-footer__inner">
+        <nav class="p-footer__nav" aria-label="フッターナビゲーション">
+          <ul class="p-footer__nav-list">
+            <li><a href="/#features" class="p-footer__nav-link">特徴</a></li>
+            <li><a href="/#voice" class="p-footer__nav-link">お客様の声</a></li>
+            <li><a href="/#faq" class="p-footer__nav-link">よくある質問</a></li>
+            <li><a href="/contact/" class="p-footer__nav-link">ご予約</a></li>
+            <li>
+              <a href="/privacy/" class="p-footer__nav-link">プライバシーポリシー</a>
+            </li>
+          </ul>
+        </nav>
+        <!-- CUSTOMIZE: 住所・電話番号・営業時間を差し替え -->
+        <address class="p-footer__address">
+          〒xxx-xxxx 東京都渋谷区○○ x-x-x ○○ビル 3F<br />
+          <a href="tel:03-xxxx-xxxx" class="p-footer__tel" translate="no">TEL: 03-xxxx-xxxx</a><br />
+          営業時間: 10:00〜20:00（最終受付 19:00）<br />
+          定休日: 毎週水曜日
+        </address>
+        <p class="p-footer__copyright">
+          <small><span translate="no">© 2026 iluha</span></small>
+        </p>
+      </div>
+    </footer>
+
+    <!-- Back to Top -->
+    <a href="#top" class="c-back-to-top" data-back-to-top aria-label="ページの先頭に戻る">
+      <svg class="c-icon" width="20" height="20" aria-hidden="true">
+        <use href="/assets/images/icons/chevron-up.svg#icon" />
+      </svg>
+    </a>
+
+    <!-- CUSTOMIZE: 組み込み時は既存サイトの 404 を使用してください。
+         このファイルは mFLOCSS starter 単体運用時の参考実装です。 -->
+  </body>
+</html>

--- a/src/assets/css/project/p-not-found.css
+++ b/src/assets/css/project/p-not-found.css
@@ -1,23 +1,23 @@
 .p-not-found {
   text-align: center;
+}
 
-  & > .p-not-found__inner {
-    display: grid;
-    gap: var(--space-xl);
-    justify-items: center;
-    max-inline-size: 40rem;
-  }
+.p-not-found__inner {
+  display: grid;
+  gap: var(--space-xl);
+  justify-items: center;
+  max-inline-size: 40rem;
+}
 
-  & .p-not-found__lead {
-    /* font-size は body から継承、line-height は既存 token を使用 */
-    line-height: var(--line-height-text);
-    color: var(--color-text-light);
-  }
+.p-not-found__lead {
+  /* font-size は body から継承、line-height は既存 token を使用 */
+  line-height: var(--line-height-text);
+  color: var(--color-text-light);
+}
 
-  & .p-not-found__actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-md);
-    justify-content: center;
-  }
+.p-not-found__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  justify-content: center;
 }

--- a/src/assets/css/project/p-not-found.css
+++ b/src/assets/css/project/p-not-found.css
@@ -1,0 +1,23 @@
+.p-not-found {
+  text-align: center;
+
+  & > .p-not-found__inner {
+    display: grid;
+    gap: var(--space-xl);
+    justify-items: center;
+    max-inline-size: 40rem;
+  }
+
+  & .p-not-found__lead {
+    /* font-size は body から継承、line-height は既存 token を使用 */
+    line-height: var(--line-height-text);
+    color: var(--color-text-light);
+  }
+
+  & .p-not-found__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-md);
+    justify-content: center;
+  }
+}

--- a/src/assets/css/project/p-not-found.css
+++ b/src/assets/css/project/p-not-found.css
@@ -10,7 +10,6 @@
 }
 
 .p-not-found__lead {
-  /* font-size は body から継承、line-height は既存 token を使用 */
   line-height: var(--line-height-text);
   color: var(--color-text-light);
 }

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -54,6 +54,7 @@
 @import './project/p-contact.css' layer(project);
 @import './project/p-thanks.css' layer(project);
 @import './project/p-privacy.css' layer(project);
+@import './project/p-not-found.css' layer(project);
 
 /* Animation */
 @import './animation/fade-in-slide-up.css' layer(animation);

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -96,6 +96,8 @@
         </button>
       </div>
     </header>
+
+    <!-- Drawer -->
     <div class="c-overlay" data-drawer-overlay hidden></div>
     <dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title" aria-modal="true">
       <div class="p-drawer__inner">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
         contact: resolve(__dirname, 'src/contact/index.html'),
         thanks: resolve(__dirname, 'src/contact/thanks/index.html'),
         privacy: resolve(__dirname, 'src/privacy/index.html'),
+        notFound: resolve(__dirname, 'src/404.html'),
       },
     },
     outDir: resolve(__dirname, 'dist'),


### PR DESCRIPTION
## Summary

v1.0 リリースに向けた **PR A-2: Layer 2 観点追加**。サイトレベル（スタンドアロン時のみ必要、組み込み時は削除対象）のファイルを新設する。

計画書 § PR A-2 に従い実施。

## 変更内容

### 新設ファイル

- `public/sitemap.xml`: LP / privacy / contact の 3 URL、CUSTOMIZE コメント付き
- `public/robots.txt`: User-agent: *, Allow: /, Sitemap 指定、CUSTOMIZE コメント付き
- `src/404.html`: c-section-heading + c-button -primary を再利用、`<meta name="robots" content="noindex,follow">` 設定
- `src/assets/css/project/p-not-found.css`: Project 層、Portability Test 合格

### 修正ファイル

- `vite.config.ts`: `notFound: resolve(__dirname, 'src/404.html')` エントリ追加
- `src/assets/css/style.css`: `@layer project` に `p-not-found.css` import 追加

## 3 Layer 分類の Layer 2

| Layer | 例 | 本 PR |
|---|---|---|
| Layer 1（ページレベル） | JSON-LD / OGP / Hero preload | PR A で完了 |
| **Layer 2（サイトレベル）** | **sitemap / robots / 404** | **本 PR** |
| Layer 3（教材外） | アナリティクス / Cookie / CI/CD | 教材スコープ外 |

Layer 2 は**スタンドアロン時のみ必要**で、既存サイトに mFLOCSS を組み込む場合は元サイトの sitemap / robots / 404 が優先される。各ファイルの HTML コメントで「組み込み時は削除」を明示。

## 注意事項

- **しゅんえい承認必須**: v1.0 一斉リリースまで main マージ不可
- base は `v1.2`（v1.0 統合ブランチ）
- PR B で `src/contact/` 削除時に sitemap の contact URL も同時削除予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## レビュー対応（2026-04-22）

しゅんえいレビュー指摘 3 点 + 一貫性修正 1 点を追加 commit で反映:

- robots.txt: Disallow 例を CUSTOMIZE コメントで追加（管理画面 / API / 下書き等）
- p-not-found.css: Element クラスのネストを解消してフラット化（mFLOCSS 命名スコープの原則）
- 404.html: `</header>` 直後に `<!-- Drawer -->` コメント追加
- privacy/index.html: 同上（一貫性修正、4/21 starter#97 と同流儀）
### 追加対応

しゅんえい追加レビュー指摘 2 点を追加 commit で反映:

- p-not-found.css: font-size 継承の自明コメント削除（CLAUDE.md「Default to writing no comments」整合）
- 404.html: 末尾の CUSTOMIZE コメントをファイル冒頭へ移動（sitemap.xml / robots.txt の冒頭 CUSTOMIZE と一貫性）

commit: [`c227b01`](https://github.com/mflocss/starter/commit/c227b016e12717ef1e4daac22dc71afdd6ca073d) / check ✅ / build ✅