### PR TITLE
feat(v1.0): Pricing section 追加（B-4、table wrapper + a11y 3 点セット教材）

### DIFF
--- a/src/assets/css/project/p-pricing.css
+++ b/src/assets/css/project/p-pricing.css
@@ -1,0 +1,51 @@
+.p-pricing {
+  /* スタイルなし（HTML クラスとの対応を維持） */
+}
+
+.p-pricing__inner {
+  /* スタイルなし（HTML クラスとの対応を維持） */
+}
+
+.p-pricing__heading {
+  /* スタイルなし（HTML クラスとの対応を維持） */
+}
+
+/* WHY: 幅広 table の横スクロール対策（Project 責務、Component 化しない理由:
+   min-inline-size がコンテンツ依存。tabindex="0" でキーボードフォーカスが
+   当たるため :focus-visible のリング描画は reset / foundation 既定で担保） */
+.p-pricing__table-wrapper {
+  margin-block-start: var(--space-xl-2xl);
+  overflow-x: auto;
+}
+
+.p-pricing__table {
+  inline-size: 100%;
+
+  /* WHY: iluha の 3 カラム料金表がここで横スクロールに切り替わる閾値。
+     コンテンツ依存の値なので Component 化せず Project に留める */
+  min-inline-size: 40rem;
+  border-collapse: collapse;
+
+  & th,
+  & td {
+    padding: var(--space-sm) var(--space-md);
+    text-align: start;
+    border-block-end: var(--border-width) solid var(--color-border);
+  }
+
+  & thead th {
+    font-weight: var(--font-weight-heading);
+    background-color: var(--color-bg-secondary);
+  }
+
+  & tbody th {
+    font-weight: var(--font-weight-body);
+  }
+}
+
+.p-pricing__note {
+  margin-block-start: var(--space-lg);
+  font-size: var(--font-size-caption);
+  color: var(--color-text-light);
+  text-align: center;
+}

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -49,6 +49,7 @@
 @import './project/p-problem.css' layer(project);
 @import './project/p-features.css' layer(project);
 @import './project/p-flow.css' layer(project);
+@import './project/p-pricing.css' layer(project);
 @import './project/p-numbers.css' layer(project);
 @import './project/p-voice.css' layer(project);
 @import './project/p-faq.css' layer(project);

--- a/src/index.html
+++ b/src/index.html
@@ -384,6 +384,55 @@
         </div>
       </section>
 
+      <!-- Pricing -->
+      <!-- CUSTOMIZE: コース内容・所要時間・料金を自社サービスに差し替え -->
+      <section class="l-section p-pricing" id="pricing" aria-labelledby="pricing-heading">
+        <div class="l-inner p-pricing__inner">
+          <hgroup class="c-section-heading p-pricing__heading" data-animate="fade-in-slide-up">
+            <p lang="en">Pricing</p>
+            <h2 id="pricing-heading">料金表</h2>
+          </hgroup>
+
+          <!-- WHY: 幅広 table を wrapper で横スクロール可能に（Project 責務）。
+               Component 化しない理由: min-inline-size はコンテンツ依存。
+               a11y 3 点セット: role="region" + 固有の aria-label（section landmark「料金表」と重複しない一意の accessible name）+ tabindex="0"（キーボードで矢印スクロール可能） -->
+          <div class="p-pricing__table-wrapper" role="region" aria-label="料金表スクロール領域" tabindex="0">
+            <table class="p-pricing__table">
+              <caption class="u-visually-hidden">
+                コース別の料金と所要時間
+              </caption>
+              <thead>
+                <tr>
+                  <th scope="col">コース</th>
+                  <th scope="col">所要時間</th>
+                  <th scope="col">料金（税込）</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th scope="row">ボディケア</th>
+                  <td>60 分</td>
+                  <td>8,800 円</td>
+                </tr>
+                <tr>
+                  <th scope="row">フェイシャル</th>
+                  <td>45 分</td>
+                  <td>7,700 円</td>
+                </tr>
+                <tr>
+                  <th scope="row">リラクゼーション</th>
+                  <td>90 分</td>
+                  <td>11,000 円</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- CUSTOMIZE: 注記を自社サービスに差し替え -->
+          <p class="p-pricing__note">初回体験は 4,400 円（60 分）。リピート回数券・ペアプランもございます。</p>
+        </div>
+      </section>
+
       <!-- Numbers -->
       <section class="l-section p-numbers" id="numbers" aria-labelledby="numbers-heading">
         <div class="l-inner p-numbers__inner">


### PR DESCRIPTION
## 目的

mflocss-starter v1.0 リリースに向けた **PR B-4**。サービス系 LP 頻出パターン「料金表（Pricing）」を starter LP に追加し、v1.0 教材価値を最大化。

## 教材価値（3 点）

### 1. table wrapper パターン
幅広コンテンツを `.p-pricing__table-wrapper` でラップし以下を組み合わせた canonical な横スクロール table パターン:
- `overflow-x: auto`（wrapper に付与、table 自体には付与しない）
- `min-inline-size: 40rem`（table に付与、スクロール発動の閾値）
- a11y 3 点セット: `role=\"region\"` + 固有 `aria-label` + `tabindex=\"0\"`

### 2. Project 責務の典型例（Component 化しない判断）
`min-inline-size: 40rem` は iluha の 3 カラム料金表固有の値。Portability Test で他の Block に流用できないため **Component 化せず Project で実装** する判断の実例。spec §6 Project 層の責任境界教材として機能。

### 3. Element 命名規則の一貫性
`__wrapper` / `__table` / `__note` など **名詞で既存 Element 名**（`__inner` / `__list` / `__item` / `__heading`）と一貫。本セッション確立ルール「Block のみ併記、Element は Component のみ、名詞統一」に準拠。

## 変更内容

| ファイル | 変更 | 行数 |
|---|---|---|
| `src/index.html` | Pricing section 追加（Flow ↔ Numbers 間） | +49 |
| `src/assets/css/project/p-pricing.css` | Project 層新設 | +51（新規） |
| `src/assets/css/style.css` | `@import p-pricing.css` 追加（p-flow と p-numbers の間） | +1 |

## 配置

LP section 順序:
```
Hero → Problem → Features → Flow → Pricing（NEW）→ Numbers → Voice → CTA → FAQ → Contact
```

DOM 順と `style.css @import` 順も同期。

## a11y 設計の補足

初稿で section の `aria-labelledby=\"pricing-heading\"` と wrapper の `aria-labelledby=\"pricing-heading\"` が両方「料金表」を accessible name として参照し **landmark-roles 警告**（一意でない）が発生したため、wrapper は `aria-label=\"料金表スクロール領域\"` で固有の名前に切り替えた。

- section landmark: 「料金表」（h2 から）
- region landmark（wrapper）: 「料金表スクロール領域」
- `<caption class=\"u-visually-hidden\">` で SR にテーブル目的を通知
- `<th scope=\"col\">` / `<th scope=\"row\">` でヘッダー関係を明示

## 品質検証

- [x] Stylelint / ESLint / markuplint / Prettier 全通過（`pnpm run check`）
- [x] Vite build 成功（40.71 kB index.html / 28.69 kB CSS、gzip 後も軽量）
- [x] トークン実在確認: `--space-xl-2xl` / `--space-sm` / `--space-md` / `--space-lg` / `--color-border` / `--color-bg-secondary` / `--color-text-light` / `--font-weight-heading` / `--font-weight-body` / `--font-size-caption` / `--border-width` 全て existing
- [x] Portability Test 自己適用: `min-inline-size: 40rem` がコンテンツ依存 = **Project 判定妥当**
- [x] Responsibility Test: wrapper は scroll 責務のみ、table は table 責務のみ = 分離 OK

## a11y 動作（設計上の保証）

- `tabindex=\"0\"` により Tab キーで wrapper にフォーカス可能、矢印キーで横スクロール
- `role=\"region\"` + `aria-label=\"料金表スクロール領域\"` で SR が scrollable region として識別
- `<caption class=\"u-visually-hidden\">` で SR にテーブル全体の目的を読み上げ

## 承認

**しゅんえい承認必須、main マージ不可**（base: `v1.2`）

## 次アクション

- PR B-4 完了で starter v1.0 の LP / Component 実装が完了
- Phase 2 (spec 反映) → Phase 3 (書籍反映) → Phase 4 (通読確認) → Phase 5 (mflocss.dev 作り直し) → Phase 6 (一斉 main マージ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)