### PR TITLE
refactor(v1.0): Component 分割（c-icon-button 新設）+ c-section-heading Element 化（原則 8 U2 版適用）

### DIFF
--- a/src/assets/css/component/c-icon-button.css
+++ b/src/assets/css/component/c-icon-button.css
@@ -1,4 +1,10 @@
-.c-button {
+/*
+ * c-icon-button: アイコン + テキストのボタン Component
+ * テキストのみのボタンは c-button を使う（責任分離）。
+ * __icon は必須 Element（アイコンなしなら c-button を使うべき）。
+ * アイコン位置（右 / 左 / 両側）は HTML 順で表現（inline-flex + gap で自動配置）。
+ */
+.c-icon-button {
   --_hover-lift: -2px;
 
   display: inline-flex;
@@ -42,25 +48,8 @@
   }
 }
 
-/* c-button / c-icon-button 共通 Modifier（両 Component に同じ見た目 API を提供） */
-.c-button.-primary,
-.c-icon-button.-primary {
-  --button-color: var(--color-surface);
-  --button-bg-color: var(--color-accent);
-  --button-border-color: var(--color-accent);
-  --button-hover-bg-color: oklch(from var(--color-accent) calc(l * 1.08) c h);
-}
-
-.c-button.-ghost,
-.c-icon-button.-ghost {
-  --button-color: var(--color-main);
-  --button-bg-color: transparent;
-  --button-border-color: var(--color-main);
-  --button-hover-bg-color: oklch(from var(--color-main) l c h / 8%);
-}
-
-.c-button.-large,
-.c-icon-button.-large {
-  padding: var(--space-md) var(--space-xl);
-  font-size: var(--font-size-button-lg);
+.c-icon-button__icon {
+  flex-shrink: 0;
+  inline-size: 1em;
+  block-size: 1em;
 }

--- a/src/assets/css/component/c-section-heading.css
+++ b/src/assets/css/component/c-section-heading.css
@@ -1,15 +1,19 @@
 .c-section-heading {
   text-align: center;
+}
 
-  & > p {
-    font-size: var(--font-size-caption);
-    font-weight: var(--font-weight-heading);
-    color: var(--color-main);
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-  }
+.c-section-heading__eyebrow {
+  font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-heading);
+  color: var(--color-main);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
 
-  & > p + * {
-    margin-block-start: var(--space-sm);
-  }
+.c-section-heading__title {
+  /* スタイルなし（foundation の h2 デフォルトを継承、HTML クラスとの対応を維持） */
+}
+
+.c-section-heading__eyebrow + .c-section-heading__title {
+  margin-block-start: var(--space-sm);
 }

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -26,6 +26,7 @@
 
 /* Component */
 @import './component/c-button.css' layer(component);
+@import './component/c-icon-button.css' layer(component);
 @import './component/c-card.css' layer(component);
 @import './component/c-media-split.css' layer(component);
 @import './component/c-stat.css' layer(component);

--- a/src/index.html
+++ b/src/index.html
@@ -200,9 +200,9 @@
               は、内側から整うボディケアサロンです。
             </p>
             <div class="p-hero__actions">
-              <a href="#contact" class="c-button -primary -large p-hero__cta">
+              <a href="#contact" class="c-icon-button -primary -large p-hero__cta">
                 初回体験を予約する
-                <svg width="20" height="20" aria-hidden="true">
+                <svg class="c-icon-button__icon" width="20" height="20" aria-hidden="true">
                   <use href="./assets/images/icons/arrow-right.svg#icon" />
                 </svg>
               </a>
@@ -229,8 +229,8 @@
         <div class="l-inner p-problem__inner">
           <div class="p-problem__container">
             <hgroup class="c-section-heading p-problem__heading" data-animate="fade-in-slide-up">
-              <p lang="en">Problem</p>
-              <h2 id="problem-heading">こんな日々、続いていませんか？</h2>
+              <p class="c-section-heading__eyebrow" lang="en">Problem</p>
+              <h2 class="c-section-heading__title" id="problem-heading">こんな日々、続いていませんか？</h2>
             </hgroup>
             <ul class="p-problem__list" data-stagger="fade-in-slide-up">
               <li class="c-card -subtle p-problem__item">
@@ -268,8 +268,8 @@
         <div class="l-inner p-features__inner">
           <div class="p-features__container">
             <hgroup class="c-section-heading p-features__heading" data-animate="fade-in-slide-up">
-              <p lang="en">Features</p>
-              <h2 id="features-heading">iluha が選ばれる理由</h2>
+              <p class="c-section-heading__eyebrow" lang="en">Features</p>
+              <h2 class="c-section-heading__title" id="features-heading">iluha が選ばれる理由</h2>
             </hgroup>
             <ul class="p-features__list" data-stagger="fade-in-slide-up">
               <li class="p-features__item">
@@ -352,8 +352,8 @@
       <section class="l-section p-flow" id="flow" aria-labelledby="flow-heading">
         <div class="l-inner p-flow__inner">
           <hgroup class="c-section-heading p-flow__heading" data-animate="fade-in-slide-up">
-            <p lang="en">Flow</p>
-            <h2 id="flow-heading">ご利用の流れ</h2>
+            <p class="c-section-heading__eyebrow" lang="en">Flow</p>
+            <h2 class="c-section-heading__title" id="flow-heading">ご利用の流れ</h2>
           </hgroup>
           <ol class="p-flow__list" data-stagger="fade-in-slide-up">
             <li class="c-card -subtle p-flow__item">
@@ -405,8 +405,8 @@
       <section class="l-section p-pricing" id="pricing" aria-labelledby="pricing-heading">
         <div class="l-inner p-pricing__inner">
           <hgroup class="c-section-heading p-pricing__heading" data-animate="fade-in-slide-up">
-            <p lang="en">Pricing</p>
-            <h2 id="pricing-heading">料金表</h2>
+            <p class="c-section-heading__eyebrow" lang="en">Pricing</p>
+            <h2 class="c-section-heading__title" id="pricing-heading">料金表</h2>
           </hgroup>
 
           <!-- WHY: 幅広 table を wrapper で横スクロール可能に（Project 責務）。
@@ -454,8 +454,8 @@
         <div class="l-inner p-numbers__inner">
           <div class="p-numbers__container">
             <hgroup class="c-section-heading p-numbers__heading" data-animate="fade-in-slide-up">
-              <p lang="en">Numbers</p>
-              <h2 id="numbers-heading">実績</h2>
+              <p class="c-section-heading__eyebrow" lang="en">Numbers</p>
+              <h2 class="c-section-heading__title" id="numbers-heading">実績</h2>
             </hgroup>
             <ul class="p-numbers__list" data-stagger="fade-in-slide-up">
               <li class="c-stat p-numbers__item">
@@ -480,8 +480,8 @@
         <div class="l-inner p-voice__inner">
           <div class="p-voice__container">
             <hgroup class="c-section-heading p-voice__heading" data-animate="fade-in-slide-up">
-              <p lang="en">Voice</p>
-              <h2 id="voice-heading">お客様の声</h2>
+              <p class="c-section-heading__eyebrow" lang="en">Voice</p>
+              <h2 class="c-section-heading__title" id="voice-heading">お客様の声</h2>
             </hgroup>
             <ul class="p-voice__list" data-stagger="fade-in-slide-up">
               <li class="p-voice__item">
@@ -552,8 +552,8 @@
       <section class="l-section p-faq" id="faq" aria-labelledby="faq-heading">
         <div class="l-inner p-faq__inner">
           <hgroup class="c-section-heading p-faq__heading" data-animate="fade-in-slide-up">
-            <p lang="en">FAQ</p>
-            <h2 id="faq-heading">よくある質問</h2>
+            <p class="c-section-heading__eyebrow" lang="en">FAQ</p>
+            <h2 class="c-section-heading__title" id="faq-heading">よくある質問</h2>
           </hgroup>
           <ul class="p-faq__list" data-stagger="fade-in-slide-up">
             <li class="p-faq__item">
@@ -620,8 +620,8 @@
       <section class="l-section p-contact" id="contact" aria-labelledby="contact-heading">
         <div class="l-inner p-contact__inner">
           <hgroup class="c-section-heading p-contact__heading" data-animate="fade-in-slide-up">
-            <p lang="en">Contact</p>
-            <h2 id="contact-heading">ご予約・お問い合わせ</h2>
+            <p class="c-section-heading__eyebrow" lang="en">Contact</p>
+            <h2 class="c-section-heading__title" id="contact-heading">ご予約・お問い合わせ</h2>
           </hgroup>
           <p class="p-contact__lead">下記フォームからお気軽にどうぞ。24時間以内に折り返しご連絡いたします。</p>
 


### PR DESCRIPTION
## Summary

3 つの設計整合を統合:

1. **Component 分割**: c-button（テキストのみ）と c-icon-button（アイコン付き）に責務分離
2. **c-section-heading Element 化**: `__eyebrow` + `__title` で markup shape を CSS から documentation
3. **stylelint `block-no-empty` 確認**: コメント付き空ルールを許可は既存設定済み（`ignore: ['comments']`）

## Why

### 1. Component 分割

PR #121 で `c-button > svg` を child selector 化したが、user 指摘:「Component 分割で矛盾解消できる」。
- テキストのみ vs アイコン付きは責任が異なる
- c-icon-button の `__icon` は必須 Element（誤読リスクなし）
- アイコン位置（右 / 左 / 両側）は HTML 順で自由

Modifier（-primary / -ghost / -large）は共通セレクタ `.c-button.-primary, .c-icon-button.-primary` で DRY 維持。

### 2. c-section-heading Element 化

現状の `& > p` child selector は markup shape が CSS から読み取れない問題あり。user's U2 原則（マークアップにあるクラスは常に documentation placeholder）に沿って Element 命名化。`__title` は styling なしだが空ルール（コメント付き）で明示、markup shape を documentation。

### 3. stylelint 設定

空ルール（コメント付き）を documentation placeholder として公式容認する設定が、PR 作成前の確認で既存設定済み（`ignore: ['comments']`）と判明。変更不要。

## 確立した原則

- **原則 8（U2 版）**: マークアップにあるクラスは常に documentation placeholder。真の dead class はマークアップにも存在しないクラスのみ。
- **原則 11（補強）**: Element 命名は meaningful sub-part に対して行う。styling 要否で判定しない。optional element の場合は Component 分割で解決可能。
- **Component 分割の指針**: 責任が異なる Component は分割（c-button vs c-icon-button）。Modifier 共通化で DRY 維持。

## 変更ファイル

- `src/assets/css/component/c-icon-button.css` — 新規作成
- `src/assets/css/component/c-button.css` — `> svg` 削除、Modifier を共通セレクタへ移動
- `src/assets/css/component/c-section-heading.css` — `__eyebrow` + `__title` Element 命名
- `src/assets/css/style.css` — c-icon-button import 追加
- `src/index.html` — Hero CTA 移行 + 8 section heading Element 化

## Test plan

- [x] `pnpm run check` 通過（prettier + stylelint + eslint + markuplint 全 pass）
- [x] `pnpm run build` 成功
- [x] 機械走査:
  - c-icon-button: 2（期待 2）✅
  - c-icon-button__icon: 1（期待 1）✅
  - c-button -primary -large p-hero__cta 残存: 0（期待 0）✅
  - c-icon-button -primary -large p-hero__cta: 1（期待 1）✅
  - c-section-heading__eyebrow (HTML): 8（期待 8）✅
  - c-section-heading__title (HTML): 8（期待 8）✅
  - c-button > svg 残存 (CSS): 0（期待 0）✅
  - c-icon-button.css 存在: yes ✅
  - style.css に c-icon-button import: 1（期待 1）✅
  - c-section-heading__eyebrow (CSS): 2（期待 2）✅
  - c-section-heading__title (CSS): 2（期待 2）✅
  - 他テキストのみ c-button 箇所（header/drawer/sub-cta/cta): 全 1 ✅
- [ ] Hero CTA アイコン表示確認（サイズ、位置、hover）
- [ ] Section heading eyebrow + h2 見た目確認（全 8 section）
- [ ] Cloudflare Pages preview pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)