### PR TITLE
feat(v1.0): c-prose 新設（A-2、リッチテキスト本文の子孫セレクタ Component）

### DIFF
--- a/src/assets/css/component/c-prose.css
+++ b/src/assets/css/component/c-prose.css
@@ -1,0 +1,41 @@
+/* Block: リッチテキスト本文（CMS / プライバシーポリシー / 利用規約 / ブログ記事等に使用）
+   子孫セレクタを許容する例外 Component。HTML 構造にクラスを付与できない CMS 流し込みに対応する。
+   public API: --c-prose-max-inline-size（読みやすい最大幅、Project 側で上書き可） */
+.c-prose {
+  max-inline-size: var(--c-prose-max-inline-size, 40rem);
+  line-height: var(--line-height-text);
+
+  & h2 {
+    margin-block-start: var(--space-xl);
+    font-weight: var(--font-weight-heading);
+  }
+
+  & :is(p, ul) {
+    margin-block-start: var(--space-md);
+  }
+
+  /* h2 直下の段落・リストはタイトルと近接させる（視覚的グルーピング） */
+  & h2 + :is(p, ul) {
+    margin-block-start: var(--space-sm);
+  }
+
+  & ul {
+    padding-inline-start: var(--space-lg);
+  }
+
+  & li + li {
+    margin-block-start: var(--space-xs);
+  }
+
+  & a {
+    color: var(--color-main);
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
+
+    @media (any-hover: hover) {
+      &:hover {
+        text-decoration: none;
+      }
+    }
+  }
+}

--- a/src/assets/css/project/p-privacy.css
+++ b/src/assets/css/project/p-privacy.css
@@ -10,43 +10,7 @@
   font-weight: var(--font-weight-heading);
 }
 
+/* タイトルと本文の間隔のみ Project 責任（本文内のタイポグラフィは c-prose が担う） */
 .p-privacy__body {
-  --_body-max: 640px;
-
-  max-inline-size: var(--_body-max);
   margin-block-start: var(--space-lg);
-  line-height: var(--line-height-text);
-
-  & h2 {
-    margin-block-start: var(--space-xl);
-    font-weight: var(--font-weight-heading);
-  }
-
-  & :is(p, ul) {
-    margin-block-start: var(--space-md);
-  }
-
-  & h2 + :is(p, ul) {
-    margin-block-start: var(--space-sm);
-  }
-
-  & ul {
-    padding-inline-start: var(--space-lg);
-  }
-
-  & li + li {
-    margin-block-start: var(--space-xs);
-  }
-
-  & a {
-    color: var(--color-main);
-    text-decoration: underline;
-    text-underline-offset: 0.2em;
-
-    @media (any-hover: hover) {
-      &:hover {
-        text-decoration: none;
-      }
-    }
-  }
 }

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -34,6 +34,7 @@
 @import './component/c-accordion.css' layer(component);
 @import './component/c-blockquote.css' layer(component);
 @import './component/c-text-block.css' layer(component);
+@import './component/c-prose.css' layer(component);
 @import './component/c-icon.css' layer(component);
 @import './component/c-back-to-top.css' layer(component);
 @import './component/c-skip-link.css' layer(component);

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -128,7 +128,7 @@
         <div class="l-inner p-privacy__inner">
           <h1 class="p-privacy__title">プライバシーポリシー</h1>
 
-          <div class="p-privacy__body">
+          <div class="c-prose p-privacy__body">
             <h2>個人情報の取り扱いについて</h2>
             <p>当サロン（以下「当店」）は、お客様の個人情報を適切に保護し、以下の方針に基づいて取り扱います。</p>
 


### PR DESCRIPTION
## Summary

CMS / プライバシーポリシー / 利用規約 / ブログ記事等の「HTML 構造にクラスを付与できない流し込み本文」に対応する **子孫セレクタを許容する例外 Component** `c-prose` を新設。Tailwind Typography の `prose` と命名を揃える。

## 変更内容

| ファイル | 変更 | 行数 |
|---|---|---|
| `src/assets/css/component/c-prose.css` | **新設** | 41 行 |
| `src/assets/css/style.css` | `c-text-block` 直後に import 追加 | +1 |
| `src/privacy/index.html` | `<div class="p-privacy__body">` → `<div class="c-prose p-privacy__body">` | 1 箇所 |
| `src/assets/css/project/p-privacy.css` | 52 行 → 16 行（`__body` 内子孫セレクタを c-prose へ移管） | -36 |

## 設計判断

- **命名**: `c-prose`（Tailwind Typography / WordPress の `prose` と命名統一、英語慣例に寄せる）
- **子孫セレクタの範囲**: h2 / p / ul / li / a のみ（starter 本編で使われる要素に限定。h3/h4/ol/blockquote/code/pre/table 等は書籍 ch7 コラムで拡張例として提示予定）
- **公開 API**: `--c-prose-max-inline-size`（デフォルト `40rem`、Project 側で上書き可）。既存 `c-form` の単層パターン `var(--c-form-required-mark, '*')` と一貫
- **併記ルール**: Block のみ併記（`class="c-prose p-privacy__body"`）。Element レベルの Project 併記なし = 子孫セレクタで装飾する c-prose の設計思想

## テスト結果

**Portability Test**: ✅ 合格 — Token (`--space-*` / `--color-main` / `--line-height-text` / `--font-weight-heading`) のみ参照、iluha 固有要素ゼロ。CMS / 利用規約 / ブログ等への転用可

**Responsibility Test**: ✅ 合格
- h2/p/ul/li/a の装飾 = **Component**（本文ブロック内のタイポグラフィ責任）
- `margin-block-start: var(--space-lg)`（タイトルとの間隔） = **Project**（ページ固有の外部配置）
- `max-inline-size` = Component のデフォルト + 公開 API で Project から上書き可

**Linter / Build**:
- ✅ `pnpm run check` 全 Linter 通過（stylelint / eslint / markuplint）
- ✅ `pnpm run build` 成功
- ✅ 視覚確認: dist/assets/main-*.css に `.c-prose{...}` 正常組込、`class="c-prose p-privacy__body"` 正常適用

## 教材価値（書籍 v1.0 ch7）

- BEM 的 Component（`c-input` / `c-field`、PR C 予定）**vs** 子孫セレクタ Component（`c-prose`）の対比教材
- 「Component は Element クラスを使う」原則 → 「CMS / リッチテキスト流し込みでは子孫セレクタも Component 責任」という例外パターンの導入
- `--c-prose-max-inline-size` を通じた公開 API 設計の実例

## レビュー観点

- [ ] 命名 `c-prose`（vs `c-rich-text` / `c-article-body`）
- [ ] 公開 API のデフォルト `40rem`（既存 `640px` より若干狭い = 読みやすさ優先の意図的変更）
- [ ] `line-height: var(--line-height-text)` を Component 側に移管した判断（p-privacy から移動）
- [ ] Block 併記のみ / Element 併記なしの設計思想

## 重要制約

- **main に絶対マージしない**（base: `v1.2`）
- **しゅんえい承認必須**
- 次 PR E: `c-card.-subtle` + `c-button` 公開 API + `p-faq` details + `scroll-margin` 統一

🤖 Generated with [Claude Code](https://claude.com/claude-code)