### PR TITLE
refactor(v1.0): Pricing table wrapper の意味不明コメント削除

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -408,8 +408,6 @@
             <h2 class="c-section-heading__title" id="pricing-heading">料金表</h2>
           </hgroup>
 
-          <!-- Component 化しない: min-inline-size はコンテンツ依存 -->
-          <!-- a11y: role="region" + aria-label + tabindex="0" -->
           <div class="p-pricing__table-wrapper" tabindex="0" aria-label="料金表スクロール領域" role="region">
             <table class="c-table p-pricing__table">
               <caption class="u-visually-hidden">


### PR DESCRIPTION
## Summary

Pricing セクションの table wrapper に残っていた短縮コメント 2 行を削除。

削除:
- `<!-- Component 化しない: min-inline-size はコンテンツ依存 -->`
- `<!-- a11y: role="region" + aria-label + tabindex="0" -->`

## Why

PR #129 で長大コメントを短縮したが、文脈を失って意味不明になっていた。HTML 属性（`role="region"` / `aria-label` / `tabindex="0"`）と命名（`p-pricing__table-wrapper`）が self-documenting のため、コメント不要。

「原則は spec、教育は書籍に任せる」方針に厳格整合。Component 化判断の記録は memory 側で保持済。

## Test plan

- [x] `pnpm run check` 通過
- [x] `pnpm run build` 成功
- [x] 対象コメント削除確認
- [x] wrapper 要素自体は維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)