### PR TITLE
fix(v1.0): c-Block = p-Element 同要素併記を全面統一（原則改訂反映）

### DIFF
--- a/src/assets/css/project/p-cta.css
+++ b/src/assets/css/project/p-cta.css
@@ -20,3 +20,11 @@
   gap: var(--space-lg);
   align-items: center;
 }
+
+.p-cta__message {
+  /* スタイルなし（HTML クラスとの対応を維持。c-text-block と Block+Element 併記パターン統一） */
+}
+
+.p-cta__button {
+  /* スタイルなし（HTML クラスとの対応を維持。c-button と Block+Element 併記パターン統一） */
+}

--- a/src/assets/css/project/p-faq.css
+++ b/src/assets/css/project/p-faq.css
@@ -27,3 +27,7 @@
     border-block-start: none;
   }
 }
+
+.p-faq__accordion {
+  /* スタイルなし（HTML クラスとの対応を維持。c-accordion と Block+Element 併記パターン統一） */
+}

--- a/src/assets/css/project/p-flow.css
+++ b/src/assets/css/project/p-flow.css
@@ -23,23 +23,16 @@
   counter-reset: step;
 }
 
-/* WHY: li 自体は listing と counter-increment だけを担い、
-   見た目（カード装飾 + grid + badge）は子の .c-card に寄せる。
-   3-level 統一構造（li + .c-card wrapper + content）における
-   Project 固有の責任境界を最小化する設計。 */
+/* WHY: li が c-card.-subtle を併記（2-level 構造）。
+   padding / background / border-radius は c-card.-subtle で委譲、
+   ここは grid + counter badge の「ステップ番号描画」固有の責任に絞る。 */
 .p-flow__item {
-  counter-increment: step;
-}
-
-/* WHY: padding / background-color / border-radius は c-card.-subtle 併記で委譲。
-   ここは grid + counter の「レイアウト + ステップ番号描画」という
-   「カード見た目領域内」固有の責任に絞る。 */
-.p-flow__item > .c-card {
   display: grid;
   grid-template-columns: auto 1fr;
   gap: var(--space-sm) var(--space-lg);
+  counter-increment: step;
 
-  /* WHY: CSS counter でステップ番号を円形バッジとして視覚化。<ol> のセマンティクスは保ったまま装飾を自前で描画 */
+  /* WHY: CSS counter でステップ番号を円形バッジとして視覚化 */
   &::before {
     display: flex;
     grid-row: 1;

--- a/src/assets/css/project/p-problem.css
+++ b/src/assets/css/project/p-problem.css
@@ -27,8 +27,6 @@
 }
 
 .p-problem__item {
-  /* スタイルなし（li は listing 子配置のみを責任範囲とする）。
-     3-level 統一構造（li + .c-card wrapper + .c-text-block content）により
-     カード装飾は inner .c-card.-subtle、内部タイポの縦積みは .c-text-block が担当。
-     HTML レベルで責任を分離する。 */
+  /* スタイルなし（2-level 構造: li 自身が c-card.-subtle wrapper を兼ねる。
+     内部タイポの縦積みは .c-text-block が担当）。 */
 }

--- a/src/assets/css/project/p-voice.css
+++ b/src/assets/css/project/p-voice.css
@@ -27,3 +27,7 @@
 .p-voice__item {
   /* スタイルなし（HTML クラスとの対応を維持） */
 }
+
+.p-voice__card {
+  /* スタイルなし（HTML クラスとの対応を維持。c-card と Block+Element 併記パターン統一） */
+}

--- a/src/index.html
+++ b/src/index.html
@@ -233,34 +233,28 @@
               <h2 id="problem-heading">こんな日々、続いていませんか？</h2>
             </hgroup>
             <ul class="p-problem__list" data-stagger="fade-in-slide-up">
-              <li class="p-problem__item">
-                <div class="c-card -subtle">
-                  <div class="c-text-block">
-                    <h3 class="c-text-block__title">朝起きても疲れが抜けない</h3>
-                    <p class="c-text-block__text">
-                      睡眠時間は取っているのに、目覚めがすっきりしない。週末に寝溜めしても月曜にはもう重い。
-                    </p>
-                  </div>
+              <li class="p-problem__item c-card -subtle">
+                <div class="c-text-block">
+                  <h3 class="c-text-block__title">朝起きても疲れが抜けない</h3>
+                  <p class="c-text-block__text">
+                    睡眠時間は取っているのに、目覚めがすっきりしない。週末に寝溜めしても月曜にはもう重い。
+                  </p>
                 </div>
               </li>
-              <li class="p-problem__item">
-                <div class="c-card -subtle">
-                  <div class="c-text-block">
-                    <h3 class="c-text-block__title">肩や腰が常に張っている</h3>
-                    <p class="c-text-block__text">
-                      デスクワークが続くと夕方には限界。マッサージに行っても翌日には戻っている。
-                    </p>
-                  </div>
+              <li class="p-problem__item c-card -subtle">
+                <div class="c-text-block">
+                  <h3 class="c-text-block__title">肩や腰が常に張っている</h3>
+                  <p class="c-text-block__text">
+                    デスクワークが続くと夕方には限界。マッサージに行っても翌日には戻っている。
+                  </p>
                 </div>
               </li>
-              <li class="p-problem__item">
-                <div class="c-card -subtle">
-                  <div class="c-text-block">
-                    <h3 class="c-text-block__title">自分のための時間がない</h3>
-                    <p class="c-text-block__text">
-                      仕事、家事、育児。気づけば一日が終わっていて、自分のことは後回しになっている。
-                    </p>
-                  </div>
+              <li class="p-problem__item c-card -subtle">
+                <div class="c-text-block">
+                  <h3 class="c-text-block__title">自分のための時間がない</h3>
+                  <p class="c-text-block__text">
+                    仕事、家事、育児。気づけば一日が終わっていて、自分のことは後回しになっている。
+                  </p>
                 </div>
               </li>
             </ul>
@@ -362,54 +356,44 @@
             <h2 id="flow-heading">ご利用の流れ</h2>
           </hgroup>
           <ol class="p-flow__list" data-stagger="fade-in-slide-up">
-            <li class="p-flow__item">
-              <div class="c-card -subtle">
-                <div class="c-text-block">
-                  <h3 class="c-text-block__title">ご予約</h3>
-                  <p class="c-text-block__text">
-                    お問い合わせフォームからご希望の日時・コースをお知らせください。24時間以内に折り返しご連絡いたします。
-                  </p>
-                </div>
+            <li class="p-flow__item c-card -subtle">
+              <div class="c-text-block">
+                <h3 class="c-text-block__title">ご予約</h3>
+                <p class="c-text-block__text">
+                  お問い合わせフォームからご希望の日時・コースをお知らせください。24時間以内に折り返しご連絡いたします。
+                </p>
               </div>
             </li>
-            <li class="p-flow__item">
-              <div class="c-card -subtle">
-                <div class="c-text-block">
-                  <h3 class="c-text-block__title">カウンセリング</h3>
-                  <p class="c-text-block__text">
-                    施術前に30分ほどお時間をいただき、お体の状態やお悩み・ご希望を丁寧にヒアリング。
-                  </p>
-                </div>
+            <li class="p-flow__item c-card -subtle">
+              <div class="c-text-block">
+                <h3 class="c-text-block__title">カウンセリング</h3>
+                <p class="c-text-block__text">
+                  施術前に30分ほどお時間をいただき、お体の状態やお悩み・ご希望を丁寧にヒアリング。
+                </p>
               </div>
             </li>
-            <li class="p-flow__item">
-              <div class="c-card -subtle">
-                <div class="c-text-block">
-                  <h3 class="c-text-block__title">施術</h3>
-                  <p class="c-text-block__text">
-                    選択したコースに沿って45〜90分の施術。完全個室で安心してお過ごしください。
-                  </p>
-                </div>
+            <li class="p-flow__item c-card -subtle">
+              <div class="c-text-block">
+                <h3 class="c-text-block__title">施術</h3>
+                <p class="c-text-block__text">
+                  選択したコースに沿って45〜90分の施術。完全個室で安心してお過ごしください。
+                </p>
               </div>
             </li>
-            <li class="p-flow__item">
-              <div class="c-card -subtle">
-                <div class="c-text-block">
-                  <h3 class="c-text-block__title">アフターケア</h3>
-                  <p class="c-text-block__text">
-                    施術後は水分補給とリラックスタイム。お体の変化を確かめながらゆっくりとお過ごしください。
-                  </p>
-                </div>
+            <li class="p-flow__item c-card -subtle">
+              <div class="c-text-block">
+                <h3 class="c-text-block__title">アフターケア</h3>
+                <p class="c-text-block__text">
+                  施術後は水分補給とリラックスタイム。お体の変化を確かめながらゆっくりとお過ごしください。
+                </p>
               </div>
             </li>
-            <li class="p-flow__item">
-              <div class="c-card -subtle">
-                <div class="c-text-block">
-                  <h3 class="c-text-block__title">次回のご案内</h3>
-                  <p class="c-text-block__text">
-                    お客様のお体に合わせた最適なペースをご提案。ご希望があれば次回のご予約も承ります。
-                  </p>
-                </div>
+            <li class="p-flow__item c-card -subtle">
+              <div class="c-text-block">
+                <h3 class="c-text-block__title">次回のご案内</h3>
+                <p class="c-text-block__text">
+                  お客様のお体に合わせた最適なペースをご提案。ご希望があれば次回のご予約も承ります。
+                </p>
               </div>
             </li>
           </ol>
@@ -501,7 +485,7 @@
             </hgroup>
             <ul class="p-voice__list" data-stagger="fade-in-slide-up">
               <li class="p-voice__item">
-                <article class="c-card">
+                <article class="c-card p-voice__card">
                   <blockquote class="c-blockquote">
                     <p class="c-blockquote__title">毎週通うつもりはなかったのに、からだが求めるようになりました</p>
                     <p class="c-blockquote__text">
@@ -524,7 +508,7 @@
                 </article>
               </li>
               <li class="p-voice__item">
-                <article class="c-card">
+                <article class="c-card p-voice__card">
                   <blockquote class="c-blockquote">
                     <p class="c-blockquote__title">ここに来ると、呼吸が深くなるんです</p>
                     <p class="c-blockquote__text">
@@ -555,11 +539,11 @@
       <section class="l-section p-cta" id="cta" aria-labelledby="cta-heading">
         <div class="l-inner p-cta__inner">
           <div class="p-cta__stack" data-stagger="fade-in-slide-up">
-            <div class="c-text-block">
+            <div class="c-text-block p-cta__message">
               <h2 id="cta-heading" class="c-text-block__title">まずは一度、からだの声を聴いてみませんか？</h2>
               <p class="c-text-block__text">初回体験は 60分 4,400円。カウンセリング込み。無理な勧誘はいたしません。</p>
             </div>
-            <a href="#contact" class="c-button -primary -large">初回体験を予約する</a>
+            <a href="#contact" class="c-button -primary -large p-cta__button">初回体験を予約する</a>
           </div>
         </div>
       </section>
@@ -573,7 +557,7 @@
           </hgroup>
           <ul class="p-faq__list" data-stagger="fade-in-slide-up">
             <li class="p-faq__item">
-              <details class="c-accordion" open>
+              <details class="c-accordion p-faq__accordion" open>
                 <summary class="c-accordion__summary">
                   施術に痛みはありますか？
                   <svg class="c-icon c-accordion__icon" width="20" height="20" aria-hidden="true">
@@ -588,7 +572,7 @@
               </details>
             </li>
             <li class="p-faq__item">
-              <details class="c-accordion">
+              <details class="c-accordion p-faq__accordion">
                 <summary class="c-accordion__summary">
                   どのくらいの頻度で通えばいいですか？
                   <svg class="c-icon c-accordion__icon" width="20" height="20" aria-hidden="true">
@@ -603,7 +587,7 @@
               </details>
             </li>
             <li class="p-faq__item">
-              <details class="c-accordion">
+              <details class="c-accordion p-faq__accordion">
                 <summary class="c-accordion__summary">
                   予約の変更やキャンセルはできますか？
                   <svg class="c-icon c-accordion__icon" width="20" height="20" aria-hidden="true">
@@ -616,7 +600,7 @@
               </details>
             </li>
             <li class="p-faq__item">
-              <details class="c-accordion">
+              <details class="c-accordion p-faq__accordion">
                 <summary class="c-accordion__summary">
                   男性も利用できますか？
                   <svg class="c-icon c-accordion__icon" width="20" height="20" aria-hidden="true">


### PR DESCRIPTION
## Summary

Component 使い方原則の改訂（原則 2 / 8 / 11）に基づき、v1.0 starter の Component 配置を「c- Block = p- Element 同要素併記」パターンに全面統一。

- Problem / Flow: 3-level → 2-level（li に c-card 併記）
- Voice: article に p-voice__card 追加
- CTA: c-text-block に p-cta__message、c-button に p-cta__button 追加
- FAQ: c-accordion に p-faq__accordion 追加

PR #118（3-level 統一）は「教材価値優先」の選択だったが、原則を「semantic で判断」に本質化した結果、`<div>` で十分な content は 2-level が適切と再判定。Voice (testimonial = `<article>` 必要) は 3-level 維持。

## 背景（原則改訂）

- **原則 2（改訂）**: Component は自らの「内側の責任のみ」を持つ（spec §5.5）。外側の配置方法は (A) 同要素併記 or (B) wrapper 分離どちらも spec 合致。
- **原則 8（改訂）**: 空ルール Element の扱いは retrospective cleanup rule として運用。マークアップ時の制約ではない。
- **原則 11（改訂）**: c- Block は常に対応する p- Element と同要素併記（spec §5.6 Block+Element 併記の推奨パターン）。card 限定を解除し、semantic で 2-level / 3-level を判定。

## Test plan

- [x] `pnpm run check` 通過
- [x] `pnpm run build` 成功
- [x] 機械走査（c-Block + p-Element 併記数が期待値）
- [ ] 実ブラウザで Problem / Flow / Voice / CTA / FAQ の見た目確認
- [ ] Flow counter badge の位置・表示確認（セレクタ変更後）
- [ ] Cloudflare Pages preview pass

## 関連

- PR #118 の一部 revert（Problem/Flow を 2-level に戻す）
- Issue #116（Component 公開 API エイリアスパターン、v1.1 予定）— 本 PR で解消しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)