### PR TITLE
feat(v1.0): Step 2 — __inner 命名分離 + c-button CTA 統一 + c-form__actions API + c-table 新設 + 文書同期

### DIFF
--- a/CODING_GUIDE.md
+++ b/CODING_GUIDE.md
@@ -50,7 +50,7 @@ ARIA 属性（`aria-label`・`aria-expanded`・`aria-controls` 等）と `transl
 | サイズ単位 | `cqi`（container query inline） | `px` / `em` / `rem` |
 | この LP での例 | Features セクション内のコンテンツ余白の流体調整 | ヘッダーのナビ表示/非表示 |
 
-`l-container.css` で `container-type: inline-size` を宣言し、Project/Component 層でクエリを記述します。
+`foundation/base.css` の `body` に `container-type: inline-size`（`container-name: page`）を宣言しており、Project/Component 層でクエリを記述します。セクション内部で独立した container を設けたい場合は、当該 Project のコンテナ要素にも `container-type: inline-size` を追加します（例: `p-features.css`、`p-voice.css`）。
 
 ## モーションガードのルール
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ mFLOCSS のリファレンス実装。架空の美容サロン「iluha」の LP 
 
 ### テキスト・画像の差し替え
 
-- `src/index.html` — サービス名、キャッチコピー、各セクションのテキスト
-- `src/contact/index.html` — フォーム項目
+- `src/index.html` — サービス名、キャッチコピー、各セクションのテキスト、Contact セクションのフォーム項目
+- `src/privacy/index.html` — プライバシーポリシー本文
+- `src/404.html` — 404 ページの見出し・リード文
 - 全ページの `<head>` — title, description, OGP 情報
 - `src/assets/images/` — コンテンツ画像（Retina 対応のため表示サイズの **2倍** で書き出し）
 
@@ -95,10 +96,10 @@ Token 層（`src/assets/css/token/`）にデザイン値が集約されていま
 
 ### フォーム送信先の設定
 
-現状は `action="/thanks/"` が設定されており、送信後にサンクスページへ遷移します。外部フォームサービスを使う場合は `action` をサービスの URL に変更してください:
+Contact セクション（`src/index.html` 内）のフォームは `action="/api/contact"` を既定値としています。starter 自体は送信処理を提供しないため、外部フォームサービスやバックエンド API に差し替えてください:
 
 ```html
-<form class="p-contact__form" action="https://your-form-service.com/submit" method="post">
+<form class="c-form p-contact__form" action="https://your-form-service.com/submit" method="post" novalidate>
 ```
 
 ## 構造の変更
@@ -132,7 +133,7 @@ Token 層（`src/assets/css/token/`）にデザイン値が集約されていま
 
 ### ページの削除
 
-1. 対象のディレクトリを削除（例: `src/thanks/`）
+1. 対象のディレクトリを削除（例: `src/privacy/`）
 2. `vite.config.ts` の `rolldownOptions.input` から該当エントリを削除
 3. ヘッダー・フッターのナビリンクを全ページから除去
 4. 不要な Project CSS があれば `style.css` の `@import` を削除
@@ -193,10 +194,9 @@ src/
 │   ├── images/                # コンテンツ画像（ビルドでハッシュ付与）
 │   └── scripts/
 │       └── main.js            # ドロワー・アニメーション・Back to Top
-├── index.html             # トップページ
-├── contact/index.html     # お問い合わせ
-├── thanks/index.html      # サンクスページ
-└── privacy/index.html     # プライバシーポリシー
+├── index.html             # トップページ（Hero〜Contact セクション統合）
+├── privacy/index.html     # プライバシーポリシー
+└── 404.html               # 404 ページ（参考実装。組み込み時は削除推奨）
 public/                    # ルートパス固定のファイル
 ├── scripts/
 │   └── viewport.js        # ビューポート幅制御（--viewport-min 未満の端末向け）

--- a/src/404.html
+++ b/src/404.html
@@ -37,7 +37,7 @@
     <!-- NOTE: ヘッダー・フッターは全ページ共通。変更時は全ファイルに反映すること -->
     <!-- Header -->
     <header class="l-header p-header">
-      <div class="l-inner p-header__inner">
+      <div class="l-inner p-header__bar">
         <a href="/" class="p-header__logo" translate="no">iluha</a>
 
         <nav class="p-header__nav" aria-label="メインナビゲーション">
@@ -66,7 +66,7 @@
     <!-- Drawer -->
     <div class="c-overlay" data-drawer-overlay hidden></div>
     <dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title" aria-modal="true">
-      <div class="p-drawer__inner">
+      <div class="p-drawer__stack">
         <span id="drawer-title" class="u-visually-hidden">ナビゲーションメニュー</span>
         <nav class="p-drawer__nav" aria-label="ドロワーナビゲーション">
           <ul class="p-drawer__nav-list">
@@ -100,7 +100,7 @@
             お手数ですが、トップページから目的のページをお探しください。
           </p>
           <div class="p-not-found__actions">
-            <a href="/" class="c-button -primary -large p-not-found__action">トップページへ戻る</a>
+            <a href="/" class="c-button -primary -large p-not-found__cta">トップページへ戻る</a>
           </div>
         </div>
       </section>
@@ -108,7 +108,7 @@
 
     <!-- Footer -->
     <footer class="l-footer p-footer" data-drawer-inert>
-      <div class="l-inner p-footer__inner">
+      <div class="l-inner p-footer__stack">
         <nav class="p-footer__nav" aria-label="フッターナビゲーション">
           <ul class="p-footer__nav-list">
             <li><a href="/#features" class="p-footer__nav-link">特徴</a></li>

--- a/src/assets/css/component/c-form.css
+++ b/src/assets/css/component/c-form.css
@@ -1,5 +1,9 @@
-/* Block: フォーム全体の縦並びレイアウト（max-inline-size / margin 等の外部配置は Project 側で制御） */
+/* Block: フォーム全体の縦並びレイアウト（max-inline-size / margin 等の外部配置は Project 側で制御）
+   公開 API: Project 側で送信ボタン前の余白を調整できるよう --form-actions-margin-top を露出（§7）。
+   命名は §6「--{対象}-{名前}」に準拠（c- プレフィックスは含めない） */
 .c-form {
+  --form-actions-margin-top: var(--space-md);
+
   display: flex;
   flex-direction: column;
   gap: var(--space-lg);
@@ -96,5 +100,5 @@ textarea.c-form__input {
 .c-form__actions {
   display: flex;
   justify-content: center;
-  margin-block-start: var(--space-md);
+  margin-block-start: var(--form-actions-margin-top);
 }

--- a/src/assets/css/component/c-table.css
+++ b/src/assets/css/component/c-table.css
@@ -1,0 +1,22 @@
+/* Block: 汎用 table ビジュアル（行ごとの罫線・ヘッダーセル装飾）。
+   幅制御（inline-size / min-inline-size）や横スクロール wrapper はコンテンツ依存のため Project に委ねる */
+.c-table {
+  inline-size: 100%;
+  border-collapse: collapse;
+
+  & th,
+  & td {
+    padding: var(--space-sm) var(--space-md);
+    text-align: start;
+    border-block-end: var(--border-width) solid var(--color-border);
+  }
+
+  & thead th {
+    font-weight: var(--font-weight-heading);
+    background-color: var(--color-bg-secondary);
+  }
+
+  & tbody th {
+    font-weight: var(--font-weight-body);
+  }
+}

--- a/src/assets/css/project/p-drawer.css
+++ b/src/assets/css/project/p-drawer.css
@@ -31,7 +31,7 @@
   }
 }
 
-.p-drawer__inner {
+.p-drawer__stack {
   display: flex;
   flex-direction: column;
   gap: var(--space-xl);

--- a/src/assets/css/project/p-footer.css
+++ b/src/assets/css/project/p-footer.css
@@ -4,7 +4,7 @@
   border-block-start: var(--border-width) solid var(--color-border);
 }
 
-.p-footer__inner {
+.p-footer__stack {
   display: flex;
   flex-direction: column;
   gap: var(--space-xl);

--- a/src/assets/css/project/p-header.css
+++ b/src/assets/css/project/p-header.css
@@ -12,7 +12,7 @@
   }
 }
 
-.p-header__inner {
+.p-header__bar {
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/src/assets/css/project/p-not-found.css
+++ b/src/assets/css/project/p-not-found.css
@@ -20,3 +20,7 @@
   gap: var(--space-md);
   justify-content: center;
 }
+
+.p-not-found__cta {
+  /* スタイルなし（HTML クラスとの対応を維持） */
+}

--- a/src/assets/css/project/p-pricing.css
+++ b/src/assets/css/project/p-pricing.css
@@ -19,28 +19,10 @@
 }
 
 .p-pricing__table {
-  inline-size: 100%;
-
   /* WHY: iluha の 3 カラム料金表がここで横スクロールに切り替わる閾値。
-     コンテンツ依存の値なので Component 化せず Project に留める */
+     コンテンツ依存の値なので Component 化せず Project に留める
+     （inline-size / border-collapse / セル装飾は c-table に委譲） */
   min-inline-size: 40rem;
-  border-collapse: collapse;
-
-  & th,
-  & td {
-    padding: var(--space-sm) var(--space-md);
-    text-align: start;
-    border-block-end: var(--border-width) solid var(--color-border);
-  }
-
-  & thead th {
-    font-weight: var(--font-weight-heading);
-    background-color: var(--color-bg-secondary);
-  }
-
-  & tbody th {
-    font-weight: var(--font-weight-body);
-  }
 }
 
 .p-pricing__note {

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -35,6 +35,7 @@
 @import './component/c-blockquote.css' layer(component);
 @import './component/c-text-block.css' layer(component);
 @import './component/c-prose.css' layer(component);
+@import './component/c-table.css' layer(component);
 @import './component/c-icon.css' layer(component);
 @import './component/c-back-to-top.css' layer(component);
 @import './component/c-skip-link.css' layer(component);

--- a/src/index.html
+++ b/src/index.html
@@ -136,7 +136,7 @@
     <!-- NOTE: ヘッダー・フッターは全ページ共通。変更時は全ファイルに反映すること -->
     <!-- Header -->
     <header class="l-header p-header">
-      <div class="l-inner p-header__inner">
+      <div class="l-inner p-header__bar">
         <!-- CUSTOMIZE: サービス名を差し替え -->
         <a href="/" class="p-header__logo" translate="no">iluha</a>
 
@@ -166,7 +166,7 @@
     <!-- Drawer -->
     <div class="c-overlay" data-drawer-overlay hidden></div>
     <dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title" aria-modal="true">
-      <div class="p-drawer__inner">
+      <div class="p-drawer__stack">
         <span id="drawer-title" class="u-visually-hidden">ナビゲーションメニュー</span>
         <nav class="p-drawer__nav" aria-label="ドロワーナビゲーション">
           <ul class="p-drawer__nav-list">
@@ -407,7 +407,7 @@
                Component 化しない理由: min-inline-size はコンテンツ依存。
                a11y 3 点セット: role="region" + 固有の aria-label（section landmark「料金表」と重複しない一意の accessible name）+ tabindex="0"（キーボードで矢印スクロール可能） -->
           <div class="p-pricing__table-wrapper" role="region" aria-label="料金表スクロール領域" tabindex="0">
-            <table class="p-pricing__table">
+            <table class="c-table p-pricing__table">
               <caption class="u-visually-hidden">
                 コース別の料金と所要時間
               </caption>
@@ -732,7 +732,7 @@
 
     <!-- Footer -->
     <footer class="l-footer p-footer" data-drawer-inert>
-      <div class="l-inner p-footer__inner">
+      <div class="l-inner p-footer__stack">
         <nav class="p-footer__nav" aria-label="フッターナビゲーション">
           <ul class="p-footer__nav-list">
             <li><a href="#features" class="p-footer__nav-link">特徴</a></li>

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -71,7 +71,7 @@
     <!-- NOTE: ヘッダー・フッターは全ページ共通。変更時は全ファイルに反映すること -->
     <!-- Header -->
     <header class="l-header p-header">
-      <div class="l-inner p-header__inner">
+      <div class="l-inner p-header__bar">
         <a href="/" class="p-header__logo" translate="no">iluha</a>
 
         <nav class="p-header__nav" aria-label="メインナビゲーション">
@@ -100,7 +100,7 @@
     <!-- Drawer -->
     <div class="c-overlay" data-drawer-overlay hidden></div>
     <dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title" aria-modal="true">
-      <div class="p-drawer__inner">
+      <div class="p-drawer__stack">
         <span id="drawer-title" class="u-visually-hidden">ナビゲーションメニュー</span>
         <nav class="p-drawer__nav" aria-label="ドロワーナビゲーション">
           <ul class="p-drawer__nav-list">
@@ -124,9 +124,9 @@
 
     <main id="main" data-drawer-inert>
       <!-- CUSTOMIZE: プライバシーポリシーの内容を差し替え -->
-      <section class="l-section p-privacy">
+      <section class="l-section p-privacy" aria-labelledby="privacy-heading">
         <div class="l-inner p-privacy__inner">
-          <h1 class="p-privacy__title">プライバシーポリシー</h1>
+          <h1 id="privacy-heading" class="p-privacy__title">プライバシーポリシー</h1>
 
           <div class="c-prose p-privacy__body">
             <h2>個人情報の取り扱いについて</h2>
@@ -163,7 +163,7 @@
 
     <!-- Footer -->
     <footer class="l-footer p-footer" data-drawer-inert>
-      <div class="l-inner p-footer__inner">
+      <div class="l-inner p-footer__stack">
         <nav class="p-footer__nav" aria-label="フッターナビゲーション">
           <ul class="p-footer__nav-list">
             <li><a href="/#features" class="p-footer__nav-link">特徴</a></li>


### PR DESCRIPTION
## Summary

W0-B（命名 + API）+ W0-C（Component 化）+ Option A（文書同期 + a11y）を 1 PR で統合。v1.0 release Step 2。

### 変更一覧

#### A. W0-B: 命名 + 公開 API

- **A-1: `__inner` 命名分離**（Header / Footer / Drawer）
  - `p-header__inner` → `p-header__bar`（横並び、space-between）
  - `p-footer__inner` → `p-footer__stack`（縦積み、中央揃え）
  - `p-drawer__inner` → `p-drawer__stack`（縦積み、safe center、padding 含む）
  - 原則 9: `__inner` は純粋な幅制御のみに用途を限定。機能を持つ inner は意味のある名前に分離
  - section 直下の `p-*__inner`（Problem/Features/Flow/Pricing 等）は幅制御のみのため据え置き
- **A-2: `p-not-found__action` → `p-not-found__cta`**
  - ページメインの行動導線を `__cta` で統一（`p-hero__cta` / `p-header__cta` / `p-drawer__cta` と揃える）
  - 1:1 マッピング維持のため p-not-found.css にも空ルールセットを追加
- **A-3: `c-form__actions` 公開 API 化**
  - `--form-actions-margin-top`（default: `var(--space-md)`）を Block に定義
  - spec §6/§7: `--{対象}-{名前}` 命名、`c-` プレフィックスは含めない

#### B. W0-C: c-table Component 新設

- **B-1/B-2**: `src/assets/css/component/c-table.css` 新設、`style.css` に `@import`（content-display 群の `c-prose` の直後）
- **B-3**: `p-pricing__table` 簡素化 — `inline-size` / `border-collapse` / セル装飾を c-table に委譲。`min-inline-size: 40rem`（pricing 固有、コンテンツ依存）のみ残存
- **B-4**: `src/index.html` Pricing section の `<table>` に `c-table` 併記

#### C. Option A: 文書同期 + a11y

- **C-1**: `README.md` — PR #101（LP 統合）後に残っていた `src/contact/` / `src/thanks/` 記述を削除、現 3 ページ構成（index / privacy / 404）に更新、フォーム送信先説明を `action="/api/contact"` の実装に整合
- **C-2**: `CODING_GUIDE.md` L53 — 実在しない `l-container.css` への誤参照を `foundation/base.css` の body への container 宣言に修正
- **C-3**: `src/privacy/index.html` — `<section class="l-section p-privacy">` に `aria-labelledby="privacy-heading"`、`<h1>` に対応する `id` を付与

## 根拠

- 統一原則 10 項（**W0-d audit 重要**）
- spec §6 SHOULD [層識別プレフィックスの使用] / SHOULD NOT [公開 API プレフィックス含有の回避]
- spec §7 SHOULD [公開 API 変数の命名規則遵守]
- cortex memory `feedback_*` 群

## 機械検証（すべて 0 件 / 通過）

- `p-header__inner|p-footer__inner|p-drawer__inner|p-not-found__action`（旧セレクタ残存）: **0 件**
- `--c-[a-z]`（Component 配下の公開 API プレフィックス含有）: **0 件**
- `pnpm run check`（format / stylelint / eslint / markuplint）: **全通過**
- `pnpm run build`: **69ms / success**

## Test plan

- [ ] `pnpm run dev` で index / privacy / 404 の 3 ページを表示確認
- [ ] Header: PC 幅で `p-header__bar` の space-between レイアウトが維持されている
- [ ] Footer: 縦積み・中央揃え（`p-footer__stack`）
- [ ] Drawer（SP 幅）: ハンバーガー開閉時のレイアウト（`p-drawer__stack`、safe center、padding）
- [ ] 404 ページ: CTA ボタン表示 + アクセシビリティ問題なし
- [ ] Pricing: テーブルの横スクロール挙動（40rem 閾値）、罫線・thead 背景・tbody th の font-weight が c-table 経由で効いている
- [ ] Privacy: スクリーンリーダーで section の accessible name（= 見出し）が読み上げられる
- [ ] Contact フォーム: `c-form__actions` の margin が Project 側で必要に応じて上書きできる

🤖 Generated with [Claude Code](https://claude.com/claude-code)