### PR TITLE
refactor(v1.0): コメント精査第2弾（HTML 9 + CSS 10 箇所の削除/短縮）

### DIFF
--- a/src/assets/css/component/c-card.css
+++ b/src/assets/css/component/c-card.css
@@ -1,14 +1,10 @@
-/* Block: 装飾だけを担う汎用カード（padding + bg + radius + shadow + border のガワ）。
-   中身の構造（タイトル・本文・メディア配置 等）は持たず、c-text-block / c-media-split 等と
-   併記して組み合わせる。
-
-   public API: Project 側で値を注入して見た目を切り替える。
-     --card-padding (default: var(--space-lg))
-     --card-bg      (default: var(--color-surface))
-     --card-radius  (default: var(--radius-md))
-     --card-shadow  (default: var(--shadow-sm) var(--color-shadow))
-     --card-border  (default: none)
-   命名は spec §6「公開 API: --{対象}-{名前}」に準拠（プレフィックス c- / p- / l- は含まない）。 */
+/* Block: 装飾だけを担う汎用カード（c-text-block / c-media-split 等と併記）
+   公開 API:
+     --card-padding  (default: var(--space-lg))
+     --card-bg       (default: var(--color-surface))
+     --card-radius   (default: var(--radius-md))
+     --card-shadow   (default: var(--shadow-sm) var(--color-shadow))
+     --card-border   (default: none) */
 .c-card {
   padding: var(--card-padding, var(--space-lg));
   background-color: var(--card-bg, var(--color-surface));

--- a/src/assets/css/component/c-form.css
+++ b/src/assets/css/component/c-form.css
@@ -1,6 +1,5 @@
-/* Block: フォーム全体の縦並びレイアウト（max-inline-size / margin 等の外部配置は Project 側で制御）
-   公開 API: Project 側で送信ボタン前の余白を調整できるよう --form-actions-margin-top を露出（§7）。
-   命名は §6「--{対象}-{名前}」に準拠（c- プレフィックスは含めない） */
+/* Block: フォーム全体の縦並びレイアウト
+   公開 API: --form-actions-margin-top（送信ボタン前の余白） */
 .c-form {
   --form-actions-margin-top: var(--space-md);
 
@@ -16,7 +15,6 @@
   gap: var(--space-xs);
 }
 
-/* fieldset として使う時の default 装飾リセット（border / padding / margin を無効化し、div と等価な箱に整える） */
 fieldset.c-form__field {
   padding: 0;
   margin: 0;
@@ -32,9 +30,7 @@ fieldset.c-form__field {
   font-weight: var(--font-weight-heading);
 }
 
-/* 必須マーク: Project 側が --form-required-mark を上書きすればサイトごとに表現（「*」→「必須」等）を切替可能。
-   API 命名は spec §6「公開 API: --{対象}-{名前}」に準拠（プレフィックス c- / p- / l- は含まない）。
-   空白は content に含めず gap: 0.25em で視覚的に担保する（コピペ・a11y 読み上げへの混入を回避） */
+/* 必須マーク: --form-required-mark で「*」→「必須」等に切替可能（公開 API） */
 .c-form__field:has(:required) > .c-form__label::after,
 .c-form__field:has(:required) > .c-form__legend::after {
   color: var(--color-error);
@@ -50,7 +46,6 @@ fieldset.c-form__field {
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--radius-sm);
 
-  /* prefers-reduced-motion: transition を抑制してアニメ酔い対策 */
   @media (prefers-reduced-motion: no-preference) {
     transition: border-color var(--duration-normal) var(--ease-out-cubic);
   }

--- a/src/assets/css/component/c-media-split.css
+++ b/src/assets/css/component/c-media-split.css
@@ -1,10 +1,5 @@
-/* Block: 画像 + コンテンツの 2 カラムレイアウトパターン（card 装飾は持たない）。
-   装飾（padding / bg / radius / shadow）が必要な文脈では c-card と併記して組み合わせる。
-   命名は「card＝装飾込みコンテンツボックス」と区別して "-split"（分割レイアウト）を採用。
-
-   public API: Project 側で `--media-split-first-order: 2` を指定すると、インライン方向で
-   一定幅以上のときに左右（画像と content）の配置を反転できる（`:nth-child(even)` 等で活用）。
-   API 命名は spec §6「公開 API: --{対象}-{名前}」に準拠（プレフィックス c- / p- / l- は含まない）。 */
+/* Block: 画像 + コンテンツの 2 カラムレイアウトパターン
+   公開 API: --media-split-first-order で左右反転（`:nth-child(even)` 等で活用） */
 .c-media-split {
   --_order: var(--media-split-first-order, 0);
 

--- a/src/assets/css/component/c-table.css
+++ b/src/assets/css/component/c-table.css
@@ -1,5 +1,3 @@
-/* Block: 汎用 table ビジュアル（行ごとの罫線・ヘッダーセル装飾）。
-   幅制御（inline-size / min-inline-size）や横スクロール wrapper はコンテンツ依存のため Project に委ねる */
 .c-table {
   inline-size: 100%;
   border-collapse: collapse;

--- a/src/assets/css/token/space.css
+++ b/src/assets/css/token/space.css
@@ -8,7 +8,7 @@
   --space-2xl: calc(48 * var(--px));
   --space-3xl: calc(64 * var(--px));
 
-  /* fluid 中間 tokens（SP/PC で値が変わる場面で使用。viewport 400→1440 で線形補間） */
+  /* fluid 中間 tokens（SP/PC で値が変わる場面で使用） */
   --space-xl-2xl: clamp(var(--space-xl), 1.538vi + 1.615rem, var(--space-2xl));
   --space-2xl-3xl: clamp(var(--space-2xl), 1.538vi + 2.615rem, var(--space-3xl));
 }

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- 描画前に viewport 最小幅を確定する必要があるため head で blocking 実行 -->
     <script src="/scripts/viewport.js"></script>
     <meta name="format-detection" content="telephone=no,address=no,email=no" />
     <!-- CUSTOMIZE: ダークモード不要なら content="light" に -->
@@ -623,25 +622,21 @@
 
           <!-- CUSTOMIZE: 本番バックエンド URL に差し替え。starter はフォーム送信処理を提供しません -->
           <form class="c-form p-contact__form" action="/api/contact" method="post">
-            <!-- 氏名 -->
             <div class="c-form__field">
               <label class="c-form__label" for="name">お名前</label>
               <input class="c-form__input" id="name" name="name" type="text" autocomplete="name" required />
             </div>
 
-            <!-- メール -->
             <div class="c-form__field">
               <label class="c-form__label" for="email">メールアドレス</label>
               <input class="c-form__input" id="email" name="email" type="email" autocomplete="email" required />
             </div>
 
-            <!-- 電話番号 -->
             <div class="c-form__field">
               <label class="c-form__label" for="tel">電話番号</label>
               <input class="c-form__input" id="tel" name="tel" type="tel" autocomplete="tel" />
             </div>
 
-            <!-- お問い合わせ種別 -->
             <div class="c-form__field">
               <label class="c-form__label" for="category">お問い合わせ種別</label>
               <select class="c-form__input" id="category" name="category" required>
@@ -652,7 +647,6 @@
               </select>
             </div>
 
-            <!-- プラン選択 -->
             <fieldset class="c-form__field">
               <legend class="c-form__legend">ご希望のプラン</legend>
               <div class="c-form__choice-group">
@@ -671,13 +665,11 @@
               </div>
             </fieldset>
 
-            <!-- メッセージ -->
             <div class="c-form__field">
               <label class="c-form__label" for="message">メッセージ</label>
               <textarea class="c-form__input" id="message" name="message" rows="6" required></textarea>
             </div>
 
-            <!-- 同意確認 -->
             <div class="c-form__field">
               <label class="c-form__choice-label">
                 <input id="agree" name="agree" type="checkbox" required />
@@ -685,7 +677,6 @@
               </label>
             </div>
 
-            <!-- 送信 -->
             <div class="c-form__actions">
               <button class="c-button -primary -large" type="submit">送信する</button>
             </div>


### PR DESCRIPTION
## Summary

PR #129, #131 に続くコメント精査。HTML / CSS に残る説明的・冗長コメントを削除または短縮。

### 削除

- `index.html`: viewport 用コメント + フォームフィールドセクションコメント 8 箇所
- `c-form.css`: fieldset default 装飾リセット解説、prefers-reduced-motion 解説
- `c-table.css`: Block 説明（全削除、CSS が self-documenting）

### 短縮

- `c-form.css`: Block 説明（3 行 → 2 行）、必須マーク（3 行 → 1 行）
- `c-card.css`: Block 説明（11 行 → 6 行、公開 API 列挙のみ）
- `c-media-split.css`: Block 説明（7 行 → 2 行、カード併記の説明は c-card に委譲）
- `token/space.css`: fluid tokens（具体値「400→1440」削除、将来変わりうる）

## Why

- **self-documenting**: HTML 属性・CSS セレクタ・class 名で意図が伝わるものは削除
- **spec 重複排除**: 「命名は spec §6 ... 準拠」等の spec 参照コメント削除
- **教育的解説削除**: prefers-reduced-motion の意図、fieldset default 挙動等
- **公開 API 列挙は残す**: Component の public interface は starter 固有の実装情報

## Test plan

- [x] `pnpm run check` 通過
- [x] `pnpm run build` 成功
- [x] 削除対象の grep 確認（全 0）
- [x] CUSTOMIZE コメント維持（21 件）
- [x] 公開 API 列挙は維持（c-card / c-media-split / c-form 各 1-2 件）
- [ ] ブラウザで視覚差なし確認
- [ ] Cloudflare Pages preview pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)