### PR TITLE
refactor(v1.0): Component 整備バンドル（PR E: c-card.-subtle / c-button API / p-faq ul / scroll-margin / form.css reduced-motion）

### DIFF
--- a/src/assets/css/component/c-button.css
+++ b/src/assets/css/component/c-button.css
@@ -9,9 +9,13 @@
   font-size: inherit;
   font-weight: var(--font-weight-heading);
   line-height: var(--line-height-title);
+
+  /* WHY: 色系は公開 API 経由でモディファイア・Project から注入。ベースには default を置かず、モディファイア未指定だと無色となる設計（誤用を設計段階で顕在化させる） */
+  color: var(--c-button-color);
   text-decoration: none;
   cursor: pointer;
-  border: var(--border-width) solid var(--color-main);
+  background-color: var(--c-button-bg-color);
+  border: var(--border-width) solid var(--c-button-border-color);
   border-radius: var(--radius-lg);
 
   @media (prefers-reduced-motion: no-preference) {
@@ -22,6 +26,7 @@
 
   @media (any-hover: hover) {
     &:hover {
+      background-color: var(--c-button-hover-bg-color);
       translate: 0 var(--_hover-lift);
     }
   }
@@ -31,26 +36,17 @@
   }
 
   &.-primary {
-    color: var(--color-surface);
-    background-color: var(--color-accent);
-    border-color: var(--color-accent);
-
-    @media (any-hover: hover) {
-      &:hover {
-        background-color: oklch(from var(--color-accent) calc(l * 1.08) c h);
-      }
-    }
+    --c-button-color: var(--color-surface);
+    --c-button-bg-color: var(--color-accent);
+    --c-button-border-color: var(--color-accent);
+    --c-button-hover-bg-color: oklch(from var(--color-accent) calc(l * 1.08) c h);
   }
 
   &.-ghost {
-    color: var(--color-main);
-    background-color: transparent;
-
-    @media (any-hover: hover) {
-      &:hover {
-        background-color: oklch(from var(--color-main) l c h / 8%);
-      }
-    }
+    --c-button-color: var(--color-main);
+    --c-button-bg-color: transparent;
+    --c-button-border-color: var(--color-main);
+    --c-button-hover-bg-color: oklch(from var(--color-main) l c h / 8%);
   }
 
   &.-large {

--- a/src/assets/css/component/c-card.css
+++ b/src/assets/css/component/c-card.css
@@ -3,4 +3,10 @@
   background-color: var(--color-surface);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-sm) var(--color-shadow);
+
+  /* WHY: 影を落とさず背景のみで区切る控えめバリエーション。グレーの面で情報をまとめたい場面（Problem セクション等）向け */
+  &.-subtle {
+    background-color: var(--color-bg-secondary);
+    box-shadow: none;
+  }
 }

--- a/src/assets/css/foundation/form.css
+++ b/src/assets/css/foundation/form.css
@@ -38,7 +38,11 @@
   appearance: none;
   cursor: pointer;
   border: var(--border-width) solid var(--color-border);
-  transition: border-color var(--duration-fast) var(--ease-out-cubic);
+
+  /* WHY: OS のモーション低減設定を尊重。c-button / c-form 等と一貫して transition をガード */
+  @media (prefers-reduced-motion: no-preference) {
+    transition: border-color var(--duration-fast) var(--ease-out-cubic);
+  }
 }
 
 :where(input[type='radio']:checked, input[type='checkbox']:checked) {

--- a/src/assets/css/layout/l-section.css
+++ b/src/assets/css/layout/l-section.css
@@ -3,4 +3,7 @@
   --section-padding-max: var(--section-standard-max);
 
   padding-block: clamp(var(--section-padding-min), 3.462vi + 3.1346rem, var(--section-padding-max));
+
+  /* WHY: 固定ヘッダー分のオフセット。アンカーリンク（#features 等）で飛んだ際、セクション冒頭がヘッダーに被らないようにする */
+  scroll-margin-block-start: var(--header-size);
 }

--- a/src/assets/css/project/p-faq.css
+++ b/src/assets/css/project/p-faq.css
@@ -12,10 +12,18 @@
 
 .p-faq__list {
   max-inline-size: var(--content-width-narrow);
+
+  /* WHY: <ul> の既定マーカー・字下げを除去。並列項目としての semantics は保ったまま見た目をフラットに */
+  padding-inline-start: 0;
   margin-block-start: var(--space-xl-2xl);
   margin-inline: auto;
+  list-style-type: none;
 }
 
 .p-faq__item {
-  /* スタイルなし（HTML クラスとの対応を維持） */
+  /* WHY: <li> で包んだことで c-accordion の「隣接兄弟で二重ボーダーを解消」ルールが効かなくなる。
+     並列に積層した FAQ の見た目は Project の合成責任なので、ここで境界線を解消する */
+  & + & .c-accordion {
+    border-block-start: none;
+  }
 }

--- a/src/assets/css/project/p-hero.css
+++ b/src/assets/css/project/p-hero.css
@@ -39,8 +39,9 @@
 }
 
 .p-hero__sub-cta {
-  color: light-dark(var(--color-main), var(--color-text));
-  border-color: light-dark(var(--color-main), var(--color-text));
+  /* WHY: Hero 背景のグラデーション上でもテキストとボーダーの可読性を確保するため、ダークモード時は text 色に寄せる。c-button 公開 API 経由で注入し、プロパティ直上書きを避ける */
+  --c-button-color: light-dark(var(--color-main), var(--color-text));
+  --c-button-border-color: light-dark(var(--color-main), var(--color-text));
 }
 
 .p-hero__actions {

--- a/src/assets/css/project/p-problem.css
+++ b/src/assets/css/project/p-problem.css
@@ -27,7 +27,5 @@
 }
 
 .p-problem__item {
-  padding: var(--space-lg);
-  background-color: var(--color-bg-secondary);
-  border-radius: var(--radius-md);
+  /* スタイルなし（カード装飾は c-card -subtle が担当。Project は grid 配置のみを責任範囲とする） */
 }

--- a/src/index.html
+++ b/src/index.html
@@ -233,19 +233,19 @@
               <h2 id="problem-heading">こんな日々、続いていませんか？</h2>
             </hgroup>
             <ul class="p-problem__list" data-stagger="fade-in-slide-up">
-              <li class="p-problem__item c-text-block">
+              <li class="c-card -subtle c-text-block p-problem__item">
                 <h3 class="c-text-block__title">朝起きても疲れが抜けない</h3>
                 <p class="c-text-block__text">
                   睡眠時間は取っているのに、目覚めがすっきりしない。週末に寝溜めしても月曜にはもう重い。
                 </p>
               </li>
-              <li class="p-problem__item c-text-block">
+              <li class="c-card -subtle c-text-block p-problem__item">
                 <h3 class="c-text-block__title">肩や腰が常に張っている</h3>
                 <p class="c-text-block__text">
                   デスクワークが続くと夕方には限界。マッサージに行っても翌日には戻っている。
                 </p>
               </li>
-              <li class="p-problem__item c-text-block">
+              <li class="c-card -subtle c-text-block p-problem__item">
                 <h3 class="c-text-block__title">自分のための時間がない</h3>
                 <p class="c-text-block__text">
                   仕事、家事、育児。気づけば一日が終わっていて、自分のことは後回しになっている。
@@ -486,56 +486,64 @@
             <p lang="en">FAQ</p>
             <h2 id="faq-heading">よくある質問</h2>
           </hgroup>
-          <div class="p-faq__list" data-stagger="fade-in-slide-up">
-            <details class="c-accordion p-faq__item" open>
-              <summary class="c-accordion__summary">
-                施術に痛みはありますか？
-                <svg class="c-icon c-accordion__icon" width="20" height="20" aria-hidden="true">
-                  <use href="./assets/images/icons/chevron-down.svg#icon" />
-                </svg>
-              </summary>
-              <div class="c-accordion__content">
-                <p>
-                  痛みを我慢していただくことはありません。からだの状態に合わせて圧を調整します。施術中に眠ってしまう方も多いです。
-                </p>
-              </div>
-            </details>
-            <details class="c-accordion p-faq__item">
-              <summary class="c-accordion__summary">
-                どのくらいの頻度で通えばいいですか？
-                <svg class="c-icon c-accordion__icon" width="20" height="20" aria-hidden="true">
-                  <use href="./assets/images/icons/chevron-down.svg#icon" />
-                </svg>
-              </summary>
-              <div class="c-accordion__content">
-                <p>
-                  最初の1ヶ月は週1回をおすすめしています。からだが整ってきたら、月1〜2回のメンテナンスに移行される方が多いです。
-                </p>
-              </div>
-            </details>
-            <details class="c-accordion p-faq__item">
-              <summary class="c-accordion__summary">
-                予約の変更やキャンセルはできますか？
-                <svg class="c-icon c-accordion__icon" width="20" height="20" aria-hidden="true">
-                  <use href="./assets/images/icons/chevron-down.svg#icon" />
-                </svg>
-              </summary>
-              <div class="c-accordion__content">
-                <p>前日までにご連絡いただければ、変更・キャンセルとも無料で承ります。</p>
-              </div>
-            </details>
-            <details class="c-accordion p-faq__item">
-              <summary class="c-accordion__summary">
-                男性も利用できますか？
-                <svg class="c-icon c-accordion__icon" width="20" height="20" aria-hidden="true">
-                  <use href="./assets/images/icons/chevron-down.svg#icon" />
-                </svg>
-              </summary>
-              <div class="c-accordion__content">
-                <p>現在は女性専用とさせていただいております。</p>
-              </div>
-            </details>
-          </div>
+          <ul class="p-faq__list" data-stagger="fade-in-slide-up">
+            <li class="p-faq__item">
+              <details class="c-accordion" open>
+                <summary class="c-accordion__summary">
+                  施術に痛みはありますか？
+                  <svg class="c-icon c-accordion__icon" width="20" height="20" aria-hidden="true">
+                    <use href="./assets/images/icons/chevron-down.svg#icon" />
+                  </svg>
+                </summary>
+                <div class="c-accordion__content">
+                  <p>
+                    痛みを我慢していただくことはありません。からだの状態に合わせて圧を調整します。施術中に眠ってしまう方も多いです。
+                  </p>
+                </div>
+              </details>
+            </li>
+            <li class="p-faq__item">
+              <details class="c-accordion">
+                <summary class="c-accordion__summary">
+                  どのくらいの頻度で通えばいいですか？
+                  <svg class="c-icon c-accordion__icon" width="20" height="20" aria-hidden="true">
+                    <use href="./assets/images/icons/chevron-down.svg#icon" />
+                  </svg>
+                </summary>
+                <div class="c-accordion__content">
+                  <p>
+                    最初の1ヶ月は週1回をおすすめしています。からだが整ってきたら、月1〜2回のメンテナンスに移行される方が多いです。
+                  </p>
+                </div>
+              </details>
+            </li>
+            <li class="p-faq__item">
+              <details class="c-accordion">
+                <summary class="c-accordion__summary">
+                  予約の変更やキャンセルはできますか？
+                  <svg class="c-icon c-accordion__icon" width="20" height="20" aria-hidden="true">
+                    <use href="./assets/images/icons/chevron-down.svg#icon" />
+                  </svg>
+                </summary>
+                <div class="c-accordion__content">
+                  <p>前日までにご連絡いただければ、変更・キャンセルとも無料で承ります。</p>
+                </div>
+              </details>
+            </li>
+            <li class="p-faq__item">
+              <details class="c-accordion">
+                <summary class="c-accordion__summary">
+                  男性も利用できますか？
+                  <svg class="c-icon c-accordion__icon" width="20" height="20" aria-hidden="true">
+                    <use href="./assets/images/icons/chevron-down.svg#icon" />
+                  </svg>
+                </summary>
+                <div class="c-accordion__content">
+                  <p>現在は女性専用とさせていただいております。</p>
+                </div>
+              </details>
+            </li>
+          </ul>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

v1.0 仕上げの Component 整備バンドル 5 タスク:

1. **A-3**: `c-card.-subtle` モディファイア追加（p-problem カード装飾の Component 吸収）
2. **A-4**: `c-button` 公開 API 化（`--c-button-color` / `--c-button-bg-color` / `--c-button-border-color` / `--c-button-hover-bg-color`）
3. **C-1**: `p-faq` を `<ul><li><details>` 化（並列項目 = ul/li 原則の一貫適用）
4. **scroll-margin-block-start 統一**: LP 全 section のアンカー飛び先 Header 被り解消
5. **form.css `prefers-reduced-motion` ガード**: radio/checkbox の transition を a11y 準拠へ

## Why

- 4/20 で確立した「Component の公開 API」設計思想を `c-button` に横展開（`--media-card-first-order` に続く第 2 実例）
- 「並列項目 = `<ul><li>`」原則を starter 全体で完全適用（p-problem / p-features / p-numbers / p-voice に続き、p-faq も統一）
- p-problem__item は Project 責任（grid 配置）のみに縮約。装飾は Component が吸収
- 本セッションで確立した Block 併記ルール・WHY コメント原則・context-aware editing をすべて適用

## Details

### A-3: c-card.-subtle

- `.c-card.-subtle { background-color: var(--color-bg-secondary); box-shadow: none; }` を追加
- `p-problem__item` の padding / bg / radius を削除し、HTML を `<li class=\"c-card -subtle c-text-block p-problem__item\">` へ
- 併記順序: Component → Modifier → Component → Project Element（spec §6 適合）

### A-4: c-button 公開 API

- ベース `.c-button` は `color: var(--c-button-color)` 等で API 経由参照、**色の default はベースに置かない**（モディファイア未指定だと無色 → 誤用が設計段階で顕在化）
- `.-primary` / `.-ghost` は 4 本すべてを設定するモディファイアに書き換え
- `p-hero__sub-cta` は `--c-button-color: light-dark(...)` / `--c-button-border-color: light-dark(...)` で API 経由注入（プロパティ直上書きを回避）
- dist 確認: 4 本すべての Custom Property が CSS バンドルに出力されている

### C-1: p-faq を <ul><li><details>

- `<div class=\"p-faq__list\"><details class=\"c-accordion p-faq__item\">...</div>` → `<ul class=\"p-faq__list\"><li class=\"p-faq__item\"><details class=\"c-accordion\">...</ul>`
- `.p-faq__list` に `list-style-type: none; padding-inline-start: 0;` 追加（既存 p-flow 等と同パターン）
- `c-accordion` の `& + &` は直接兄弟前提なので `<li>` 包含で効かなくなる。並列項目の積層視覚は Project の合成責任として `.p-faq__item + .p-faq__item .c-accordion { border-block-start: none; }` を追加（責任境界が明確化される副次効果）

### scroll-margin-block-start 統一

- `.l-section { scroll-margin-block-start: var(--header-size); }`
- `--header-size`（64px）は既存 token。新規 token 追加なし
- privacy ページから `/#contact` 遷移時などに固定ヘッダーに被らない

### form.css reduced-motion ガード

- PR #105 の申し送り対応
- `:where(input[type='radio'], input[type='checkbox'])` の `transition` を `@media (prefers-reduced-motion: no-preference) { ... }` で囲む
- c-button / c-form / c-accordion__icon と一貫

## Test plan

- [x] `pnpm run check` 全 Linter 通過（stylelint / eslint / markuplint / prettier）
- [x] `pnpm run build` 成功（28.42 kB CSS / 6.21 kB gzip）
- [x] `--c-button-color` / `--c-button-bg-color` / `--c-button-border-color` / `--c-button-hover-bg-color` の 4 本が dist CSS に出力されていることを grep で確認
- [x] Portability Test 自己適用（c-card.-subtle は Token のみ、c-button API も Token のみ）
- [x] Responsibility Test 自己適用（カード装飾 = Component、grid 配置 = Project、色 default = モディファイア、色上書き = Project が API 経由で注入）
- [x] 併記順序が spec §6 に準拠（Component → Modifier → Component → Project Element）
- [ ] しゅんえい視覚確認: p-problem カード装飾（subtle）/ p-hero__sub-cta の light-dark 反応 / FAQ のスクリーンリーダー「4 項目」通知 / Header 固定時の #features アンカー着地
- [ ] しゅんえい承認 → v1.2 にマージ

## 注意

- **main に絶対マージしない**、base は `v1.2`
- しゅんえい承認必須
- PR B-4（Pricing section + table wrapper）へ次につなぐ

## 教材価値

- ch7「既存 Component の育て方」: c-card にモディファイアを追加するケースと、c-button に公開 API を追加するケースの対比実例
- ch7「公開 API パターン」: `--media-card-first-order` に続く第 2 実例（より身近な c-button で再確認）
- ch6「並列項目 = <ul><li>」: starter 内で完全一貫（p-problem / p-features / p-numbers / p-voice / p-flow / p-faq）
- ch8 a11y: reduced-motion ガードの一貫適用

🤖 Generated with [Claude Code](https://claude.com/claude-code)