### PR TITLE
fix(v1.0): form バリデーションを browser native に統一（novalidate 削除、custom error 要素削除）

### DIFF
--- a/src/assets/css/component/c-form.css
+++ b/src/assets/css/component/c-form.css
@@ -90,12 +90,6 @@ textarea.c-form__input {
   margin-block-start: var(--space-xs);
 }
 
-/* Element: エラーメッセージ表示（role="alert" + hidden で JS トグル前提） */
-.c-form__error {
-  font-size: var(--font-size-caption);
-  color: var(--color-error);
-}
-
 /* Element: 送信ボタン配置ラッパー（中央寄せ default、Project 側で上書き可） */
 .c-form__actions {
   display: flex;

--- a/src/index.html
+++ b/src/index.html
@@ -626,66 +626,38 @@
           <p class="p-contact__lead">下記フォームからお気軽にどうぞ。24時間以内に折り返しご連絡いたします。</p>
 
           <!-- CUSTOMIZE: 本番バックエンド URL に差し替え。starter はフォーム送信処理を提供しません -->
-          <!-- NOTE: aria-describedby でエラーメッセージ要素を紐付け済み。JS でバリデーション時に hidden を解除し aria-invalid="true" を切り替えること -->
-          <form class="c-form p-contact__form" action="/api/contact" method="post" novalidate>
+          <form class="c-form p-contact__form" action="/api/contact" method="post">
             <!-- 氏名 -->
             <div class="c-form__field">
               <label for="name" class="c-form__label">お名前</label>
-              <input
-                type="text"
-                id="name"
-                name="name"
-                class="c-form__input"
-                required
-                autocomplete="name"
-                aria-describedby="name-error"
-              />
-              <p id="name-error" class="c-form__error" role="alert" hidden>お名前を入力してください。</p>
+              <input type="text" id="name" name="name" class="c-form__input" required autocomplete="name" />
             </div>
 
             <!-- メール -->
             <div class="c-form__field">
               <label for="email" class="c-form__label">メールアドレス</label>
-              <input
-                type="email"
-                id="email"
-                name="email"
-                class="c-form__input"
-                required
-                autocomplete="email"
-                aria-describedby="email-error"
-              />
-              <p id="email-error" class="c-form__error" role="alert" hidden>メールアドレスの形式が正しくありません。</p>
+              <input type="email" id="email" name="email" class="c-form__input" required autocomplete="email" />
             </div>
 
             <!-- 電話番号 -->
             <div class="c-form__field">
               <label for="tel" class="c-form__label">電話番号</label>
-              <input
-                type="tel"
-                id="tel"
-                name="tel"
-                class="c-form__input"
-                autocomplete="tel"
-                aria-describedby="tel-error"
-              />
-              <p id="tel-error" class="c-form__error" role="alert" hidden>電話番号の形式が正しくありません。</p>
+              <input type="tel" id="tel" name="tel" class="c-form__input" autocomplete="tel" />
             </div>
 
             <!-- お問い合わせ種別 -->
             <div class="c-form__field">
               <label for="category" class="c-form__label">お問い合わせ種別</label>
-              <select id="category" name="category" class="c-form__input" required aria-describedby="category-error">
+              <select id="category" name="category" class="c-form__input" required>
                 <option value="">選択してください</option>
                 <option value="reservation">初回体験の予約</option>
                 <option value="inquiry">施術に関するお問い合わせ</option>
                 <option value="other">その他</option>
               </select>
-              <p id="category-error" class="c-form__error" role="alert" hidden>お問い合わせ種別を選択してください。</p>
             </div>
 
             <!-- プラン選択 -->
-            <fieldset class="c-form__field" aria-describedby="plan-error">
+            <fieldset class="c-form__field">
               <legend class="c-form__legend">ご希望のプラン</legend>
               <div class="c-form__choice-group">
                 <label class="c-form__choice-label">
@@ -701,30 +673,20 @@
                   リラクゼーション（90分）
                 </label>
               </div>
-              <p id="plan-error" class="c-form__error" role="alert" hidden>ご希望のプランを選択してください。</p>
             </fieldset>
 
             <!-- メッセージ -->
             <div class="c-form__field">
               <label for="message" class="c-form__label">メッセージ</label>
-              <textarea
-                id="message"
-                name="message"
-                class="c-form__input"
-                required
-                rows="6"
-                aria-describedby="message-error"
-              ></textarea>
-              <p id="message-error" class="c-form__error" role="alert" hidden>メッセージを入力してください。</p>
+              <textarea id="message" name="message" class="c-form__input" required rows="6"></textarea>
             </div>
 
             <!-- 同意確認 -->
             <div class="c-form__field">
               <label class="c-form__choice-label">
-                <input type="checkbox" name="agree" id="agree" required aria-describedby="agree-error" />
+                <input type="checkbox" name="agree" id="agree" required />
                 <a href="/privacy/">プライバシーポリシー</a>に同意する
               </label>
-              <p id="agree-error" class="c-form__error" role="alert" hidden>プライバシーポリシーへの同意が必要です。</p>
             </div>
 
             <!-- 送信 -->


### PR DESCRIPTION
## Summary

form の `novalidate` 属性と JS 前提の custom error elements（`<p class="c-form__error">` × 7）、`aria-describedby` 参照を削除し、HTML5 ブラウザネイティブバリデーションに統一する。

## Why

- 現状: `novalidate` でブラウザ検証無効化 + JS バリデーション未実装 → 送信ボタン押下で画面遷移（バグ）
- starter ではカスタムバリデーションを実装しない方針（しゅんえい判断、2026-04-23）
  - シンプル志向 + 教材性優先
  - 実案件でカスタム UX が必要な場合はユーザー（開発者）が個別実装
- `required` / `type="email"` 等は保持、ブラウザが native で検証・エラー表示

## 変更

- `<form novalidate>` → `<form>`（1 箇所）
- L629 の JS 前提コメント（aria-describedby / hidden / aria-invalid 切替案内）削除
- `<p id="xxx-error" class="c-form__error" role="alert" hidden>` 削除（7 箇所）
- `aria-describedby="xxx-error"` 削除（7 箇所）
- `.c-form__error { ... }` CSS ルール削除

## 保持

- HTML5 native バリデーション（`required`, `type="email"`, `type="tel"`）
- フォーム構造（`c-form__field` / `c-form__label` / `c-form__input` / `c-form__choice-group` 等）
- `p-contact__form` Element 併記
- `--color-error` 変数（required マーク・`:user-invalid` で引き続き使用）

## 機械走査

| チェック項目 | 結果 | 期待 |
|---|---|---|
| novalidate 残存 | 0 | 0 ✅ |
| c-form__error (HTML) | 0 | 0 ✅ |
| c-form__error (CSS) | 0 | 0 ✅ |
| aria-describedby (form 関連) | 0 | 0 ✅ |
| required 保持 | 6 | 6 ✅ |
| type="email" | 1 | 1 ✅ |
| type="tel" | 1 | 1 ✅ |

※ 仕様書の「期待: 7」はリスト本文（6 項目）と乖離した誤記。実際の required 数は 6 が正しい。

## Test plan

- [x] `pnpm run check` 通過（prettier / stylelint / eslint / markuplint 全通過）
- [x] `pnpm run build` 成功
- [x] 機械走査（全指標 ✅）
- [ ] ブラウザで空送信テスト → native エラー表示確認
- [ ] ブラウザで email 不正テスト → native エラー表示確認
- [ ] ブラウザで全入力送信 → POST 実行確認（/api/contact 未実装のため 404 遷移が期待動作）
- [ ] Cloudflare Pages preview pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)