### PR TITLE
refactor(v1.0): CTA section を中間配置へ移動（AIDA フロー最適化）

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -427,6 +427,15 @@
         </div>
       </section>
 
+      <!-- CTA -->
+      <section class="l-section p-cta" id="cta" aria-labelledby="cta-heading">
+        <div class="l-inner p-cta__inner c-text-block" data-stagger="fade-in-slide-up">
+          <h2 id="cta-heading" class="p-cta__title c-text-block__title">まずは一度、からだの声を聴いてみませんか？</h2>
+          <p class="c-text-block__text">初回体験は 60分 4,400円。カウンセリング込み。無理な勧誘はいたしません。</p>
+          <a href="#contact" class="c-button -primary -large p-cta__button">初回体験を予約する</a>
+        </div>
+      </section>
+
       <!-- FAQ -->
       <section class="l-section p-faq" id="faq" aria-labelledby="faq-heading">
         <div class="l-inner p-faq__inner">
@@ -484,15 +493,6 @@
               </div>
             </details>
           </div>
-        </div>
-      </section>
-
-      <!-- CTA -->
-      <section class="l-section p-cta" id="cta" aria-labelledby="cta-heading">
-        <div class="l-inner p-cta__inner c-text-block" data-stagger="fade-in-slide-up">
-          <h2 id="cta-heading" class="p-cta__title c-text-block__title">まずは一度、からだの声を聴いてみませんか？</h2>
-          <p class="c-text-block__text">初回体験は 60分 4,400円。カウンセリング込み。無理な勧誘はいたしません。</p>
-          <a href="#contact" class="c-button -primary -large p-cta__button">初回体験を予約する</a>
         </div>
       </section>
 


### PR DESCRIPTION
## 目的

AIDA フローの最適化。現状は CTA section が Contact section の直前に置かれており「予約ボタン → スクロール 1 画面分で form が見える」状態のため、CTAボタンの意義が薄く、heading も冗長になっていた。

CTA を Voice と FAQ の間に移動することで:
- **社会的証明（Voice）**の温度感ピークで行動誘導
- **FAQ** で最後の疑問解消
- **Contact** で淡々と受け皿

という AIDA フロー（Attention → Interest → Desire → Action）を実現する。

## 変更内容

**変更前**: Hero → Problem → Features → Numbers → Voice → FAQ → CTA → Contact

**変更後**: Hero → Problem → Features → Numbers → Voice → **CTA（中間）** → FAQ → Contact

- `src/index.html`: section 順序の入れ替えのみ
- **CSS / JS 変更なし**（各 section は独立構造のため影響ゼロ）
- CTA の予約ボタン `<a href="#contact">` はそのまま維持（末尾 Contact へのアンカー）

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `src/index.html` | 1 file changed, 9 insertions(+), 9 deletions(-) |

## 検証結果

- [x] `pnpm run check` 全 Linter 通過（stylelint / eslint / markuplint）
- [x] `pnpm run build` 成功（76ms）
- [x] 最終 section 順序: Hero → Problem → Features → Numbers → Voice → CTA → FAQ → Contact

## ⚠️ 重要

- **しゅんえい承認必須**
- **main にマージしない**（base: `v1.2`）
- 本 PR は PR #102（feat/v1.0-c-input-c-field）と `src/index.html` 上で conflict の可能性あり → マージ時に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)