### PR TITLE
refactor(v1.0): c-button__icon を child selector 化（Element 命名判断基準の確立）

### DIFF
--- a/src/assets/css/component/c-button.css
+++ b/src/assets/css/component/c-button.css
@@ -59,10 +59,16 @@
     pointer-events: none;
     opacity: 0.7;
   }
-}
 
-.c-button__icon {
-  flex-shrink: 0;
-  inline-size: 1em;
-  block-size: 1em;
+  /*
+   * button 内の svg アイコンは子セレクタで汎用サイズを適用。
+   * 固有の振る舞い（回転・状態連動等）を持たないため Element 命名は不要。
+   * アイコン位置（右 / 左 / 両側）は HTML 順で決まる（inline-flex + gap で自動配置）。
+   * cf. c-accordion__icon は [open] 連動の回転アニメという固有責任があるため Element 命名。
+   */
+  & > svg {
+    flex-shrink: 0;
+    inline-size: 1em;
+    block-size: 1em;
+  }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -202,7 +202,7 @@
             <div class="p-hero__actions">
               <a href="#contact" class="c-button -primary -large p-hero__cta">
                 初回体験を予約する
-                <svg class="c-button__icon" width="20" height="20" aria-hidden="true">
+                <svg width="20" height="20" aria-hidden="true">
                   <use href="./assets/images/icons/arrow-right.svg#icon" />
                 </svg>
               </a>


### PR DESCRIPTION
## Summary

c-button 内の svg アイコン styling を Element `.c-button__icon` から child selector `.c-button > svg` に変更。

- HTML の class 削除（`<svg class="c-button__icon">` → `<svg>`）
- CSS の Element 定義 → child selector nested rule に置換

## Why

しゅんえい指摘: `c-button__icon` が定義されていると「c-button はアイコン必須」と誤読しやすい。実際はアイコンありなし両方を同じ c-button で扱いたい（かつアイコン位置も HTML 順で自由）。

解決: 汎用 styling だけの子要素は child selector で対応し、Element 命名は**固有責任を持つ部位**のみに限定する原則を確立。

## 設計原則（mFLOCSS Element 命名の判断基準）

| 子要素の性質 | 命名戦略 | 例 |
|---|---|---|
| **固有責任**（状態連動、特定 role、識別可能な sub-part） | Element 命名（`c-xxx__yyy`） | `c-accordion__icon`（[open] 連動の回転）、`c-back-to-top__icon`（固有の icon エリア）、`c-card__title` |
| **汎用 styling**（サイズ合わせ・margin 等、当たり前の調整） | child selector（`.c-xxx > tag`） | `.c-button > svg`（icon サイズ 1em × 1em） |

この使い分けにより:
- Element 命名が「必須部位」を示す意図が明確化
- HTML が軽量化（汎用調整用の class が消える）
- アイコン位置は HTML 順で自由に表現可能（c-button の場合、右/左/両側を Modifier なしで実現）

## Test plan

- [x] `pnpm run check` 通過
- [x] `pnpm run build` 成功
- [x] c-button__icon class 除去確認（HTML + CSS）
- [x] child selector 追加確認
- [x] c-accordion__icon / c-back-to-top__icon は保持確認（固有責任あり）
- [ ] 実ブラウザで Hero CTA アイコン表示確認（1em サイズ、位置正常）
- [ ] Cloudflare Pages preview pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)