### PR TITLE
fix(v1.0): Problem section を 3-div 分離（原則 1/4/7 準拠）

### DIFF
--- a/src/assets/css/project/p-problem.css
+++ b/src/assets/css/project/p-problem.css
@@ -27,5 +27,6 @@
 }
 
 .p-problem__item {
-  /* スタイルなし（カード装飾は c-card -subtle が担当。Project は grid 配置のみを責任範囲とする） */
+  /* スタイルなし（grid 子配置のみを責任範囲とする。カード装飾は子の c-card.-subtle、
+     内部タイポの縦積みはさらにその子の c-text-block が担当し、HTML レベルで責任を分離する） */
 }

--- a/src/index.html
+++ b/src/index.html
@@ -233,23 +233,35 @@
               <h2 id="problem-heading">こんな日々、続いていませんか？</h2>
             </hgroup>
             <ul class="p-problem__list" data-stagger="fade-in-slide-up">
-              <li class="c-card -subtle c-text-block p-problem__item">
-                <h3 class="c-text-block__title">朝起きても疲れが抜けない</h3>
-                <p class="c-text-block__text">
-                  睡眠時間は取っているのに、目覚めがすっきりしない。週末に寝溜めしても月曜にはもう重い。
-                </p>
+              <li class="p-problem__item">
+                <div class="c-card -subtle">
+                  <div class="c-text-block">
+                    <h3 class="c-text-block__title">朝起きても疲れが抜けない</h3>
+                    <p class="c-text-block__text">
+                      睡眠時間は取っているのに、目覚めがすっきりしない。週末に寝溜めしても月曜にはもう重い。
+                    </p>
+                  </div>
+                </div>
               </li>
-              <li class="c-card -subtle c-text-block p-problem__item">
-                <h3 class="c-text-block__title">肩や腰が常に張っている</h3>
-                <p class="c-text-block__text">
-                  デスクワークが続くと夕方には限界。マッサージに行っても翌日には戻っている。
-                </p>
+              <li class="p-problem__item">
+                <div class="c-card -subtle">
+                  <div class="c-text-block">
+                    <h3 class="c-text-block__title">肩や腰が常に張っている</h3>
+                    <p class="c-text-block__text">
+                      デスクワークが続くと夕方には限界。マッサージに行っても翌日には戻っている。
+                    </p>
+                  </div>
+                </div>
               </li>
-              <li class="c-card -subtle c-text-block p-problem__item">
-                <h3 class="c-text-block__title">自分のための時間がない</h3>
-                <p class="c-text-block__text">
-                  仕事、家事、育児。気づけば一日が終わっていて、自分のことは後回しになっている。
-                </p>
+              <li class="p-problem__item">
+                <div class="c-card -subtle">
+                  <div class="c-text-block">
+                    <h3 class="c-text-block__title">自分のための時間がない</h3>
+                    <p class="c-text-block__text">
+                      仕事、家事、育児。気づけば一日が終わっていて、自分のことは後回しになっている。
+                    </p>
+                  </div>
+                </div>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
## Summary

- Problem section の `<li class=\"c-card -subtle c-text-block p-problem__item\">` 4 Block 併記を 3 要素分離に変更
- 責任境界を HTML レベルで明示（教材価値向上）
- visual 変化なし（同じスタイルが別要素に分配されるだけ）

## 背景

しゅんえい指摘 — c-card + -subtle + c-text-block + p-problem__item の 4 Block 併記は責任境界が曖昧で教材価値を損なう。統一原則 10 項の原則 1（Component は自己完結）/ 4（責任が直交する場合のみ併記 OK）/ 7（Component 責任は単一）に準拠した構造に改める。

## 変更内容

### HTML（`src/index.html`）

Problem section の 3 件の `<li>` をすべて同じパターンで分離:

```html
<!-- Before -->
<li class=\"c-card -subtle c-text-block p-problem__item\">
  <h3 class=\"c-text-block__title\">...</h3>
  <p class=\"c-text-block__text\">...</p>
</li>

<!-- After -->
<li class=\"p-problem__item\">
  <div class=\"c-card -subtle\">
    <div class=\"c-text-block\">
      <h3 class=\"c-text-block__title\">...</h3>
      <p class=\"c-text-block__text\">...</p>
    </div>
  </div>
</li>
```

### CSS（`src/assets/css/project/p-problem.css`）

`.p-problem__item` は元から空ルール（コメント付き）だったため、分離後の責任分担を明示するようコメントを更新:

```css
.p-problem__item {
  /* スタイルなし（grid 子配置のみを責任範囲とする。カード装飾は子の c-card.-subtle、
     内部タイポの縦積みはさらにその子の c-text-block が担当し、HTML レベルで責任を分離する） */
}
```

## 責任分担（visual 不変の根拠）

| 要素 | 責任 | スタイル |
|------|------|----------|
| `li.p-problem__item` | grid 子配置 | grid セル（`.p-problem__list` が `display: grid; grid-template-columns: repeat(3, 1fr)` で自動配置） |
| `div.c-card.-subtle` | 外枠装飾 | padding / bg / radius / shadow / border |
| `div.c-text-block` | 内部タイポ縦積み | display: flex; flex-direction: column; gap |

li 自体は空ルール（margin / padding / border を持たない）ため、grid セルの矩形 = c-card div の外形と一致し、分離前後で見た目は変わらない。

## 機械走査結果

- Element 併記違反（`__xxx __yyy` の組み合わせ）: **0 件**
  - `grep -rn 'class=\"[^\"]*__[a-zA-Z-]+ [^\"]*__[a-zA-Z-]+\"' src/**/*.html` → No matches
- Problem 併記パターン（c-card / c-text-block / p-problem 同居）: **0 件**
  - `grep -n 'c-card.*c-text-block.*p-problem' src/index.html` → No matches

## 品質検証

- [x] Stylelint（`pnpm run lint:css`）: pass
- [x] ESLint（`pnpm run lint:js`）: pass
- [x] markuplint（`pnpm run lint:html`）: pass（`src/index.html` / `404.html` / `privacy/index.html` すべて）
- [x] `pnpm run build`: success（77ms、CSS 29.11 KB gzip 6.38 KB）
- [x] visual 変化: スタイルが別要素に分配されるだけ、見た目は不変

## 参考

- Component 使用統一原則（原則 1 / 4 / 7）
- spec §5.4（Component 責任）/ §5.5（Project 責任）/ §6（併記ルール）

🤖 Generated with [Claude Code](https://claude.com/claude-code)