### PR TITLE
refactor(v1.0): c-icon-button 自己完結化（c-button 依存解消）+ 冒頭コメント削除

### DIFF
--- a/src/assets/css/component/c-button.css
+++ b/src/assets/css/component/c-button.css
@@ -39,25 +39,21 @@
   }
 }
 
-/* c-button / c-icon-button 共通 Modifier */
-.c-button.-primary,
-.c-icon-button.-primary {
+.c-button.-primary {
   --button-color: var(--color-surface);
   --button-bg-color: var(--color-accent);
   --button-border-color: var(--color-accent);
   --button-hover-bg-color: oklch(from var(--color-accent) calc(l * 1.08) c h);
 }
 
-.c-button.-ghost,
-.c-icon-button.-ghost {
+.c-button.-ghost {
   --button-color: var(--color-main);
   --button-bg-color: transparent;
   --button-border-color: var(--color-main);
   --button-hover-bg-color: oklch(from var(--color-main) l c h / 8%);
 }
 
-.c-button.-large,
-.c-icon-button.-large {
+.c-button.-large {
   padding: var(--space-md) var(--space-xl);
   font-size: var(--font-size-button-lg);
 }

--- a/src/assets/css/component/c-icon-button.css
+++ b/src/assets/css/component/c-icon-button.css
@@ -1,9 +1,3 @@
-/*
- * c-icon-button: アイコン + テキストのボタン Component
- * テキストのみのボタンは c-button を使う（責任分離）。
- * __icon は必須 Element（アイコンなしなら c-button を使うべき）。
- * アイコン位置（右 / 左 / 両側）は HTML 順で表現（inline-flex + gap で自動配置）。
- */
 .c-icon-button {
   --_hover-lift: -2px;
 
@@ -49,4 +43,23 @@
   flex-shrink: 0;
   inline-size: 1em;
   block-size: 1em;
+}
+
+.c-icon-button.-primary {
+  --button-color: var(--color-surface);
+  --button-bg-color: var(--color-accent);
+  --button-border-color: var(--color-accent);
+  --button-hover-bg-color: oklch(from var(--color-accent) calc(l * 1.08) c h);
+}
+
+.c-icon-button.-ghost {
+  --button-color: var(--color-main);
+  --button-bg-color: transparent;
+  --button-border-color: var(--color-main);
+  --button-hover-bg-color: oklch(from var(--color-main) l c h / 8%);
+}
+
+.c-icon-button.-large {
+  padding: var(--space-md) var(--space-xl);
+  font-size: var(--font-size-button-lg);
 }


### PR DESCRIPTION
## Summary

c-icon-button が c-button.css に依存している問題を解消。各 Component に独自の Modifier 定義を持たせ、完全自己完結化。合わせて冒頭の説明コメント削除。

### 変更

- `c-button.css`: 共通 Modifier セレクタ（`.c-button.-primary, .c-icon-button.-primary`）を `.c-button.-primary` のみに戻す
- `c-icon-button.css`: 冒頭説明コメント削除、Modifier 定義（-primary / -ghost / -large）を自 Component 内に追加

## Why

### 自己完結化

PR #123 で Component 分離した際、共通 Modifier を `c-button.css` に両方のセレクタを併記して DRY 維持したが、これは c-icon-button が c-button.css に依存する状態。Portability Test の厳密解釈では不整合。

解決: 各 Component 内に独自の Modifier 定義を持つ。10 行弱の DRY 違反は自己完結性を優先して許容。値は Custom Property 経由（`--button-bg-color: var(--color-accent)` 等）で semantic token 参照のため、**実質的な重複は semantic token のマッピングのみ**。

### コメント削除

冒頭の説明コメントは class 名（c-icon-button）+ Element 定義（__icon）+ CSS 実装から自明。「原則は spec、教育は書籍に任せる」方針に整合。

## Test plan

- [x] `pnpm run check` 通過
- [x] `pnpm run build` 成功
- [x] c-button.css から c-icon-button 言及削除確認（grep: 0 件）
- [x] c-button.css の「共通 Modifier」コメント削除確認（grep: 0 件）
- [x] c-icon-button.css 冒頭コメント削除確認（grep: 0 件）
- [x] c-icon-button.css に Modifier 独自定義確認（-primary / -ghost / -large 各 1 件）
- [x] c-button.css の Modifier は c-button のみで維持（-primary / -ghost / -large 各 1 件）
- [ ] ブラウザで Hero CTA（c-icon-button）/ Header CTA（c-button）/ sub-cta の視覚確認（変わらないこと）
- [ ] Cloudflare Pages preview pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)