### PR TITLE
refactor(v1.0): CSS 定義順を HTML 登場順に統一（style.css 4 箇所 + 5 CSS ファイル内）

### DIFF
--- a/src/assets/css/project/p-features.css
+++ b/src/assets/css/project/p-features.css
@@ -2,12 +2,12 @@
   /* スタイルなし（HTML クラスとの対応を維持） */
 }
 
-.p-features__container {
-  container-type: inline-size;
-}
-
 .p-features__inner {
   /* スタイルなし（HTML クラスとの対応を維持） */
+}
+
+.p-features__container {
+  container-type: inline-size;
 }
 
 .p-features__heading {

--- a/src/assets/css/project/p-hero.css
+++ b/src/assets/css/project/p-hero.css
@@ -30,6 +30,14 @@
   font-size: var(--font-size-lead);
 }
 
+.p-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  justify-content: center;
+  margin-block-start: var(--space-sm);
+}
+
 .p-hero__cta {
   /* スタイルなし（HTML クラスとの対応を維持） */
 }
@@ -38,14 +46,6 @@
   /* WHY: Hero 背景のグラデーション上でもテキストとボーダーの可読性を確保するため、ダークモード時は text 色に寄せる。c-button 公開 API 経由で注入し、プロパティ直上書きを避ける */
   --button-color: light-dark(var(--color-main), var(--color-text));
   --button-border-color: light-dark(var(--color-main), var(--color-text));
-}
-
-.p-hero__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-md);
-  justify-content: center;
-  margin-block-start: var(--space-sm);
 }
 
 .p-hero__media {

--- a/src/assets/css/project/p-numbers.css
+++ b/src/assets/css/project/p-numbers.css
@@ -5,12 +5,12 @@
   background-color: var(--color-bg-secondary);
 }
 
-.p-numbers__container {
-  container-type: inline-size;
-}
-
 .p-numbers__inner {
   /* スタイルなし（HTML クラスとの対応を維持） */
+}
+
+.p-numbers__container {
+  container-type: inline-size;
 }
 
 .p-numbers__heading {

--- a/src/assets/css/project/p-problem.css
+++ b/src/assets/css/project/p-problem.css
@@ -3,12 +3,12 @@
   --section-padding-max: var(--section-narrow-max);
 }
 
-.p-problem__container {
-  container-type: inline-size;
-}
-
 .p-problem__inner {
   /* スタイルなし（HTML クラスとの対応を維持） */
+}
+
+.p-problem__container {
+  container-type: inline-size;
 }
 
 .p-problem__heading {

--- a/src/assets/css/project/p-voice.css
+++ b/src/assets/css/project/p-voice.css
@@ -2,12 +2,12 @@
   /* スタイルなし（HTML クラスとの対応を維持） */
 }
 
-.p-voice__container {
-  container-type: inline-size;
-}
-
 .p-voice__inner {
   /* スタイルなし（HTML クラスとの対応を維持） */
+}
+
+.p-voice__container {
+  container-type: inline-size;
 }
 
 .p-voice__heading {

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -43,7 +43,7 @@
 @import './component/c-overlay.css' layer(component);
 @import './component/c-form.css' layer(component);
 
-/* Project */
+/* Project - HTML 登場順 */
 @import './project/p-header.css' layer(project);
 @import './project/p-drawer.css' layer(project);
 @import './project/p-hero.css' layer(project);
@@ -53,10 +53,12 @@
 @import './project/p-pricing.css' layer(project);
 @import './project/p-numbers.css' layer(project);
 @import './project/p-voice.css' layer(project);
-@import './project/p-faq.css' layer(project);
 @import './project/p-cta.css' layer(project);
-@import './project/p-footer.css' layer(project);
+@import './project/p-faq.css' layer(project);
 @import './project/p-contact.css' layer(project);
+@import './project/p-footer.css' layer(project);
+
+/* index.html 以外のページで使用 */
 @import './project/p-privacy.css' layer(project);
 @import './project/p-not-found.css' layer(project);
 


### PR DESCRIPTION
## Summary

CSS の定義順を HTML 登場順（DOM 外→内）に揃える。教材性 + 保守性向上、機能影響なし。

### 変更範囲

1. **style.css** @import 順: Project セクションの 2 組の逆転を修正
   - `p-faq ↔ p-cta` の入れ替え
   - `p-footer ↔ p-contact` の入れ替え

2. **各 CSS ファイル内のセレクタ順** を HTML 登場順に修正:
   - `p-hero.css`: `__actions` を `__cta`/`__sub-cta` の前に
   - `p-problem.css`: `__inner` を `__container` の前に
   - `p-features.css`: 同上
   - `p-numbers.css`: 同上
   - `p-voice.css`: 同上

## Why

### 教材性
- HTML を読みながら対応 CSS を順次参照できる
- 新規 section 追加時の配置位置が明確（迷わない）

### 保守性
- 単一ルール「CSS は HTML 登場順」で決定、属人的判断不要

### 機能影響
- ゼロ。`@layer` で全 Project rule が同じ cascade layer、import 順は影響なし
- 各 CSS ファイル内も、セレクタ間の特異性（specificity）は変わらず

### p-contact.css __form 2 回出現
- line 21（`.p-contact__form` — Element 定義）と line 32（`.p-contact__form a` — 子孫セレクタ）
- nested selector / 子孫セレクタの正常使用。順序違反なし、変更不要

## Test plan

- [x] `pnpm run check` 通過（stylelint / eslint / markuplint 全通過）
- [x] `pnpm run build` 成功
- [x] style.css @import 順が HTML 登場順に一致
- [x] 各 CSS ファイルのセレクタ順が HTML 登場順に一致（grep 確認済み）
- [ ] ブラウザでレンダリング確認（視覚差なし）
- [ ] Cloudflare Pages preview pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)