### PR TITLE
refactor(v1.0): c-form 統合 Component + Element 併記ルール適用（PR #102 方針変更）

### DIFF
--- a/src/assets/css/component/c-form.css
+++ b/src/assets/css/component/c-form.css
@@ -1,0 +1,78 @@
+/* Block: フォーム全体の縦並びレイアウト（max-inline-size / margin 等の外部配置は Project 側で制御） */
+.c-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+/* Element: label + input ラッパー（label / fieldset 両構造に対応） */
+.c-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+/* fieldset として使う時の default 装飾リセット（border / padding / margin を無効化し、div と等価な箱に整える） */
+fieldset.c-form__field {
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+
+/* Element: label / legend（見出し扱いのタイポグラフィを共通化） */
+.c-form__label,
+.c-form__legend {
+  display: flex;
+  gap: 0.25em;
+  align-items: baseline;
+  font-weight: var(--font-weight-heading);
+}
+
+/* 必須マーク: Project 側が --c-form-required-mark を上書きすればサイトごとに表現（「*」→「必須」等）を切替可能。
+   空白は content に含めず gap: 0.25em で視覚的に担保する（コピペ・a11y 読み上げへの混入を回避） */
+.c-form__field:has(:required) > .c-form__label::after,
+.c-form__field:has(:required) > .c-form__legend::after {
+  color: var(--color-error);
+  content: var(--c-form-required-mark, '*');
+}
+
+/* Element: 入力装飾（input / textarea / select 共通のビジュアル定義） */
+.c-form__input {
+  padding: var(--space-sm) var(--space-md);
+  font: inherit;
+  color: var(--color-text);
+  background-color: var(--color-surface);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-sm);
+
+  /* prefers-reduced-motion: transition を抑制してアニメ酔い対策 */
+  @media (prefers-reduced-motion: no-preference) {
+    transition: border-color var(--duration-normal) var(--ease-out-cubic);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--color-main);
+  }
+
+  /* :user-invalid: ユーザー操作後のみ invalid 表示（初期表示で赤枠を出さない） */
+  &:user-invalid {
+    border-color: var(--color-error);
+  }
+}
+
+/* textarea は自動リサイズ + 下限/上限行数を指定（field-sizing は Chrome 123+ / Safari 17.4+） */
+textarea.c-form__input {
+  field-sizing: content;
+  min-block-size: 10lh;
+  max-block-size: 20lh;
+}
+
+/* Element: radio / checkbox ラベル（両用、WCAG 2.5.5 Target Size AAA 相当のタップ領域確保） */
+.c-form__choice-label {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: center;
+  min-block-size: var(--size-tap-target);
+  cursor: pointer;
+}

--- a/src/assets/css/component/c-form.css
+++ b/src/assets/css/component/c-form.css
@@ -76,3 +76,24 @@ textarea.c-form__input {
   min-block-size: var(--size-tap-target);
   cursor: pointer;
 }
+
+/* Element: radio / checkbox グループコンテナ（複数の choice-label を縦に並べる） */
+.c-form__choice-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  margin-block-start: var(--space-xs);
+}
+
+/* Element: エラーメッセージ表示（role="alert" + hidden で JS トグル前提） */
+.c-form__error {
+  font-size: var(--font-size-caption);
+  color: var(--color-error);
+}
+
+/* Element: 送信ボタン配置ラッパー（中央寄せ default、Project 側で上書き可） */
+.c-form__actions {
+  display: flex;
+  justify-content: center;
+  margin-block-start: var(--space-md);
+}

--- a/src/assets/css/project/p-contact.css
+++ b/src/assets/css/project/p-contact.css
@@ -16,68 +16,17 @@
   text-align: center;
 }
 
+/* フォーム全体の外部配置（最大幅・上余白・中央寄せ）は Project 側が保持。
+   縦並び / gap 等の内部レイアウトは Component（c-form）が担当。 */
 .p-contact__form {
   --_form-max: 640px;
 
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-lg);
   max-inline-size: var(--_form-max);
   margin-block-start: var(--space-xl-2xl);
   margin-inline: auto;
 }
 
-.p-contact__field {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xs);
-}
-
-.p-contact__label:has(+ :required),
-.p-contact__legend:has(~ .p-contact__field :required) {
-  &::after {
-    color: var(--color-error);
-    content: ' *';
-  }
-}
-
-.p-contact__textarea {
-  --_textarea-min: 160px;
-
-  field-sizing: content;
-  min-block-size: var(--_textarea-min);
-  max-block-size: 20lh;
-}
-
-.p-contact__input,
-.p-contact__textarea,
-.p-contact__select {
-  padding: var(--space-sm) var(--space-md);
-  font: inherit;
-  color: inherit;
-  background-color: var(--color-surface);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-sm);
-  transition: border-color var(--duration-fast) var(--ease-out-cubic);
-
-  &:focus {
-    border-color: var(--color-main);
-  }
-
-  &:user-invalid {
-    border-color: var(--color-error);
-  }
-}
-
-.p-contact__fieldset {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-sm);
-}
-
-.p-contact__legend {
-  font-weight: var(--font-weight-heading);
-}
+/* Project 固有 Element（Component 化しない装飾・配置） */
 
 .p-contact__radio-group {
   display: flex;
@@ -86,20 +35,10 @@
   margin-block-start: var(--space-xs);
 }
 
-.p-contact__radio-label,
-.p-contact__checkbox-label {
-  display: flex;
-  gap: var(--space-sm);
-  align-items: center;
-  min-block-size: var(--size-tap-target);
-  cursor: pointer;
-}
-
-.p-contact__checkbox-label {
-  & a {
-    color: var(--color-main);
-    text-decoration: underline;
-  }
+/* 同意確認リンク（プライバシーポリシー）は p-contact 固有の装飾 */
+.p-contact__form a {
+  color: var(--color-main);
+  text-decoration: underline;
 }
 
 .p-contact__error {
@@ -107,20 +46,15 @@
   color: var(--color-error);
 }
 
-.p-contact__radio {
-  /* スタイルなし（HTML クラスとの対応を維持） */
-}
-
-.p-contact__checkbox {
-  /* スタイルなし（HTML クラスとの対応を維持） */
-}
-
-.p-contact__submit {
-  /* スタイルなし（HTML クラスとの対応を維持） */
-}
-
 .p-contact__actions {
   display: flex;
   justify-content: center;
   margin-block-start: var(--space-md);
 }
+
+/* TEACHING: Project が Component Element を文脈依存に上書きする場合は、子孫セレクタで対応する。
+   例:
+     .p-contact__form .c-form__input {
+       border-radius: var(--radius-md);
+     }
+   Component の公開 API（--c-form-required-mark 等）を使って差し替える方法も推奨される。 */

--- a/src/assets/css/project/p-contact.css
+++ b/src/assets/css/project/p-contact.css
@@ -28,28 +28,10 @@
 
 /* Project 固有 Element（Component 化しない装飾・配置） */
 
-.p-contact__radio-group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-sm);
-  margin-block-start: var(--space-xs);
-}
-
 /* 同意確認リンク（プライバシーポリシー）は p-contact 固有の装飾 */
 .p-contact__form a {
   color: var(--color-main);
   text-decoration: underline;
-}
-
-.p-contact__error {
-  font-size: var(--font-size-caption);
-  color: var(--color-error);
-}
-
-.p-contact__actions {
-  display: flex;
-  justify-content: center;
-  margin-block-start: var(--space-md);
 }
 
 /* TEACHING: Project が Component Element を文脈依存に上書きする場合は、子孫セレクタで対応する。

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -39,6 +39,7 @@
 @import './component/c-skip-link.css' layer(component);
 @import './component/c-hamburger.css' layer(component);
 @import './component/c-overlay.css' layer(component);
+@import './component/c-form.css' layer(component);
 
 /* Project */
 @import './project/p-header.css' layer(project);

--- a/src/index.html
+++ b/src/index.html
@@ -507,15 +507,15 @@
 
           <!-- CUSTOMIZE: 本番バックエンド URL に差し替え。starter はフォーム送信処理を提供しません -->
           <!-- NOTE: aria-describedby でエラーメッセージ要素を紐付け済み。JS でバリデーション時に hidden を解除し aria-invalid="true" を切り替えること -->
-          <form class="p-contact__form" action="/api/contact" method="post" novalidate>
+          <form class="c-form p-contact__form" action="/api/contact" method="post" novalidate>
             <!-- 氏名 -->
-            <div class="p-contact__field">
-              <label for="name" class="p-contact__label">お名前</label>
+            <div class="c-form__field">
+              <label for="name" class="c-form__label">お名前</label>
               <input
                 type="text"
                 id="name"
                 name="name"
-                class="p-contact__input"
+                class="c-form__input"
                 required
                 autocomplete="name"
                 aria-describedby="name-error"
@@ -524,13 +524,13 @@
             </div>
 
             <!-- メール -->
-            <div class="p-contact__field">
-              <label for="email" class="p-contact__label">メールアドレス</label>
+            <div class="c-form__field">
+              <label for="email" class="c-form__label">メールアドレス</label>
               <input
                 type="email"
                 id="email"
                 name="email"
-                class="p-contact__input"
+                class="c-form__input"
                 required
                 autocomplete="email"
                 aria-describedby="email-error"
@@ -541,13 +541,13 @@
             </div>
 
             <!-- 電話番号 -->
-            <div class="p-contact__field">
-              <label for="tel" class="p-contact__label">電話番号</label>
+            <div class="c-form__field">
+              <label for="tel" class="c-form__label">電話番号</label>
               <input
                 type="tel"
                 id="tel"
                 name="tel"
-                class="p-contact__input"
+                class="c-form__input"
                 autocomplete="tel"
                 aria-describedby="tel-error"
               />
@@ -555,15 +555,9 @@
             </div>
 
             <!-- お問い合わせ種別 -->
-            <div class="p-contact__field">
-              <label for="category" class="p-contact__label">お問い合わせ種別</label>
-              <select
-                id="category"
-                name="category"
-                class="p-contact__select"
-                required
-                aria-describedby="category-error"
-              >
+            <div class="c-form__field">
+              <label for="category" class="c-form__label">お問い合わせ種別</label>
+              <select id="category" name="category" class="c-form__input" required aria-describedby="category-error">
                 <option value="">選択してください</option>
                 <option value="reservation">初回体験の予約</option>
                 <option value="inquiry">施術に関するお問い合わせ</option>
@@ -575,19 +569,19 @@
             </div>
 
             <!-- プラン選択 -->
-            <fieldset class="p-contact__fieldset" aria-describedby="plan-error">
-              <legend class="p-contact__legend">ご希望のプラン</legend>
+            <fieldset class="c-form__field" aria-describedby="plan-error">
+              <legend class="c-form__legend">ご希望のプラン</legend>
               <div class="p-contact__radio-group">
-                <label class="p-contact__radio-label">
-                  <input type="radio" name="plan" value="body-care" class="p-contact__radio" required />
+                <label class="c-form__choice-label">
+                  <input type="radio" name="plan" value="body-care" required />
                   ボディケア（60分）
                 </label>
-                <label class="p-contact__radio-label">
-                  <input type="radio" name="plan" value="facial" class="p-contact__radio" />
+                <label class="c-form__choice-label">
+                  <input type="radio" name="plan" value="facial" />
                   フェイシャル（45分）
                 </label>
-                <label class="p-contact__radio-label">
-                  <input type="radio" name="plan" value="relaxation" class="p-contact__radio" />
+                <label class="c-form__choice-label">
+                  <input type="radio" name="plan" value="relaxation" />
                   リラクゼーション（90分）
                 </label>
               </div>
@@ -595,12 +589,12 @@
             </fieldset>
 
             <!-- メッセージ -->
-            <div class="p-contact__field">
-              <label for="message" class="p-contact__label">メッセージ</label>
+            <div class="c-form__field">
+              <label for="message" class="c-form__label">メッセージ</label>
               <textarea
                 id="message"
                 name="message"
-                class="p-contact__textarea"
+                class="c-form__input"
                 required
                 rows="6"
                 aria-describedby="message-error"
@@ -609,16 +603,9 @@
             </div>
 
             <!-- 同意確認 -->
-            <div class="p-contact__field">
-              <label class="p-contact__checkbox-label">
-                <input
-                  type="checkbox"
-                  name="agree"
-                  id="agree"
-                  class="p-contact__checkbox"
-                  required
-                  aria-describedby="agree-error"
-                />
+            <div class="c-form__field">
+              <label class="c-form__choice-label">
+                <input type="checkbox" name="agree" id="agree" required aria-describedby="agree-error" />
                 <a href="/privacy/">プライバシーポリシー</a>に同意する
               </label>
               <p id="agree-error" class="p-contact__error" role="alert" hidden>
@@ -628,7 +615,7 @@
 
             <!-- 送信 -->
             <div class="p-contact__actions">
-              <button type="submit" class="c-button -primary -large p-contact__submit">送信する</button>
+              <button type="submit" class="c-button -primary -large">送信する</button>
             </div>
           </form>
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -520,7 +520,7 @@
                 autocomplete="name"
                 aria-describedby="name-error"
               />
-              <p id="name-error" class="p-contact__error" role="alert" hidden>お名前を入力してください。</p>
+              <p id="name-error" class="c-form__error" role="alert" hidden>お名前を入力してください。</p>
             </div>
 
             <!-- メール -->
@@ -535,9 +535,7 @@
                 autocomplete="email"
                 aria-describedby="email-error"
               />
-              <p id="email-error" class="p-contact__error" role="alert" hidden>
-                メールアドレスの形式が正しくありません。
-              </p>
+              <p id="email-error" class="c-form__error" role="alert" hidden>メールアドレスの形式が正しくありません。</p>
             </div>
 
             <!-- 電話番号 -->
@@ -551,7 +549,7 @@
                 autocomplete="tel"
                 aria-describedby="tel-error"
               />
-              <p id="tel-error" class="p-contact__error" role="alert" hidden>電話番号の形式が正しくありません。</p>
+              <p id="tel-error" class="c-form__error" role="alert" hidden>電話番号の形式が正しくありません。</p>
             </div>
 
             <!-- お問い合わせ種別 -->
@@ -563,15 +561,13 @@
                 <option value="inquiry">施術に関するお問い合わせ</option>
                 <option value="other">その他</option>
               </select>
-              <p id="category-error" class="p-contact__error" role="alert" hidden>
-                お問い合わせ種別を選択してください。
-              </p>
+              <p id="category-error" class="c-form__error" role="alert" hidden>お問い合わせ種別を選択してください。</p>
             </div>
 
             <!-- プラン選択 -->
             <fieldset class="c-form__field" aria-describedby="plan-error">
               <legend class="c-form__legend">ご希望のプラン</legend>
-              <div class="p-contact__radio-group">
+              <div class="c-form__choice-group">
                 <label class="c-form__choice-label">
                   <input type="radio" name="plan" value="body-care" required />
                   ボディケア（60分）
@@ -585,7 +581,7 @@
                   リラクゼーション（90分）
                 </label>
               </div>
-              <p id="plan-error" class="p-contact__error" role="alert" hidden>ご希望のプランを選択してください。</p>
+              <p id="plan-error" class="c-form__error" role="alert" hidden>ご希望のプランを選択してください。</p>
             </fieldset>
 
             <!-- メッセージ -->
@@ -599,7 +595,7 @@
                 rows="6"
                 aria-describedby="message-error"
               ></textarea>
-              <p id="message-error" class="p-contact__error" role="alert" hidden>メッセージを入力してください。</p>
+              <p id="message-error" class="c-form__error" role="alert" hidden>メッセージを入力してください。</p>
             </div>
 
             <!-- 同意確認 -->
@@ -608,13 +604,11 @@
                 <input type="checkbox" name="agree" id="agree" required aria-describedby="agree-error" />
                 <a href="/privacy/">プライバシーポリシー</a>に同意する
               </label>
-              <p id="agree-error" class="p-contact__error" role="alert" hidden>
-                プライバシーポリシーへの同意が必要です。
-              </p>
+              <p id="agree-error" class="c-form__error" role="alert" hidden>プライバシーポリシーへの同意が必要です。</p>
             </div>
 
             <!-- 送信 -->
-            <div class="p-contact__actions">
+            <div class="c-form__actions">
               <button type="submit" class="c-button -primary -large">送信する</button>
             </div>
           </form>


### PR DESCRIPTION
## Summary

PR #102 の方針全面変更 PR。c-input / c-field / c-choice-label の 3 独立 Component を **c-form 1 統合 Component（1 Block + 5 Element）** へ refactor し、**Element 併記ルール**を明確化（Block 併記のみ、Element は Component のみ）。

## Why

1. 3 Component はフォーム以外で使わない → 独立性は理論的のみ、実用的には常にセット
2. mFLOCSS の既存 Component `c-media-card` が「1 Block + 5 Element」パターンを採用している既存原則と整合
3. Element の Project 併記（例: `<input class="c-form__input p-contact__input">`）は過剰。Project 側から Component Element を制御する場合は子孫セレクタ（`.p-contact__form .c-form__input`）や公開 API（`--c-form-required-mark`）を使う

## 変更内容

### 新設
- `src/assets/css/component/c-form.css`（78 行、1 Block + 5 Element）
  - Block: `.c-form`（縦並び装飾のみ、`max-inline-size` 等の外部配置は Project）
  - Element: `.c-form__field` / `.c-form__label` / `.c-form__legend` / `.c-form__input` / `.c-form__choice-label`
  - `textarea.c-form__input` に `field-sizing: content` + `min/max-block-size: 10lh/20lh`
  - 公開 API: `--c-form-required-mark`（必須マーク表現をサイトごとに切替可）
  - `@media (prefers-reduced-motion: no-preference)` で transition を抑制（a11y 配慮）

### 修正
- `src/assets/css/style.css`: `c-form.css` を Component 層に追加
- `src/index.html`: contact section のクラスを Block 併記のみに修正
  - `<form class="c-form p-contact__form">` — Block 併記 OK
  - `<input class="c-form__input">` — Element は Component のみ（`p-contact__input` 等を削除）
  - `<button class="c-button -primary -large">` — `p-contact__submit` を削除、c-button + modifier で完結
  - radio の `class="p-contact__radio"` 削除（foundation + `c-form__choice-label` で十分）
- `src/assets/css/project/p-contact.css`: 121 行 → 60 行に削減
  - 削除: `__field` / `__label` / `__input` / `__textarea` / `__select` / `__fieldset` / `__legend` / `__radio-label` / `__checkbox-label` / `__radio` / `__checkbox` / `__submit`（併記用スタブ + 装飾定義）
  - 残存: `__form`（max-inline-size + margin のみ）/ `__radio-group` / `__error` / `__actions` / リンク装飾
  - 教材コメント追記: Project から Component Element を文脈依存に上書きする場合の子孫セレクタ例

## Portability / Responsibility / Layout Test

- **Portability Test**: c-form は Token 参照のみで構成され、iluha 固有要素を一切含まない汎用フォームパーツ → ✅ Yes
- **Responsibility Test**: 入力装飾・必須マーク・タップ領域確保 = Component、フォーム全体の max-inline-size / 中央寄せ = Project → ✅ 責任境界明確
- **Layout Test**: Component は内部配置のみ（padding / gap / border-radius 等）、外部配置（margin / max-inline-size）は Project に残存 → ✅ 合格

## 品質確認

- ✅ `pnpm run check`: prettier / stylelint / eslint / markuplint 全通過
- ✅ `pnpm run build`: vite build 成功（77ms、main-CYPc-8NX.css 27.40 kB）
- ✅ トークン整合: `--color-text` / `--color-surface` / `--color-border` / `--color-error` / `--color-main` / `--size-tap-target` / `--space-xs..xl-2xl` / `--radius-sm` / `--border-width` / `--duration-normal` / `--ease-out-cubic` / `--font-weight-heading` / `--font-size-caption` の存在確認済み

## 併記ルールの妥当性

| 要素 | クラス | 判定 |
|---|---|---|
| form | `c-form p-contact__form` | Block 併記 OK |
| div.field | `c-form__field` | Element は Component のみ |
| label | `c-form__label` | 同上 |
| input/select/textarea | `c-form__input` | 同上 |
| fieldset | `c-form__field`（fieldset 要素に直接） | 同上 |
| legend | `c-form__legend` | 同上 |
| label.choice | `c-form__choice-label` | 同上 |
| button.submit | `c-button -primary -large` | modifier で完結、Project 不要 |
| div.radio-group | `p-contact__radio-group` | Project 固有装飾 |
| p.error | `p-contact__error` | 同上 |
| div.actions | `p-contact__actions` | 同上 |

## 関連

- 設計根拠: 内部設計分析（2026-04-21）§ A-1
- 既存パターン: `src/assets/css/component/c-media-card.css`（1 Block + 5 Element）

## 次アクション

PR #102（`feat/v1.0-c-input-c-field`）は本 PR マージ後に close 予定（統合により obsolete）。しゅんえいのマージ判断をお願いします。

## Test plan

- [ ] Prettier / Stylelint / ESLint / Markuplint 全通過（本 PR で確認済み）
- [ ] Vite build 成功（本 PR で確認済み）
- [ ] `pnpm run dev` で form 動作確認（label 構造 + legend 構造両方で必須マーク表示）
- [ ] Chrome / Safari / Firefox で radio / checkbox のタップ領域（44px 以上）確認
- [ ] 必須マーク `*` が label / legend の末尾に gap: 0.25em で表示される
- [ ] `:user-invalid` で border が error 色に変化する
- [ ] textarea の field-sizing が動作する（Chrome 123+ / Safari 17.4+）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## レビュー対応（2026-04-22）

しゅんえい指摘で以下 3 Element が p-contact 側に残っていたのを c-form に取り込み:

- `p-contact__error` → `c-form__error`（エラーメッセージ表示、Portability Test 合格）
- `p-contact__actions` → `c-form__actions`（送信ボタン配置ラッパー、Portability Test 合格）
- `p-contact__radio-group` → `c-form__choice-group`（choice グループコンテナ、Portability Test 合格）

結果:
- c-form は 1 Block + **8 Element** になり、フォーム系の汎用 Component として完成度向上
- p-contact は外部配置のみ（max-inline-size, margin 等）に純化、mFLOCSS の Project 責務と整合
