### PR TITLE
feat(v1.0): 3-level 統一構造最終形（Problem + Flow を inner wrapper 化）

### DIFF
--- a/src/assets/css/project/p-flow.css
+++ b/src/assets/css/project/p-flow.css
@@ -23,13 +23,21 @@
   counter-reset: step;
 }
 
-/* WHY: padding / background-color / border-radius は c-card.-subtle 併記で委譲。
-   ここは grid + counter の「レイアウト + ステップ番号描画」という Project 固有の責任に絞る。 */
+/* WHY: li 自体は listing と counter-increment だけを担い、
+   見た目（カード装飾 + grid + badge）は子の .c-card に寄せる。
+   3-level 統一構造（li + .c-card wrapper + content）における
+   Project 固有の責任境界を最小化する設計。 */
 .p-flow__item {
+  counter-increment: step;
+}
+
+/* WHY: padding / background-color / border-radius は c-card.-subtle 併記で委譲。
+   ここは grid + counter の「レイアウト + ステップ番号描画」という
+   「カード見た目領域内」固有の責任に絞る。 */
+.p-flow__item > .c-card {
   display: grid;
   grid-template-columns: auto 1fr;
   gap: var(--space-sm) var(--space-lg);
-  counter-increment: step;
 
   /* WHY: CSS counter でステップ番号を円形バッジとして視覚化。<ol> のセマンティクスは保ったまま装飾を自前で描画 */
   &::before {

--- a/src/assets/css/project/p-problem.css
+++ b/src/assets/css/project/p-problem.css
@@ -27,6 +27,8 @@
 }
 
 .p-problem__item {
-  /* スタイルなし（grid 子配置のみを責任範囲とする。カード装飾は li に併記した c-card.-subtle、
-     内部タイポの縦積みは子の c-text-block が担当し、HTML レベルで責任を分離する） */
+  /* スタイルなし（li は listing 子配置のみを責任範囲とする）。
+     3-level 統一構造（li + .c-card wrapper + .c-text-block content）により
+     カード装飾は inner .c-card.-subtle、内部タイポの縦積みは .c-text-block が担当。
+     HTML レベルで責任を分離する。 */
 }

--- a/src/index.html
+++ b/src/index.html
@@ -233,28 +233,34 @@
               <h2 id="problem-heading">こんな日々、続いていませんか？</h2>
             </hgroup>
             <ul class="p-problem__list" data-stagger="fade-in-slide-up">
-              <li class="p-problem__item c-card -subtle">
-                <div class="c-text-block">
-                  <h3 class="c-text-block__title">朝起きても疲れが抜けない</h3>
-                  <p class="c-text-block__text">
-                    睡眠時間は取っているのに、目覚めがすっきりしない。週末に寝溜めしても月曜にはもう重い。
-                  </p>
+              <li class="p-problem__item">
+                <div class="c-card -subtle">
+                  <div class="c-text-block">
+                    <h3 class="c-text-block__title">朝起きても疲れが抜けない</h3>
+                    <p class="c-text-block__text">
+                      睡眠時間は取っているのに、目覚めがすっきりしない。週末に寝溜めしても月曜にはもう重い。
+                    </p>
+                  </div>
                 </div>
               </li>
-              <li class="p-problem__item c-card -subtle">
-                <div class="c-text-block">
-                  <h3 class="c-text-block__title">肩や腰が常に張っている</h3>
-                  <p class="c-text-block__text">
-                    デスクワークが続くと夕方には限界。マッサージに行っても翌日には戻っている。
-                  </p>
+              <li class="p-problem__item">
+                <div class="c-card -subtle">
+                  <div class="c-text-block">
+                    <h3 class="c-text-block__title">肩や腰が常に張っている</h3>
+                    <p class="c-text-block__text">
+                      デスクワークが続くと夕方には限界。マッサージに行っても翌日には戻っている。
+                    </p>
+                  </div>
                 </div>
               </li>
-              <li class="p-problem__item c-card -subtle">
-                <div class="c-text-block">
-                  <h3 class="c-text-block__title">自分のための時間がない</h3>
-                  <p class="c-text-block__text">
-                    仕事、家事、育児。気づけば一日が終わっていて、自分のことは後回しになっている。
-                  </p>
+              <li class="p-problem__item">
+                <div class="c-card -subtle">
+                  <div class="c-text-block">
+                    <h3 class="c-text-block__title">自分のための時間がない</h3>
+                    <p class="c-text-block__text">
+                      仕事、家事、育児。気づけば一日が終わっていて、自分のことは後回しになっている。
+                    </p>
+                  </div>
                 </div>
               </li>
             </ul>
@@ -356,44 +362,54 @@
             <h2 id="flow-heading">ご利用の流れ</h2>
           </hgroup>
           <ol class="p-flow__list" data-stagger="fade-in-slide-up">
-            <li class="p-flow__item c-card -subtle">
-              <div class="c-text-block">
-                <h3 class="c-text-block__title">ご予約</h3>
-                <p class="c-text-block__text">
-                  お問い合わせフォームからご希望の日時・コースをお知らせください。24時間以内に折り返しご連絡いたします。
-                </p>
+            <li class="p-flow__item">
+              <div class="c-card -subtle">
+                <div class="c-text-block">
+                  <h3 class="c-text-block__title">ご予約</h3>
+                  <p class="c-text-block__text">
+                    お問い合わせフォームからご希望の日時・コースをお知らせください。24時間以内に折り返しご連絡いたします。
+                  </p>
+                </div>
               </div>
             </li>
-            <li class="p-flow__item c-card -subtle">
-              <div class="c-text-block">
-                <h3 class="c-text-block__title">カウンセリング</h3>
-                <p class="c-text-block__text">
-                  施術前に30分ほどお時間をいただき、お体の状態やお悩み・ご希望を丁寧にヒアリング。
-                </p>
+            <li class="p-flow__item">
+              <div class="c-card -subtle">
+                <div class="c-text-block">
+                  <h3 class="c-text-block__title">カウンセリング</h3>
+                  <p class="c-text-block__text">
+                    施術前に30分ほどお時間をいただき、お体の状態やお悩み・ご希望を丁寧にヒアリング。
+                  </p>
+                </div>
               </div>
             </li>
-            <li class="p-flow__item c-card -subtle">
-              <div class="c-text-block">
-                <h3 class="c-text-block__title">施術</h3>
-                <p class="c-text-block__text">
-                  選択したコースに沿って45〜90分の施術。完全個室で安心してお過ごしください。
-                </p>
+            <li class="p-flow__item">
+              <div class="c-card -subtle">
+                <div class="c-text-block">
+                  <h3 class="c-text-block__title">施術</h3>
+                  <p class="c-text-block__text">
+                    選択したコースに沿って45〜90分の施術。完全個室で安心してお過ごしください。
+                  </p>
+                </div>
               </div>
             </li>
-            <li class="p-flow__item c-card -subtle">
-              <div class="c-text-block">
-                <h3 class="c-text-block__title">アフターケア</h3>
-                <p class="c-text-block__text">
-                  施術後は水分補給とリラックスタイム。お体の変化を確かめながらゆっくりとお過ごしください。
-                </p>
+            <li class="p-flow__item">
+              <div class="c-card -subtle">
+                <div class="c-text-block">
+                  <h3 class="c-text-block__title">アフターケア</h3>
+                  <p class="c-text-block__text">
+                    施術後は水分補給とリラックスタイム。お体の変化を確かめながらゆっくりとお過ごしください。
+                  </p>
+                </div>
               </div>
             </li>
-            <li class="p-flow__item c-card -subtle">
-              <div class="c-text-block">
-                <h3 class="c-text-block__title">次回のご案内</h3>
-                <p class="c-text-block__text">
-                  お客様のお体に合わせた最適なペースをご提案。ご希望があれば次回のご予約も承ります。
-                </p>
+            <li class="p-flow__item">
+              <div class="c-card -subtle">
+                <div class="c-text-block">
+                  <h3 class="c-text-block__title">次回のご案内</h3>
+                  <p class="c-text-block__text">
+                    お客様のお体に合わせた最適なペースをご提案。ご希望があれば次回のご予約も承ります。
+                  </p>
+                </div>
               </div>
             </li>
           </ol>


### PR DESCRIPTION
## Summary

2026-04-23 セッション 2 最終確定方針に基づき、card 相当の list item を「3-level 統一構造」に揃える。wrapper element は semantic で決まる（testimonial は `<article>`、section の部分は `<div>`）。

- Problem section: PR #117 の 2-level（`<li class="... c-card -subtle">`）を 3-level with `<div>` wrapper に再編成。PR #115 の構造が結果的に最終形。
- Flow section: 2-level を 3-level with `<div>` wrapper に再編成。counter badge（`::before`）を `.p-flow__item` から `.p-flow__item > .c-card` に移動し、card 内装飾として一貫化。
- Voice section: 変更なし（既に 3-level with `<article>`）。

結果、全 card section が **`li + (article|div).c-card + content`** の統一パターン。

## Iteration 経緯

| PR | 構造 | 結論 |
|---|---|---|
| #115 | 3-div 分離（Problem） | 過剰分離と判断されるも、最終的に正解 |
| #117 | 2-div（Problem、li に c-card 併記） | semantic-first で revert |
| #118（本 PR） | 3-level 統一（Problem + Flow 共に inner `<div>`） | SEO/パフォーマンス影響ゼロ、教材価値優先 |

## 判断の根拠

- **SEO / パフォーマンス**: DOM ネスト +1 の影響は Google / Lighthouse / WCAG いずれも直接ペナルティなし
- **教材価値**: 例外が減る（全 section で統一判断基準）、読者が新 section にどう適用するか予測可能
- **責任明確化**: `c-card` は常に wrapper element に、counter badge は常に wrapper の `::before` に
- **semantic-first は維持**: wrapper element の選択は semantic で決まる（testimonial = `<article>`、section の一部 = `<div>`）

## 変更詳細

### HTML（`src/index.html`）
- Problem 3 項目: `<li class="p-problem__item">` + `<div class="c-card -subtle">` + `<div class="c-text-block">`
- Flow 5 ステップ: `<li class="p-flow__item">` + `<div class="c-card -subtle">` + `<div class="c-text-block">`

### CSS
- `src/assets/css/project/p-problem.css`: `.p-problem__item` のコメントを 3-level 責任分離に合わせて更新
- `src/assets/css/project/p-flow.css`:
  - `.p-flow__item` は `counter-increment` のみ（listing 責任）
  - `.p-flow__item > .c-card` に `display: grid` + `grid-template-columns: auto 1fr` を移動
  - `.p-flow__item > .c-card::before` に badge 装飾を移動

## 機械走査結果

```
=== Element 併記違反チェック ===
（0 件）
=== Problem 3-level 確認 ===
<li class="p-problem__item"> → 3 件
=== Problem/Flow inner div ===
<div class="c-card -subtle"> → 8 件（Problem 3 + Flow 5）
=== Flow 3-level 確認 ===
<li class="p-flow__item"> → 5 件
=== Voice 3-level（変更なし）===
<li class="p-voice__item"> → 2 件
```

## Test plan

- [x] `pnpm run check`（prettier + stylelint + eslint + markuplint）全通過
- [x] `pnpm run build` 成功、`dist/assets/main-*.css` に `.p-flow__item>.c-card::before` が `content: counter(step); grid-row: 1; align-self: start;` で出力されていることを確認
- [x] Problem 3 項目・Flow 5 ステップが 3-level with `<div>` で書かれていることを grep で機械確認
- [x] Voice は `<article>` のまま（変更なし）
- [ ] 手動 preview で Flow の番号 badge が card 左上（grid column 1, row 1）に円形表示されることを視覚確認
- [ ] Problem / Flow のレイアウトが `c-card.-subtle` の padding / background-color / border-radius を wrapper div で受け取り、見た目に変化がないことを視覚確認

## 関連 memory

- Component 使用統一原則 11:
  「装飾 Component（ガワ = c-card 等）は card にしたい semantic element に付ける。element 種別は semantic で決まる」
  本 PR の「3-level 統一」方針に合わせ、**適用例テーブル**と**反例ブロック**の memory 更新が後続必要（セッション終了時）。

## 制約確認

- base: `v1.2` ✅
- main 直接コミット: なし ✅
- マージ: Cortex 側で実施
- Voice は変更せず ✅

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>