### PR TITLE
refactor(v1.0): class 記載順を l- → c- → -modifier → p- → u- に統一（11 箇所）

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -233,7 +233,7 @@
               <h2 id="problem-heading">こんな日々、続いていませんか？</h2>
             </hgroup>
             <ul class="p-problem__list" data-stagger="fade-in-slide-up">
-              <li class="p-problem__item c-card -subtle">
+              <li class="c-card -subtle p-problem__item">
                 <div class="c-text-block">
                   <h3 class="c-text-block__title">朝起きても疲れが抜けない</h3>
                   <p class="c-text-block__text">
@@ -241,7 +241,7 @@
                   </p>
                 </div>
               </li>
-              <li class="p-problem__item c-card -subtle">
+              <li class="c-card -subtle p-problem__item">
                 <div class="c-text-block">
                   <h3 class="c-text-block__title">肩や腰が常に張っている</h3>
                   <p class="c-text-block__text">
@@ -249,7 +249,7 @@
                   </p>
                 </div>
               </li>
-              <li class="p-problem__item c-card -subtle">
+              <li class="c-card -subtle p-problem__item">
                 <div class="c-text-block">
                   <h3 class="c-text-block__title">自分のための時間がない</h3>
                   <p class="c-text-block__text">
@@ -273,7 +273,7 @@
             </hgroup>
             <ul class="p-features__list" data-stagger="fade-in-slide-up">
               <li class="p-features__item">
-                <article class="p-features__card c-media-split">
+                <article class="c-media-split p-features__card">
                   <div class="c-media-split__content">
                     <span class="c-badge -accent c-media-split__badge" lang="en">Counseling</span>
                     <h3 class="c-media-split__title">まず、30分話すことから</h3>
@@ -296,7 +296,7 @@
                 </article>
               </li>
               <li class="p-features__item">
-                <article class="p-features__card c-media-split">
+                <article class="c-media-split p-features__card">
                   <div class="c-media-split__content">
                     <span class="c-badge -accent c-media-split__badge" lang="en">Treatment</span>
                     <h3 class="c-media-split__title">筋膜と深層にアプローチ</h3>
@@ -320,7 +320,7 @@
                 </article>
               </li>
               <li class="p-features__item">
-                <article class="p-features__card c-media-split">
+                <article class="c-media-split p-features__card">
                   <div class="c-media-split__content">
                     <span class="c-badge -accent c-media-split__badge" lang="en">Private</span>
                     <h3 class="c-media-split__title">完全個室、あなただけの空間</h3>
@@ -356,7 +356,7 @@
             <h2 id="flow-heading">ご利用の流れ</h2>
           </hgroup>
           <ol class="p-flow__list" data-stagger="fade-in-slide-up">
-            <li class="p-flow__item c-card -subtle">
+            <li class="c-card -subtle p-flow__item">
               <div class="c-text-block">
                 <h3 class="c-text-block__title">ご予約</h3>
                 <p class="c-text-block__text">
@@ -364,7 +364,7 @@
                 </p>
               </div>
             </li>
-            <li class="p-flow__item c-card -subtle">
+            <li class="c-card -subtle p-flow__item">
               <div class="c-text-block">
                 <h3 class="c-text-block__title">カウンセリング</h3>
                 <p class="c-text-block__text">
@@ -372,7 +372,7 @@
                 </p>
               </div>
             </li>
-            <li class="p-flow__item c-card -subtle">
+            <li class="c-card -subtle p-flow__item">
               <div class="c-text-block">
                 <h3 class="c-text-block__title">施術</h3>
                 <p class="c-text-block__text">
@@ -380,7 +380,7 @@
                 </p>
               </div>
             </li>
-            <li class="p-flow__item c-card -subtle">
+            <li class="c-card -subtle p-flow__item">
               <div class="c-text-block">
                 <h3 class="c-text-block__title">アフターケア</h3>
                 <p class="c-text-block__text">
@@ -388,7 +388,7 @@
                 </p>
               </div>
             </li>
-            <li class="p-flow__item c-card -subtle">
+            <li class="c-card -subtle p-flow__item">
               <div class="c-text-block">
                 <h3 class="c-text-block__title">次回のご案内</h3>
                 <p class="c-text-block__text">


### PR DESCRIPTION
## Summary

HTML の class 属性の記載順を **`l-* → c-* → -modifier → p-* → u-*`** に統一する。

修正対象: Problem × 3 + Flow × 5 + Features × 3 = 11 箇所

- `p-problem__item c-card -subtle` → `c-card -subtle p-problem__item`
- `p-flow__item c-card -subtle` → `c-card -subtle p-flow__item`
- `p-features__card c-media-split` → `c-media-split p-features__card`

## Why

現状 starter は「p- 先」と「c- 先」が混在しており一貫性がなかった。統一ルールを確立:

1. **@layer cascade 順と一致**（token < ... < layout < component < project < ... < utility）
2. **Component の primary identity を先**（Portability Test 視点で c- が主体）
3. **-modifier は対象層の直後に続ける**（c-button の modifier `-ghost` は c-button 直後）

CSS 変更なし、HTML の class 順のみ変更。視覚的差は一切発生しない。

## Test plan

- [x] `pnpm run check` 通過（prettier / stylelint / eslint / markuplint）
- [x] `pnpm run build` 成功
- [x] 機械走査（要修正パターン残存 0、新パターン期待数一致）
- [x] 全量スキャン（p- 先パターンが原則違反でない例外のみになっていることを確認）
- [ ] Cloudflare Pages preview pass（視覚差なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)