### PR TITLE
feat(v1.0): Flow section 追加（利用の流れ、<ol> + CSS counter 教材）

### DIFF
--- a/src/assets/css/project/p-flow.css
+++ b/src/assets/css/project/p-flow.css
@@ -1,0 +1,59 @@
+.p-flow {
+  /* スタイルなし（HTML クラスとの対応を維持） */
+}
+
+.p-flow__inner {
+  /* スタイルなし（HTML クラスとの対応を維持） */
+}
+
+.p-flow__heading {
+  /* スタイルなし（HTML クラスとの対応を維持） */
+}
+
+.p-flow__list {
+  display: grid;
+  gap: var(--space-lg);
+
+  /* WHY: <ol> の既定パディングを除去し、カード左端を l-inner 基準に揃える */
+  padding-inline-start: 0;
+  margin-block-start: var(--space-xl-2xl);
+
+  /* WHY: ブラウザ既定の番号表示を無効化し、::before で独自の円形バッジを描画する */
+  list-style: none;
+  counter-reset: step;
+}
+
+.p-flow__item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--space-sm) var(--space-lg);
+  padding: var(--space-lg);
+  counter-increment: step;
+  background-color: var(--color-bg-secondary);
+  border-radius: var(--radius-md);
+
+  /* WHY: CSS counter でステップ番号を円形バッジとして視覚化。<ol> のセマンティクスは保ったまま装飾を自前で描画 */
+  &::before {
+    display: flex;
+    grid-row: 1 / 3;
+    align-items: center;
+    align-self: start;
+    justify-content: center;
+    inline-size: var(--space-2xl);
+    block-size: var(--space-2xl);
+    font-size: var(--font-size-h3);
+    font-weight: var(--font-weight-heading);
+    color: var(--color-surface);
+    content: counter(step);
+    background-color: var(--color-main);
+    border-radius: var(--radius-full);
+  }
+}
+
+.p-flow__item-title {
+  /* スタイルなし（:where(h3) の foundation スタイルで十分） */
+}
+
+.p-flow__item-description {
+  /* スタイルなし（body の基本スタイルで十分） */
+}

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -46,6 +46,7 @@
 @import './project/p-hero.css' layer(project);
 @import './project/p-problem.css' layer(project);
 @import './project/p-features.css' layer(project);
+@import './project/p-flow.css' layer(project);
 @import './project/p-numbers.css' layer(project);
 @import './project/p-voice.css' layer(project);
 @import './project/p-faq.css' layer(project);

--- a/src/index.html
+++ b/src/index.html
@@ -341,6 +341,49 @@
         </div>
       </section>
 
+      <!-- Flow -->
+      <!-- CUSTOMIZE: ステップの数・内容・所要時間を自社サービスに差し替え -->
+      <section class="l-section p-flow" id="flow" aria-labelledby="flow-heading">
+        <div class="l-inner p-flow__inner">
+          <hgroup class="c-section-heading p-flow__heading" data-animate="fade-in-slide-up">
+            <p lang="en">Flow</p>
+            <h2 id="flow-heading">ご利用の流れ</h2>
+          </hgroup>
+          <ol class="p-flow__list" data-stagger="fade-in-slide-up">
+            <li class="p-flow__item">
+              <h3 class="p-flow__item-title">ご予約</h3>
+              <p class="p-flow__item-description">
+                お問い合わせフォームからご希望の日時・コースをお知らせください。24時間以内に折り返しご連絡いたします。
+              </p>
+            </li>
+            <li class="p-flow__item">
+              <h3 class="p-flow__item-title">カウンセリング</h3>
+              <p class="p-flow__item-description">
+                施術前に30分ほどお時間をいただき、お体の状態やお悩み・ご希望を丁寧にヒアリング。
+              </p>
+            </li>
+            <li class="p-flow__item">
+              <h3 class="p-flow__item-title">施術</h3>
+              <p class="p-flow__item-description">
+                選択したコースに沿って45〜90分の施術。完全個室で安心してお過ごしください。
+              </p>
+            </li>
+            <li class="p-flow__item">
+              <h3 class="p-flow__item-title">アフターケア</h3>
+              <p class="p-flow__item-description">
+                施術後は水分補給とリラックスタイム。お体の変化を確かめながらゆっくりとお過ごしください。
+              </p>
+            </li>
+            <li class="p-flow__item">
+              <h3 class="p-flow__item-title">次回のご案内</h3>
+              <p class="p-flow__item-description">
+                お客様のお体に合わせた最適なペースをご提案。ご希望があれば次回のご予約も承ります。
+              </p>
+            </li>
+          </ol>
+        </div>
+      </section>
+
       <!-- Numbers -->
       <section class="l-section p-numbers" id="numbers" aria-labelledby="numbers-heading">
         <div class="l-inner p-numbers__inner">


### PR DESCRIPTION
## 目的

サービス系 LP 頻出パターン「利用の流れ（Flow）」を starter に追加し、`<ol>` セマンティック + CSS counter による番号装飾の教材を提供する。LP 設計としても、Features → Flow → Numbers という「不安解消 → 信頼形成」の流れを示す。

## 教材価値

1. **`<ol>` + CSS counter**: `list-style: none` で既定番号を消し、`counter-reset` / `counter-increment` と `::before { content: counter(step) }` で円形バッジを自前描画する装飾パターン
2. **grid layout でのステップ表現**: `grid-template-columns: auto 1fr` + `::before { grid-row: 1 / 3 }` で番号がタイトル＋説明の両行にまたがる配置
3. **Project 層の責務**: iluha 固有のステップ内容 + カード装飾（`--color-bg-secondary` + `--radius-md`）を Project に閉じ込める
4. **LP 設計**: Features の後に Flow を配置して「選ばれる理由 → 利用の流れ」の順で読み手の不安を解消

## 実装スコープ

- 本 PR の範囲: **Flow section（Project 層のみ）**
- 範囲外: c-step の Component 抽出は将来の PR（PR E 以降）で検討。まず Project で実装し、実運用で汎用パターンを確認してから抽出する段階的アプローチ。

## 変更ファイル

- `src/index.html` — Features の直後、Numbers の直前に Flow section を追加（`<ol>` + 5 ステップ、CUSTOMIZE コメント付き）
- `src/assets/css/project/p-flow.css` — 新設（grid layout + CSS counter 円形バッジ + カード装飾）
- `src/assets/css/style.css` — `@import './project/p-flow.css' layer(project);` を DOM 順に追加（p-features と p-numbers の間）

## トークン実在確認

全て実在する token のみ参照:
- 余白: `--space-sm` / `--space-lg` / `--space-2xl` / `--space-xl-2xl`
- 色: `--color-bg-secondary` / `--color-main` / `--color-surface`
- 角丸: `--radius-md` / `--radius-full`
- タイポ: `--font-size-h3` / `--font-weight-heading`

## 検証結果

- `pnpm run check` ✅ 全 Linter 通過（Prettier / Stylelint / ESLint / markuplint）
- `pnpm run build` ✅ Vite build 成功（dist に Flow section + CSS counter 規則出力を確認）

## ナビゲーション

現状維持（Header / Drawer / Footer のナビは既存 4 項目のまま）。Flow はスクロール導線で自然に目に入る設計。必要に応じて別 PR で追加検討。

## 注意

- **しゅんえい承認必須**
- **main に絶対マージしない**（base は `v1.2`）
- c-step の Component 抽出は将来の PR E 以降で検討

## 次 PR

- PR B-4（Pricing section + table wrapper）次着手