### PR TITLE
refactor(v1.0): c-icon 廃止 — 各 Component に icon Element を内包（Portability Test 強化）

### DIFF
--- a/src/assets/css/component/c-accordion.css
+++ b/src/assets/css/component/c-accordion.css
@@ -20,6 +20,8 @@
 
 .c-accordion__icon {
   flex-shrink: 0;
+  inline-size: 1em;
+  block-size: 1em;
 
   @media (prefers-reduced-motion: no-preference) {
     transition: rotate var(--duration-normal) var(--ease-out-cubic);

--- a/src/assets/css/component/c-back-to-top.css
+++ b/src/assets/css/component/c-back-to-top.css
@@ -45,3 +45,9 @@
     opacity: 1;
   }
 }
+
+.c-back-to-top__icon {
+  flex-shrink: 0;
+  inline-size: 1em;
+  block-size: 1em;
+}

--- a/src/assets/css/component/c-button.css
+++ b/src/assets/css/component/c-button.css
@@ -60,3 +60,9 @@
     opacity: 0.7;
   }
 }
+
+.c-button__icon {
+  flex-shrink: 0;
+  inline-size: 1em;
+  block-size: 1em;
+}

--- a/src/assets/css/component/c-icon.css
+++ b/src/assets/css/component/c-icon.css
@@ -1,5 +1,0 @@
-.c-icon {
-  flex-shrink: 0;
-  inline-size: 1em;
-  block-size: 1em;
-}

--- a/src/assets/css/project/p-hero.css
+++ b/src/assets/css/project/p-hero.css
@@ -34,10 +34,6 @@
   /* スタイルなし（HTML クラスとの対応を維持） */
 }
 
-.p-hero__cta-icon {
-  /* スタイルなし（HTML クラスとの対応を維持） */
-}
-
 .p-hero__sub-cta {
   /* WHY: Hero 背景のグラデーション上でもテキストとボーダーの可読性を確保するため、ダークモード時は text 色に寄せる。c-button 公開 API 経由で注入し、プロパティ直上書きを避ける */
   --button-color: light-dark(var(--color-main), var(--color-text));

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -36,7 +36,6 @@
 @import './component/c-text-block.css' layer(component);
 @import './component/c-prose.css' layer(component);
 @import './component/c-table.css' layer(component);
-@import './component/c-icon.css' layer(component);
 @import './component/c-back-to-top.css' layer(component);
 @import './component/c-skip-link.css' layer(component);
 @import './component/c-hamburger.css' layer(component);

--- a/src/index.html
+++ b/src/index.html
@@ -202,7 +202,7 @@
             <div class="p-hero__actions">
               <a href="#contact" class="c-button -primary -large p-hero__cta">
                 初回体験を予約する
-                <svg class="c-icon p-hero__cta-icon" width="20" height="20" aria-hidden="true">
+                <svg class="c-button__icon" width="20" height="20" aria-hidden="true">
                   <use href="./assets/images/icons/arrow-right.svg#icon" />
                 </svg>
               </a>
@@ -560,7 +560,7 @@
               <details class="c-accordion p-faq__accordion" open>
                 <summary class="c-accordion__summary">
                   施術に痛みはありますか？
-                  <svg class="c-icon c-accordion__icon" width="20" height="20" aria-hidden="true">
+                  <svg class="c-accordion__icon" width="20" height="20" aria-hidden="true">
                     <use href="./assets/images/icons/chevron-down.svg#icon" />
                   </svg>
                 </summary>
@@ -575,7 +575,7 @@
               <details class="c-accordion p-faq__accordion">
                 <summary class="c-accordion__summary">
                   どのくらいの頻度で通えばいいですか？
-                  <svg class="c-icon c-accordion__icon" width="20" height="20" aria-hidden="true">
+                  <svg class="c-accordion__icon" width="20" height="20" aria-hidden="true">
                     <use href="./assets/images/icons/chevron-down.svg#icon" />
                   </svg>
                 </summary>
@@ -590,7 +590,7 @@
               <details class="c-accordion p-faq__accordion">
                 <summary class="c-accordion__summary">
                   予約の変更やキャンセルはできますか？
-                  <svg class="c-icon c-accordion__icon" width="20" height="20" aria-hidden="true">
+                  <svg class="c-accordion__icon" width="20" height="20" aria-hidden="true">
                     <use href="./assets/images/icons/chevron-down.svg#icon" />
                   </svg>
                 </summary>
@@ -603,7 +603,7 @@
               <details class="c-accordion p-faq__accordion">
                 <summary class="c-accordion__summary">
                   男性も利用できますか？
-                  <svg class="c-icon c-accordion__icon" width="20" height="20" aria-hidden="true">
+                  <svg class="c-accordion__icon" width="20" height="20" aria-hidden="true">
                     <use href="./assets/images/icons/chevron-down.svg#icon" />
                   </svg>
                 </summary>
@@ -765,7 +765,7 @@
 
     <!-- Back to Top -->
     <a href="#top" class="c-back-to-top" data-back-to-top aria-label="ページの先頭に戻る">
-      <svg class="c-icon" width="20" height="20" aria-hidden="true">
+      <svg class="c-back-to-top__icon" width="20" height="20" aria-hidden="true">
         <use href="./assets/images/icons/chevron-up.svg#icon" />
       </svg>
     </a>


### PR DESCRIPTION
## Summary

`c-icon` Component を廃止し、使用元 3 Component に icon Element を内包させる。

- c-button: `__icon` Element 新設
- c-accordion: `__icon` を拡張（1em サイズ吸収）
- c-back-to-top: `__icon` Element 新設
- `src/assets/css/component/c-icon.css` 削除 + import 削除
- `p-hero__cta-icon` empty rule 削除（元々 dead class）

## Why

`c-icon` の責任は「flex-shrink: 0; 1em × 1em」のみで Component というより SVG サイズ default。共通化より各 Component の自己完結（Portability Test 合格）を優先。

別サイトに c-button を持っていく時、c-icon が依存として追従する状態を解消。9 行の CSS 重複と引き換えに依存関係をクリーン化。

## Test plan

- [x] `pnpm run check` 通過
- [x] `pnpm run build` 成功
- [x] c-icon class 除去確認（残存 0）
- [x] c-button__icon: 1 / c-accordion__icon: 4 / c-back-to-top__icon: 1
- [ ] 実ブラウザでアイコン表示確認（Hero 矢印 / FAQ chevron / Back-to-top）
- [ ] Cloudflare Pages preview pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)