### PR TITLE
fix(v1.0): Hero 画像 alt 改善 + viewport.js 意図コメント追加

### DIFF
--- a/public/scripts/viewport.js
+++ b/public/scripts/viewport.js
@@ -1,3 +1,22 @@
+/**
+ * viewport 最小幅制御（早期実行が必要）
+ *
+ * 目的:
+ * - 極小画面（outerWidth ≤ VIEWPORT_MIN）で viewport を固定幅にする
+ * - VIEWPORT_MIN 以上ではレスポンシブ動作（device-width）に戻す
+ * - CSS の `--viewport-min` と値を同期し、レイアウト崩れを防ぐ
+ *
+ * なぜ head で blocking 実行か:
+ * - 描画開始前に viewport の content を確定する必要がある
+ * - defer / async にすると初回レンダリング後に viewport が変わり CLS が発生する
+ * - ResizeObserver で resize にも追従するため、初期値だけでなく継続的に更新
+ *
+ * CUSTOMIZE:
+ * - VIEWPORT_MIN の値は token/structure.css の `--viewport-min` と必ず一致させる
+ * - 最小幅制限が不要なサイト（全幅でレスポンシブ対応済み）は
+ *   <script src="/scripts/viewport.js"> および ResizeObserver ごと削除可
+ */
+
 // CUSTOMIZE: must match --viewport-min in token/structure.css
 const VIEWPORT_MIN = 400;
 const meta = document.querySelector('meta[name="viewport"]');

--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- 描画前に viewport 最小幅を確定する必要があるため head で blocking 実行 -->
     <script src="/scripts/viewport.js"></script>
     <meta name="format-detection" content="telephone=no,address=no,email=no" />
     <!-- CUSTOMIZE: ダークモード不要なら content="light" に -->
@@ -214,7 +215,7 @@
         <div class="p-hero__media">
           <img
             src="./assets/images/hero-main.webp"
-            alt="サロン内観のイメージ"
+            alt="完全個室のサロン内観"
             width="1440"
             height="720"
             loading="eager"


### PR DESCRIPTION
## Summary

5 軸マークアップレビューの検出事項 2 件を修正。

1. **Hero 画像 alt 改善**: 「〜のイメージ」の冗長表現を削除
2. **viewport.js 意図コメント追加**: JS 側に doc コメント、HTML 側に簡潔コメント

## Why

### 1. Hero alt 改善

「〜のイメージ」「〜の画像」は alt 冗長表現。スクリーンリーダーが「画像、サロン内観のイメージ」と二重読み上げ、Google SEO 的にも不要（`<img>` tag 自体で「画像」の情報は伝わる）。

変更: `"サロン内観のイメージ"` → `"完全個室のサロン内観"`

### 2. viewport.js コメント

`<script src="/scripts/viewport.js">` が head で blocking 実行されている理由が不明瞭だった。

**実装の正確な目的**:
- 極小画面（outerWidth ≤ VIEWPORT_MIN: 400）で viewport を固定幅にする
- `--viewport-min` CSS トークンと値を同期し、レイアウト崩れを防ぐ
- 描画前に確定が必要なため head blocking 実行（defer/async だと CLS 発生）

JS 側（doc comment）+ HTML 側（簡潔コメント）で意図を明記。教材性重視の starter として、head blocking script の「なぜ」を示すことが重要。

なお、プロンプトでは「100vh 問題 / `--vh` 変数」との説明があったが、実際の実装は **viewport 最小幅制御**のため、実装に合わせた正確なコメントを記述。

## Test plan

- [x] `pnpm run check` 通過（format / lint:css / lint:js / lint:html 全合格）
- [x] `pnpm run build` 成功
- [x] hero alt 旧テキスト「〜のイメージ」残存: 0（grep 確認）
- [x] hero alt 新テキスト「完全個室のサロン内観」: 1（grep 確認）
- [x] HTML viewport コメント追加: 1（grep 確認）
- [x] JS viewport doc コメント追加: 1（grep 確認）
- [ ] ブラウザでレンダリング確認（視覚差なし、コメント追加のみ）
- [ ] Cloudflare Pages preview pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)