### PR TITLE
feat(v1.0): c-text-block 契約確定 + CTA/Flow 再構成 + p-hero__stack リネーム

### DIFF
--- a/src/assets/css/component/c-text-block.css
+++ b/src/assets/css/component/c-text-block.css
@@ -1,11 +1,14 @@
 .c-text-block {
+  /* 公開 API: title 最大幅を使う側（project 層）が制御する */
+  --text-block-title-max-inline-size: none;
+
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
 }
 
 .c-text-block__title {
-  /* スタイルなし（HTML クラスとの対応を維持） */
+  max-inline-size: var(--text-block-title-max-inline-size);
 }
 
 .c-text-block__text {

--- a/src/assets/css/project/p-cta.css
+++ b/src/assets/css/project/p-cta.css
@@ -2,25 +2,21 @@
   --section-padding-min: var(--section-wide-min);
   --section-padding-max: var(--section-wide-max);
 
+  /* c-text-block 公開 API override: CTA の見出しを適度な幅で折り返す */
+  --text-block-title-max-inline-size: 600px;
+
   background-color: var(--color-bg-secondary);
 }
 
 .p-cta__inner {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-lg);
-  align-items: center;
   max-inline-size: var(--content-width-narrow);
   margin-inline: auto;
   text-align: center;
 }
 
-.p-cta__title {
-  --_title-max: 600px;
-
-  max-inline-size: var(--_title-max);
-}
-
-.p-cta__button {
-  margin-block-start: var(--space-sm);
+.p-cta__stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  align-items: center;
 }

--- a/src/assets/css/project/p-flow.css
+++ b/src/assets/css/project/p-flow.css
@@ -35,7 +35,7 @@
   /* WHY: CSS counter でステップ番号を円形バッジとして視覚化。<ol> のセマンティクスは保ったまま装飾を自前で描画 */
   &::before {
     display: flex;
-    grid-row: 1 / 3;
+    grid-row: 1;
     align-items: center;
     align-self: start;
     justify-content: center;
@@ -48,12 +48,4 @@
     background-color: var(--color-main);
     border-radius: var(--radius-full);
   }
-}
-
-.p-flow__item-title {
-  /* スタイルなし（:where(h3) の foundation スタイルで十分） */
-}
-
-.p-flow__item-description {
-  /* スタイルなし（body の基本スタイルで十分） */
 }

--- a/src/assets/css/project/p-hero.css
+++ b/src/assets/css/project/p-hero.css
@@ -7,7 +7,7 @@
   background: radial-gradient(ellipse at 50% 0%, oklch(from var(--color-main) l c h / 6%) 0%, transparent 70%);
 }
 
-.p-hero__inner {
+.p-hero__stack {
   position: relative;
   z-index: 1;
   grid-area: stack;

--- a/src/index.html
+++ b/src/index.html
@@ -191,7 +191,7 @@
     <main id="main" data-drawer-inert>
       <!-- Hero -->
       <section class="l-section p-hero" aria-labelledby="hero-heading" data-immediate="scale-in">
-        <div class="l-inner p-hero__inner">
+        <div class="l-inner p-hero__stack">
           <!-- CUSTOMIZE: サービス名・キャッチコピーを差し替え -->
           <div class="p-hero__content">
             <h1 id="hero-heading" class="p-hero__title">からだの声を、<br class="u-hidden-pc" />聴く時間。</h1>
@@ -351,34 +351,44 @@
           </hgroup>
           <ol class="p-flow__list" data-stagger="fade-in-slide-up">
             <li class="p-flow__item">
-              <h3 class="p-flow__item-title">ご予約</h3>
-              <p class="p-flow__item-description">
-                お問い合わせフォームからご希望の日時・コースをお知らせください。24時間以内に折り返しご連絡いたします。
-              </p>
+              <div class="c-text-block">
+                <h3 class="c-text-block__title">ご予約</h3>
+                <p class="c-text-block__text">
+                  お問い合わせフォームからご希望の日時・コースをお知らせください。24時間以内に折り返しご連絡いたします。
+                </p>
+              </div>
             </li>
             <li class="p-flow__item">
-              <h3 class="p-flow__item-title">カウンセリング</h3>
-              <p class="p-flow__item-description">
-                施術前に30分ほどお時間をいただき、お体の状態やお悩み・ご希望を丁寧にヒアリング。
-              </p>
+              <div class="c-text-block">
+                <h3 class="c-text-block__title">カウンセリング</h3>
+                <p class="c-text-block__text">
+                  施術前に30分ほどお時間をいただき、お体の状態やお悩み・ご希望を丁寧にヒアリング。
+                </p>
+              </div>
             </li>
             <li class="p-flow__item">
-              <h3 class="p-flow__item-title">施術</h3>
-              <p class="p-flow__item-description">
-                選択したコースに沿って45〜90分の施術。完全個室で安心してお過ごしください。
-              </p>
+              <div class="c-text-block">
+                <h3 class="c-text-block__title">施術</h3>
+                <p class="c-text-block__text">
+                  選択したコースに沿って45〜90分の施術。完全個室で安心してお過ごしください。
+                </p>
+              </div>
             </li>
             <li class="p-flow__item">
-              <h3 class="p-flow__item-title">アフターケア</h3>
-              <p class="p-flow__item-description">
-                施術後は水分補給とリラックスタイム。お体の変化を確かめながらゆっくりとお過ごしください。
-              </p>
+              <div class="c-text-block">
+                <h3 class="c-text-block__title">アフターケア</h3>
+                <p class="c-text-block__text">
+                  施術後は水分補給とリラックスタイム。お体の変化を確かめながらゆっくりとお過ごしください。
+                </p>
+              </div>
             </li>
             <li class="p-flow__item">
-              <h3 class="p-flow__item-title">次回のご案内</h3>
-              <p class="p-flow__item-description">
-                お客様のお体に合わせた最適なペースをご提案。ご希望があれば次回のご予約も承ります。
-              </p>
+              <div class="c-text-block">
+                <h3 class="c-text-block__title">次回のご案内</h3>
+                <p class="c-text-block__text">
+                  お客様のお体に合わせた最適なペースをご提案。ご希望があれば次回のご予約も承ります。
+                </p>
+              </div>
             </li>
           </ol>
         </div>
@@ -521,10 +531,14 @@
 
       <!-- CTA -->
       <section class="l-section p-cta" id="cta" aria-labelledby="cta-heading">
-        <div class="l-inner p-cta__inner c-text-block" data-stagger="fade-in-slide-up">
-          <h2 id="cta-heading" class="p-cta__title">まずは一度、からだの声を聴いてみませんか？</h2>
-          <p class="c-text-block__text">初回体験は 60分 4,400円。カウンセリング込み。無理な勧誘はいたしません。</p>
-          <a href="#contact" class="c-button -primary -large p-cta__button">初回体験を予約する</a>
+        <div class="l-inner p-cta__inner">
+          <div class="p-cta__stack" data-stagger="fade-in-slide-up">
+            <div class="c-text-block">
+              <h2 id="cta-heading" class="c-text-block__title">まずは一度、からだの声を聴いてみませんか？</h2>
+              <p class="c-text-block__text">初回体験は 60分 4,400円。カウンセリング込み。無理な勧誘はいたしません。</p>
+            </div>
+            <a href="#contact" class="c-button -primary -large">初回体験を予約する</a>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

W0-d audit で検出された Critical 3 件と、関連する p-hero 命名不一致を統合解消する。統一原則 10 項準拠。

### 解消した Critical

**C1: p-cta__inner の責任完全混在（7 プロパティ）**
- `__inner` に flex 配置系と幅制御が混在していた
- `__inner` を幅制御（max-inline-size / margin-inline / text-align）に限定
- `__stack` を新設して flex / gap / align-items を担当
- `__title` / `__button` は c-text-block / c-button の標準利用に回収

**C2: p-flow__item-title / __item-description の空ルール（再利用漏れ）**
- `<h3>` / `<p>` を `c-text-block` で wrap し、`__item-title` / `__item-description` 空ルール削除
- `grid-template-columns: auto 1fr` の構造を保ったまま `::before` を `grid-row: 1` に（単一セル化）

**C3: c-text-block が 3 パターン混在**
- 公開 API `--text-block-title-max-inline-size` を確定（spec §6 準拠: `c-` プレフィックスなし）
- `__title` / `__text` の役割を仕様化、project 層（p-cta 等）が use 側として上書き可能に

### 追加で解消した問題

**p-hero__inner → p-hero__stack リネーム**
- grid-area が `stack` なのに `__inner` 命名で責任不一致だった
- `grid-area: stack` を担う Element として `__stack` に統一

## 変更ファイル

- `src/assets/css/component/c-text-block.css` — 公開 API `--text-block-title-max-inline-size` 追加
- `src/assets/css/project/p-cta.css` — 責任分解（__inner 幅制御 / __stack レイアウト）
- `src/assets/css/project/p-flow.css` — 空ルール Element 削除、grid-row 調整
- `src/assets/css/project/p-hero.css` — __inner → __stack リネーム
- `src/index.html` — CTA / Flow / Hero の 3 箇所再構成

## 品質検証

### 機械走査（全 0 件を確認）

- Element 併記違反（Block __foo Block __bar パターン）: **0 件**
- Component 層の `c-` プレフィックス付き custom property: **0 件**
- 旧セレクタ残存（`p-cta__title` / `p-cta__button` / `p-flow__item-title` / `p-flow__item-description` / `p-hero__inner`）: **0 件**

### Linter / Build

- `pnpm run check` (prettier + stylelint + eslint + markuplint): ✅ 全通過
- `pnpm run build` (vite): ✅ 82ms で成功、dist 出力正常

## Test plan

- [ ] ローカルで `pnpm run dev` し、Hero / Flow / CTA の見た目差分がないこと（リネームのみのため回帰ゼロ想定）
- [ ] Flow セクションで `::before` の番号バッジが各 item の 1 行目左端に配置されること
- [ ] CTA セクションで見出しが 600px で折り返し、ボタンが gap-lg で下に配置されること
- [ ] Hero セクションで grid-area stack の重なり順が維持されること

## 備考

- base は `v1.2`、main マージ禁止（公開リリース対象、しゅんえい承認後にマージ）
- 統一原則 10 項準拠、spec §6 公開 API 命名規則（`--{component}-{name}`、`c-` 除外）準拠