### PR TITLE
fix(v1.0): §6 Element 併記違反を解消（CTA section の h2）

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -522,7 +522,7 @@
       <!-- CTA -->
       <section class="l-section p-cta" id="cta" aria-labelledby="cta-heading">
         <div class="l-inner p-cta__inner c-text-block" data-stagger="fade-in-slide-up">
-          <h2 id="cta-heading" class="p-cta__title c-text-block__title">まずは一度、からだの声を聴いてみませんか？</h2>
+          <h2 id="cta-heading" class="p-cta__title">まずは一度、からだの声を聴いてみませんか？</h2>
           <p class="c-text-block__text">初回体験は 60分 4,400円。カウンセリング込み。無理な勧誘はいたしません。</p>
           <a href="#contact" class="c-button -primary -large p-cta__button">初回体験を予約する</a>
         </div>


### PR DESCRIPTION
## Summary

`src/index.html` L525（CTA section の `<h2 id="cta-heading">`）で、`p-cta__title` と `c-text-block__title` が同一要素に併記されていた違反（spec §6 SHOULD NOT [Element 併記の回避]）を `c-text-block__title` 削除で解消する。

## 背景

Phase 2 spec 通読整合確認の code-reviewer 検証で、LP 全域を機械走査した結果、Element 同士併記が 1 件残存していることが判明（`grep 'class="[^"]*__[^"]* [^"]*__[^"]*"' src/*.html`）。PR #110（c-card API 化 + c-prefix 除去）のスコープでは検出されなかった見落とし。

## 変更内容

- `src/index.html` L525: `class="p-cta__title c-text-block__title"` → `class="p-cta__title"`
- CSS 側の `.c-text-block__title` 空ルール宣言は削除せず残す（教育的スタブ宣言としての価値あり、他箇所での使用や将来の使用を許容）

## 整合性

- `c-text-block.css` の `.c-text-block__title` は**スタイルなし**（視覚変化ゼロ）
- `p-cta__title` が `max-inline-size: 600px;` を担当（CTA 固有スタイル維持）
- 親 `.c-text-block` の `display: flex; gap: var(--space-sm);` が子要素の間隔を自動適用
- 横展開機械走査で他に同パターンの違反なしを確認（0 件）
- `.c-text-block__title` は他 3 箇所（L237/243/249）で**単独使用**されており、空ルール宣言を残す判断を裏付け

## Test plan

- [x] `src/index.html` L525 の変更確認
- [x] 機械走査（`grep 'class="[^"]*__[^"]* [^"]*__[^"]*"' src/*.html src/**/*.html`）で 0 件
- [x] `pnpm run check` 全通過（stylelint / eslint / markuplint）
- [x] `pnpm run build` 成功（69ms）
- [ ] ブラウザで CTA section の見た目変化なし確認

## 制約

- **base は `v1.2`**、main に絶対マージしない（v1.0 リリース時の一斉マージまで統合ブランチで保持）
- しゅんえい承認必須（mflocss/starter は公開リポ）

## 関連

- spec PR #73（MERGED）: §6 SHOULD NOT [Element 併記の回避]
- Phase 2 レポート: cortex `business/projects/mflocss/phase2-spec-alignment-audit-2026-04-22.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)