### PR TITLE
feat(v1.0): c-input / c-field / c-choice-label 新設（A-1 Component 抽出、書籍 ch7 教材価値最強）

### DIFF
--- a/src/assets/css/component/c-choice-label.css
+++ b/src/assets/css/component/c-choice-label.css
@@ -1,0 +1,8 @@
+/* radio / checkbox 両用: min-block-size でタップ領域 44px を確保（WCAG 2.5.5 Target Size AAA 相当） */
+.c-choice-label {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: center;
+  min-block-size: var(--size-tap-target);
+  cursor: pointer;
+}

--- a/src/assets/css/component/c-field.css
+++ b/src/assets/css/component/c-field.css
@@ -1,0 +1,15 @@
+.c-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.c-field__label {
+  font-weight: var(--font-weight-heading);
+}
+
+/* 必須マーク: Project 側が --c-field-required-mark を上書きすればサイトごとに表現（「 *」→「 必須」等）を切替可能 */
+.c-field:has(:required) > .c-field__label::after {
+  color: var(--color-error);
+  content: var(--c-field-required-mark, ' *');
+}

--- a/src/assets/css/component/c-field.css
+++ b/src/assets/css/component/c-field.css
@@ -4,12 +4,25 @@
   gap: var(--space-xs);
 }
 
-.c-field__label {
+/* fieldset として使う時の default 装飾リセット（border / padding / margin を無効化し、div と等価な箱に整える） */
+fieldset.c-field {
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+
+.c-field__label,
+.c-field__legend {
+  display: flex;
+  gap: 0.25em;
+  align-items: baseline;
   font-weight: var(--font-weight-heading);
 }
 
-/* 必須マーク: Project 側が --c-field-required-mark を上書きすればサイトごとに表現（「 *」→「 必須」等）を切替可能 */
-.c-field:has(:required) > .c-field__label::after {
+/* 必須マーク: Project 側が --c-field-required-mark を上書きすればサイトごとに表現（「*」→「必須」等）を切替可能。
+   空白は content に含めず gap: 0.25em で視覚的に担保する（コピペ・a11y 読み上げへの混入を回避） */
+.c-field:has(:required) > .c-field__label::after,
+.c-field:has(:required) > .c-field__legend::after {
   color: var(--color-error);
-  content: var(--c-field-required-mark, ' *');
+  content: var(--c-field-required-mark, '*');
 }

--- a/src/assets/css/component/c-input.css
+++ b/src/assets/css/component/c-input.css
@@ -1,0 +1,32 @@
+.c-input {
+  padding: var(--space-sm) var(--space-md);
+  font: inherit;
+  color: var(--color-text);
+  background-color: var(--color-surface);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-sm);
+
+  /* prefers-reduced-motion: transition を抑制してアニメ酔い対策 */
+  @media (prefers-reduced-motion: no-preference) {
+    transition: border-color var(--duration-normal) var(--ease-out-cubic);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--color-main);
+  }
+
+  /* :user-invalid: ユーザー操作後のみ invalid 表示（初期表示で赤枠を出さない） */
+  &:user-invalid {
+    border-color: var(--color-error);
+  }
+}
+
+/* textarea は自動リサイズ + 下限/上限行数を指定（field-sizing は Chrome 123+ / Safari 17.4+）  */
+textarea.c-input {
+  --_textarea-min: 160px;
+
+  field-sizing: content;
+  min-block-size: var(--_textarea-min);
+  max-block-size: 20lh;
+}

--- a/src/assets/css/project/p-contact.css
+++ b/src/assets/css/project/p-contact.css
@@ -42,19 +42,12 @@
 }
 
 .p-contact__fieldset {
-  display: flex;
-  flex-direction: column;
+  /* c-field の gap を radio-group 向けに上書き（c-field default は label-input 用 xs、radio-group fieldset は legend-group 用 sm） */
   gap: var(--space-sm);
 }
 
 .p-contact__legend {
-  font-weight: var(--font-weight-heading);
-}
-
-/* fieldset 内 required のマーク付与（c-field は fieldset 構造に対応しないためここに残す） */
-.p-contact__fieldset:has(:required) .p-contact__legend::after {
-  color: var(--color-error);
-  content: ' *';
+  /* スタイルなし（将来の外部配置制御の拡張点として c-field__legend と併記） */
 }
 
 .p-contact__radio-group {

--- a/src/assets/css/project/p-contact.css
+++ b/src/assets/css/project/p-contact.css
@@ -28,45 +28,17 @@
 }
 
 .p-contact__field {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xs);
+  /* スタイルなし（将来の外部配置制御の拡張点として c-field と併記） */
 }
 
-.p-contact__label:has(+ :required),
-.p-contact__legend:has(~ .p-contact__field :required) {
-  &::after {
-    color: var(--color-error);
-    content: ' *';
-  }
-}
-
-.p-contact__textarea {
-  --_textarea-min: 160px;
-
-  field-sizing: content;
-  min-block-size: var(--_textarea-min);
-  max-block-size: 20lh;
+.p-contact__label {
+  /* スタイルなし（将来の外部配置制御の拡張点として c-field__label と併記） */
 }
 
 .p-contact__input,
 .p-contact__textarea,
 .p-contact__select {
-  padding: var(--space-sm) var(--space-md);
-  font: inherit;
-  color: inherit;
-  background-color: var(--color-surface);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-sm);
-  transition: border-color var(--duration-fast) var(--ease-out-cubic);
-
-  &:focus {
-    border-color: var(--color-main);
-  }
-
-  &:user-invalid {
-    border-color: var(--color-error);
-  }
+  /* スタイルなし（将来の外部配置制御の拡張点として c-input と併記） */
 }
 
 .p-contact__fieldset {
@@ -79,6 +51,12 @@
   font-weight: var(--font-weight-heading);
 }
 
+/* fieldset 内 required のマーク付与（c-field は fieldset 構造に対応しないためここに残す） */
+.p-contact__fieldset:has(:required) .p-contact__legend::after {
+  color: var(--color-error);
+  content: ' *';
+}
+
 .p-contact__radio-group {
   display: flex;
   flex-direction: column;
@@ -88,18 +66,13 @@
 
 .p-contact__radio-label,
 .p-contact__checkbox-label {
-  display: flex;
-  gap: var(--space-sm);
-  align-items: center;
-  min-block-size: var(--size-tap-target);
-  cursor: pointer;
+  /* スタイルなし（将来の外部配置制御の拡張点として c-choice-label と併記） */
 }
 
-.p-contact__checkbox-label {
-  & a {
-    color: var(--color-main);
-    text-decoration: underline;
-  }
+/* チェックラベル内のリンク（プライバシーポリシー同意）は p-contact 固有の装飾 */
+.p-contact__checkbox-label a {
+  color: var(--color-main);
+  text-decoration: underline;
 }
 
 .p-contact__error {

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -39,6 +39,9 @@
 @import './component/c-skip-link.css' layer(component);
 @import './component/c-hamburger.css' layer(component);
 @import './component/c-overlay.css' layer(component);
+@import './component/c-input.css' layer(component);
+@import './component/c-field.css' layer(component);
+@import './component/c-choice-label.css' layer(component);
 
 /* Project */
 @import './project/p-header.css' layer(project);

--- a/src/index.html
+++ b/src/index.html
@@ -575,8 +575,8 @@
             </div>
 
             <!-- プラン選択 -->
-            <fieldset class="p-contact__fieldset" aria-describedby="plan-error">
-              <legend class="p-contact__legend">ご希望のプラン</legend>
+            <fieldset class="c-field p-contact__fieldset" aria-describedby="plan-error">
+              <legend class="c-field__legend p-contact__legend">ご希望のプラン</legend>
               <div class="p-contact__radio-group">
                 <label class="c-choice-label p-contact__radio-label">
                   <input type="radio" name="plan" value="body-care" class="p-contact__radio" required />

--- a/src/index.html
+++ b/src/index.html
@@ -509,13 +509,13 @@
           <!-- NOTE: aria-describedby でエラーメッセージ要素を紐付け済み。JS でバリデーション時に hidden を解除し aria-invalid="true" を切り替えること -->
           <form class="p-contact__form" action="/api/contact" method="post" novalidate>
             <!-- 氏名 -->
-            <div class="p-contact__field">
-              <label for="name" class="p-contact__label">お名前</label>
+            <div class="c-field p-contact__field">
+              <label for="name" class="c-field__label p-contact__label">お名前</label>
               <input
                 type="text"
                 id="name"
                 name="name"
-                class="p-contact__input"
+                class="c-input p-contact__input"
                 required
                 autocomplete="name"
                 aria-describedby="name-error"
@@ -524,13 +524,13 @@
             </div>
 
             <!-- メール -->
-            <div class="p-contact__field">
-              <label for="email" class="p-contact__label">メールアドレス</label>
+            <div class="c-field p-contact__field">
+              <label for="email" class="c-field__label p-contact__label">メールアドレス</label>
               <input
                 type="email"
                 id="email"
                 name="email"
-                class="p-contact__input"
+                class="c-input p-contact__input"
                 required
                 autocomplete="email"
                 aria-describedby="email-error"
@@ -541,13 +541,13 @@
             </div>
 
             <!-- 電話番号 -->
-            <div class="p-contact__field">
-              <label for="tel" class="p-contact__label">電話番号</label>
+            <div class="c-field p-contact__field">
+              <label for="tel" class="c-field__label p-contact__label">電話番号</label>
               <input
                 type="tel"
                 id="tel"
                 name="tel"
-                class="p-contact__input"
+                class="c-input p-contact__input"
                 autocomplete="tel"
                 aria-describedby="tel-error"
               />
@@ -555,12 +555,12 @@
             </div>
 
             <!-- お問い合わせ種別 -->
-            <div class="p-contact__field">
-              <label for="category" class="p-contact__label">お問い合わせ種別</label>
+            <div class="c-field p-contact__field">
+              <label for="category" class="c-field__label p-contact__label">お問い合わせ種別</label>
               <select
                 id="category"
                 name="category"
-                class="p-contact__select"
+                class="c-input p-contact__select"
                 required
                 aria-describedby="category-error"
               >
@@ -578,15 +578,15 @@
             <fieldset class="p-contact__fieldset" aria-describedby="plan-error">
               <legend class="p-contact__legend">ご希望のプラン</legend>
               <div class="p-contact__radio-group">
-                <label class="p-contact__radio-label">
+                <label class="c-choice-label p-contact__radio-label">
                   <input type="radio" name="plan" value="body-care" class="p-contact__radio" required />
                   ボディケア（60分）
                 </label>
-                <label class="p-contact__radio-label">
+                <label class="c-choice-label p-contact__radio-label">
                   <input type="radio" name="plan" value="facial" class="p-contact__radio" />
                   フェイシャル（45分）
                 </label>
-                <label class="p-contact__radio-label">
+                <label class="c-choice-label p-contact__radio-label">
                   <input type="radio" name="plan" value="relaxation" class="p-contact__radio" />
                   リラクゼーション（90分）
                 </label>
@@ -595,12 +595,12 @@
             </fieldset>
 
             <!-- メッセージ -->
-            <div class="p-contact__field">
-              <label for="message" class="p-contact__label">メッセージ</label>
+            <div class="c-field p-contact__field">
+              <label for="message" class="c-field__label p-contact__label">メッセージ</label>
               <textarea
                 id="message"
                 name="message"
-                class="p-contact__textarea"
+                class="c-input p-contact__textarea"
                 required
                 rows="6"
                 aria-describedby="message-error"
@@ -609,8 +609,8 @@
             </div>
 
             <!-- 同意確認 -->
-            <div class="p-contact__field">
-              <label class="p-contact__checkbox-label">
+            <div class="c-field p-contact__field">
+              <label class="c-choice-label p-contact__checkbox-label">
                 <input
                   type="checkbox"
                   name="agree"


### PR DESCRIPTION
## 目的

p-contact に飼われていた汎用フォームパーツを Portability Test に基づき 3 Component に抽出。
**書籍 ch7（Component / Project 境界）の導入ケーススタディ**として機能する教材価値最強の PR。

既定の草案は内部設計分析（2026-04-21）§ A-1。

## 3 Component の責任境界

| Component | 責任 | 内部配置 | 外部配置は？ |
|---|---|---|---|
| **c-input** | input / textarea / select の視覚装飾 | padding / font: inherit / border / :focus / :user-invalid / prefers-reduced-motion 下の transition | p-contact へ |
| **c-field** | label + input + error のラッパー | display: flex / flex-direction: column / gap / 必須マーク付与 | p-contact へ |
| **c-choice-label** | radio / checkbox 両用ラベル | display: flex / gap / align-items / min-block-size / cursor | p-contact へ |

textarea 固有の `field-sizing: content` + 行数制約は `textarea.c-input` として要素セレクタで追加（1 Component で完結、属性セレクタ不要）。

## 公開 API

\`\`\`css
/* Project 側で必須マーク表記（「 *」→「 必須」等）を上書き可能 */
.p-contact__field {
  --c-field-required-mark: ' 必須';
}
\`\`\`

草案リスク 3「必須マークはサイトによって変わる」に対応。

## Portability Test / Responsibility Test / Layout Test 自己適用

### c-input

- **Portability Test: Yes** — Token 参照のみ（`--color-text` / `--color-surface` / `--color-border` / `--color-error` / `--color-main` / `--space-sm/md` / `--border-width` / `--radius-sm` / `--duration-normal` / `--ease-out-cubic`）。iluha 固有要素ゼロ
- **Responsibility Test: Component** — 入力装飾は部品自身の視覚的責任
- **Layout Test: 合格** — 内部配置のみ、外部配置（margin / position 等）なし

### c-field

- **Portability Test: Yes** — flex-direction: column + gap + 必須マーク付与は全フォームで汎用
- **Responsibility Test: Component** — label + input + error の内部配置は部品責任
- **Layout Test: 合格** — 内部配置のみ。\`--c-field-required-mark\` の公開 API で表現を外部化

### c-choice-label

- **Portability Test: Yes** — WCAG 2.5.5 Target Size AAA（44px）準拠のタップ領域確保は普遍パターン
- **Responsibility Test: Component** — ラベルの内部配置 + タップ領域確保は部品責任
- **Layout Test: 合格** — 内部配置のみ

## 教材価値

書籍 ch7「Component / Project 境界」の導入ケーススタディとして以下を自然に書ける:

1. 「最初は p-contact に全部書いていた（v1.2 まで）」
2. 「Portability Test を各 Element に適用したら c-input / c-field / c-choice-label が見つかる」
3. 「併記パターンで外部配置の拡張点を Project Element に残す」
4. 「必須マークは `--c-field-required-mark` の公開 API で Project から上書きする（公開 API 設計）」

## 影響

- **新設**: `src/assets/css/component/c-input.css` (32 lines) / `c-field.css` (15 lines) / `c-choice-label.css` (8 lines)
- **削減**: `src/assets/css/project/p-contact.css` 126 → 99 行（Component 抽出 + 併記拡張点としてスタブルール保持）
- **HTML**: `src/index.html` contact section に併記クラス追加（input/textarea/select に \`c-input\`、フィールドラッパに \`c-field\`、radio/checkbox ラベルに \`c-choice-label\`）
- **style.css**: @import 3 行追加

**注**: p-contact.css の目標 30 行は草案の理想値だが、starter 原則「HTML クラスとの対応を維持するため空ルールを保持」（書籍 ch11 スタブルールパターン）に従い、スタブルールを WHY コメント付きで残した結果 99 行。実質的なスタイル定義は 8 件（約 37 行）のみ。

## 設計判断と逸脱しなかった点

- ✅ 1 Component で input / textarea / select 内包（草案推奨、属性セレクタ不要）
- ✅ radio / checkbox 両用の `c-choice-label` 1 本（草案推奨、`c-radio-label` + `c-checkbox-label` に分けない）
- ✅ 必須マークは `--c-field-required-mark` の公開 API で Project 側からオーバーライド可能（草案推奨）
- ✅ `:has(+ :required)` ではなく `:has(:required)` で c-field ルート配下の required 検知（flex-direction: column 構造のため `+` は使えない）
- ✅ fieldset 内 required マーク（radio-group）は c-field 構造外のため `p-contact__fieldset:has(:required) .p-contact__legend::after` で p-contact 側に維持（c-fieldset 化は PR E 以降で検討）

## 品質チェック

- [x] Portability Test / Responsibility Test / Layout Test 自己適用（全合格）
- [x] `pnpm run check` 全 Linter 通過（stylelint / eslint / markuplint / prettier）
- [x] `pnpm run build` 成功（27.40 kB CSS, 36.94 kB HTML）
- [x] 既存 token のみ使用（未定義 token 参照なし、token 新設なし）
- [x] Element を Block にネストしない（フラット記述、c-field / c-field__label / `:has()` もフラット）
- [x] コメントは WHY のみ（HOW/WHAT 説明なし）
- [x] 空ルール（スタブ）は WHY コメント付きで保持（`/* 将来の外部配置制御の拡張点として c-field と併記 */` 等）

## 制約

- **main に絶対マージしない** — base は \`v1.2\`
- **しゅんえい承認必須**

## レビュー対応 2（2026-04-22）

しゅんえいレビュー指摘 3 点を追加 commit（b8f7275）で反映:

- **`content` から先頭空白を排除**（`' *'` → `'*'`）→ 視覚余白は `.c-field__label` / `.c-field__legend` の `gap: 0.25em`（flex + baseline align）で制御。コピペ・スクリーンリーダーへの余計なスペース混入を回避
- **c-field を label / legend 両構造対応に拡張**（`fieldset.c-field` + `.c-field__legend`）→ radio-group 等の fieldset 構造も Component として扱える。`:has(:required) > .c-field__legend::after` セレクタ追加で required 判定も両対応
- **`--c-field-required-mark` 公開 API が fieldset 構造でも反映**→ p-contact 側の fieldset 独自記述（`content: ' *'` ハードコード）を削除し c-field に吸収。Project 側の上書きが label / legend 両方に反映される

影響ファイル: `c-field.css` +12/-2、`p-contact.css` +2/-10、`index.html` +2/-2

## 次 PR への申し送り

- **PR D (c-prose)**: `src/privacy/index.html` のリッチテキスト本文を Component 化
- **PR E (c-card.-subtle + c-button 公開 API + p-faq details 化)**: 既存 Component 整備（fieldset 対応は本 PR で c-field に統合済）


🤖 Generated with [Claude Code](https://claude.com/claude-code)
