### PR TITLE
refactor(v1.0): コメント精査（原則は spec、教育は書籍に任せる方針）

### DIFF
--- a/src/assets/css/component/c-button.css
+++ b/src/assets/css/component/c-button.css
@@ -9,9 +9,6 @@
   font-size: inherit;
   font-weight: var(--font-weight-heading);
   line-height: var(--line-height-title);
-
-  /* WHY: 色系は公開 API 経由でモディファイア・Project から注入。ベースには default を置かず、モディファイア未指定だと無色となる設計（誤用を設計段階で顕在化させる）。
-     API 命名は spec §6「公開 API: --{対象}-{名前}」に準拠（プレフィックス c- / p- / l- は含まない）。 */
   color: var(--button-color);
   text-decoration: none;
   cursor: pointer;
@@ -42,7 +39,7 @@
   }
 }
 
-/* c-button / c-icon-button 共通 Modifier（両 Component に同じ見た目 API を提供） */
+/* c-button / c-icon-button 共通 Modifier */
 .c-button.-primary,
 .c-icon-button.-primary {
   --button-color: var(--color-surface);

--- a/src/assets/css/component/c-card.css
+++ b/src/assets/css/component/c-card.css
@@ -16,9 +16,7 @@
   border-radius: var(--card-radius, var(--radius-md));
   box-shadow: var(--card-shadow, var(--shadow-sm) var(--color-shadow));
 
-  /* WHY: 影を落とさず背景のみで区切る控えめバリエーション。グレーの面で情報をまとめたい
-     場面（Problem セクション等）向け。公開 API 経由で値セットすることで、プロパティ直上書き
-     を避け、Project 側からも同じ差し替え手順で拡張できる。 */
+  /* 控えめバリエーション（影なし、背景のみで区切る） */
   &.-subtle {
     --card-bg: var(--color-bg-secondary);
     --card-shadow: none;

--- a/src/assets/css/component/c-form.css
+++ b/src/assets/css/component/c-form.css
@@ -60,20 +60,18 @@ fieldset.c-form__field {
     border-color: var(--color-main);
   }
 
-  /* :user-invalid: ユーザー操作後のみ invalid 表示（初期表示で赤枠を出さない） */
   &:user-invalid {
     border-color: var(--color-error);
   }
 }
 
-/* textarea は自動リサイズ + 下限/上限行数を指定（field-sizing は Chrome 123+ / Safari 17.4+） */
 textarea.c-form__input {
   field-sizing: content;
   min-block-size: 10lh;
   max-block-size: 20lh;
 }
 
-/* Element: radio / checkbox ラベル（両用、WCAG 2.5.5 Target Size AAA 相当のタップ領域確保） */
+/* Element: radio / checkbox ラベル（両用） */
 .c-form__choice-label {
   display: flex;
   gap: var(--space-sm);

--- a/src/assets/css/component/c-icon-button.css
+++ b/src/assets/css/component/c-icon-button.css
@@ -15,9 +15,6 @@
   font-size: inherit;
   font-weight: var(--font-weight-heading);
   line-height: var(--line-height-title);
-
-  /* WHY: 色系は公開 API 経由でモディファイア・Project から注入。ベースには default を置かず、モディファイア未指定だと無色となる設計（誤用を設計段階で顕在化させる）。
-     API 命名は spec §6「公開 API: --{対象}-{名前}」に準拠（プレフィックス c- / p- / l- は含まない）。 */
   color: var(--button-color);
   text-decoration: none;
   cursor: pointer;

--- a/src/assets/css/foundation/form.css
+++ b/src/assets/css/foundation/form.css
@@ -39,7 +39,6 @@
   cursor: pointer;
   border: var(--border-width) solid var(--color-border);
 
-  /* WHY: OS のモーション低減設定を尊重。c-button / c-form 等と一貫して transition をガード */
   @media (prefers-reduced-motion: no-preference) {
     transition: border-color var(--duration-fast) var(--ease-out-cubic);
   }

--- a/src/assets/css/layout/l-section.css
+++ b/src/assets/css/layout/l-section.css
@@ -3,7 +3,5 @@
   --section-padding-max: var(--section-standard-max);
 
   padding-block: clamp(var(--section-padding-min), 3.462vi + 3.1346rem, var(--section-padding-max));
-
-  /* WHY: 固定ヘッダー分のオフセット。アンカーリンク（#features 等）で飛んだ際、セクション冒頭がヘッダーに被らないようにする */
   scroll-margin-block-start: var(--header-size);
 }

--- a/src/index.html
+++ b/src/index.html
@@ -32,12 +32,10 @@
     <meta property="og:site_name" content="iluha" />
     <meta property="og:locale" content="ja_JP" />
     <meta name="twitter:card" content="summary_large_image" />
-    <!-- NOTE: twitter:title / twitter:description / twitter:image は未設定の場合 og:* が fallback として使われるため省略 -->
     <!-- Favicon -->
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <!-- Hero LCP 最適化: 早期発見のため preload -->
     <link rel="preload" as="image" href="/assets/images/hero-main.webp" fetchpriority="high" />
     <!-- Styles -->
     <link rel="stylesheet" href="/assets/css/style.css" />
@@ -410,9 +408,8 @@
             <h2 class="c-section-heading__title" id="pricing-heading">料金表</h2>
           </hgroup>
 
-          <!-- WHY: 幅広 table を wrapper で横スクロール可能に（Project 責務）。
-               Component 化しない理由: min-inline-size はコンテンツ依存。
-               a11y 3 点セット: role="region" + 固有の aria-label（section landmark「料金表」と重複しない一意の accessible name）+ tabindex="0"（キーボードで矢印スクロール可能） -->
+          <!-- Component 化しない: min-inline-size はコンテンツ依存 -->
+          <!-- a11y: role="region" + aria-label + tabindex="0" -->
           <div class="p-pricing__table-wrapper" tabindex="0" aria-label="料金表スクロール領域" role="region">
             <table class="c-table p-pricing__table">
               <caption class="u-visually-hidden">


### PR DESCRIPTION
## Summary

starter のコメントを精査し、「原則は spec、教育は書籍に任せる」方針に沿って説明的 / 教育的コメントを削除または短縮。

### 削除（spec/書籍の領域）

- `c-button.css` / `c-icon-button.css` の公開 API 設計思想 WHY
- `l-section.css` の固定ヘッダーオフセット WHY
- `foundation/form.css` の reduced-motion WHY
- `c-form.css` の `:user-invalid` / `field-sizing` 挙動解説
- `index.html` L35 Twitter Card fallback NOTE
- `index.html` L40 Hero LCP 最適化コメント

### 短縮

- `c-button.css` Modifier 共通化（余分な「両 Component に ... 提供」削除）
- `c-card.css` -subtle Modifier 意図
- `c-form.css` WCAG 2.5.5 根拠削除
- `index.html` table wrapper 長大コメント → 2 行

### 残す確定

- CUSTOMIZE 系、DEVIATION、空ルール placeholder、BEM 命名、運用注意、公開 API 明示、構造セクションラベル

## Why

starter の責任境界明確化:
- **spec**: 原則・仕様記述
- **書籍**: 教育・解説・WHY
- **starter のコード**: 実装 + starter 特有情報（CUSTOMIZE / DEVIATION / 運用）

設計思想や一般原則のコメントは重複するため削除、starter 固有情報のみ残す。

## Test plan

- [x] `pnpm run check` 通過
- [x] `pnpm run build` 成功
- [x] 削除対象コメントの grep 確認（全 0）
- [x] 残す確定コメントが維持されていること
- [ ] ブラウザでレンダリング確認（視覚差なし）
- [ ] Cloudflare Pages preview pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)