### PR TITLE
refactor(v1.0): 全 section を「責任ごとに Block、直交時は併記」の統一パターンに

### DIFF
--- a/src/assets/css/project/p-flow.css
+++ b/src/assets/css/project/p-flow.css
@@ -23,19 +23,23 @@
   counter-reset: step;
 }
 
-/* WHY: li が c-card.-subtle を併記（2-level 構造）。
-   padding / background / border-radius は c-card.-subtle で委譲、
-   ここは grid + counter badge の「ステップ番号描画」固有の責任に絞る。 */
+/* WHY: li が c-card.-subtle + c-text-block を併記（2-level 構造、責任直交併記）。
+   padding / background / border-radius は c-card.-subtle、タイポ縦積み（row-gap）は c-text-block、
+   ここは grid + counter badge の「ステップ番号描画」固有の責任に絞る。
+   c-text-block の display: flex は p-flow__item の display: grid で上書きされるが、
+   grid の row-gap が c-text-block の gap と同値（space-sm）なので h3 + p の縦間隔は同等に保たれる。 */
 .p-flow__item {
   display: grid;
   grid-template-columns: auto 1fr;
   gap: var(--space-sm) var(--space-lg);
   counter-increment: step;
 
-  /* WHY: CSS counter でステップ番号を円形バッジとして視覚化 */
+  /* WHY: CSS counter でステップ番号を円形バッジとして視覚化。
+     grid-column: 1 / grid-row: 1 で左上に固定し、h3 + p の折り返しに影響されない。 */
   &::before {
     display: flex;
     grid-row: 1;
+    grid-column: 1;
     align-items: center;
     align-self: start;
     justify-content: center;
@@ -47,5 +51,11 @@
     content: counter(step);
     background-color: var(--color-main);
     border-radius: var(--radius-full);
+  }
+
+  /* WHY: ::before 以外の直接子（h3 + p）を column 2 に揃える。
+     grid auto-flow では p が col 1 row 2（badge 下）に回り込むため明示配置で回避。 */
+  & > * {
+    grid-column: 2;
   }
 }

--- a/src/assets/css/project/p-problem.css
+++ b/src/assets/css/project/p-problem.css
@@ -27,6 +27,6 @@
 }
 
 .p-problem__item {
-  /* スタイルなし（2-level 構造: li 自身が c-card.-subtle wrapper を兼ねる。
-     内部タイポの縦積みは .c-text-block が担当）。 */
+  /* スタイルなし（2-level 構造: li に c-card.-subtle + c-text-block を併記。
+     装飾は c-card.-subtle、タイポの縦積みは c-text-block が担当）。 */
 }

--- a/src/index.html
+++ b/src/index.html
@@ -231,29 +231,23 @@
               <h2 class="c-section-heading__title" id="problem-heading">こんな日々、続いていませんか？</h2>
             </hgroup>
             <ul class="p-problem__list" data-stagger="fade-in-slide-up">
-              <li class="c-card -subtle p-problem__item">
-                <div class="c-text-block">
-                  <h3 class="c-text-block__title">朝起きても疲れが抜けない</h3>
-                  <p class="c-text-block__text">
-                    睡眠時間は取っているのに、目覚めがすっきりしない。週末に寝溜めしても月曜にはもう重い。
-                  </p>
-                </div>
+              <li class="c-card -subtle c-text-block p-problem__item">
+                <h3 class="c-text-block__title">朝起きても疲れが抜けない</h3>
+                <p class="c-text-block__text">
+                  睡眠時間は取っているのに、目覚めがすっきりしない。週末に寝溜めしても月曜にはもう重い。
+                </p>
               </li>
-              <li class="c-card -subtle p-problem__item">
-                <div class="c-text-block">
-                  <h3 class="c-text-block__title">肩や腰が常に張っている</h3>
-                  <p class="c-text-block__text">
-                    デスクワークが続くと夕方には限界。マッサージに行っても翌日には戻っている。
-                  </p>
-                </div>
+              <li class="c-card -subtle c-text-block p-problem__item">
+                <h3 class="c-text-block__title">肩や腰が常に張っている</h3>
+                <p class="c-text-block__text">
+                  デスクワークが続くと夕方には限界。マッサージに行っても翌日には戻っている。
+                </p>
               </li>
-              <li class="c-card -subtle p-problem__item">
-                <div class="c-text-block">
-                  <h3 class="c-text-block__title">自分のための時間がない</h3>
-                  <p class="c-text-block__text">
-                    仕事、家事、育児。気づけば一日が終わっていて、自分のことは後回しになっている。
-                  </p>
-                </div>
+              <li class="c-card -subtle c-text-block p-problem__item">
+                <h3 class="c-text-block__title">自分のための時間がない</h3>
+                <p class="c-text-block__text">
+                  仕事、家事、育児。気づけば一日が終わっていて、自分のことは後回しになっている。
+                </p>
               </li>
             </ul>
           </div>
@@ -271,7 +265,7 @@
             </hgroup>
             <ul class="p-features__list" data-stagger="fade-in-slide-up">
               <li class="p-features__item">
-                <article class="c-media-split p-features__card">
+                <article class="c-card -subtle c-media-split p-features__card">
                   <div class="c-media-split__content">
                     <span class="c-badge -accent c-media-split__badge" lang="en">Counseling</span>
                     <h3 class="c-media-split__title">まず、30分話すことから</h3>
@@ -294,7 +288,7 @@
                 </article>
               </li>
               <li class="p-features__item">
-                <article class="c-media-split p-features__card">
+                <article class="c-card -subtle c-media-split p-features__card">
                   <div class="c-media-split__content">
                     <span class="c-badge -accent c-media-split__badge" lang="en">Treatment</span>
                     <h3 class="c-media-split__title">筋膜と深層にアプローチ</h3>
@@ -318,7 +312,7 @@
                 </article>
               </li>
               <li class="p-features__item">
-                <article class="c-media-split p-features__card">
+                <article class="c-card -subtle c-media-split p-features__card">
                   <div class="c-media-split__content">
                     <span class="c-badge -accent c-media-split__badge" lang="en">Private</span>
                     <h3 class="c-media-split__title">完全個室、あなただけの空間</h3>
@@ -354,45 +348,35 @@
             <h2 class="c-section-heading__title" id="flow-heading">ご利用の流れ</h2>
           </hgroup>
           <ol class="p-flow__list" data-stagger="fade-in-slide-up">
-            <li class="c-card -subtle p-flow__item">
-              <div class="c-text-block">
-                <h3 class="c-text-block__title">ご予約</h3>
-                <p class="c-text-block__text">
-                  お問い合わせフォームからご希望の日時・コースをお知らせください。24時間以内に折り返しご連絡いたします。
-                </p>
-              </div>
+            <li class="c-card -subtle c-text-block p-flow__item">
+              <h3 class="c-text-block__title">ご予約</h3>
+              <p class="c-text-block__text">
+                お問い合わせフォームからご希望の日時・コースをお知らせください。24時間以内に折り返しご連絡いたします。
+              </p>
             </li>
-            <li class="c-card -subtle p-flow__item">
-              <div class="c-text-block">
-                <h3 class="c-text-block__title">カウンセリング</h3>
-                <p class="c-text-block__text">
-                  施術前に30分ほどお時間をいただき、お体の状態やお悩み・ご希望を丁寧にヒアリング。
-                </p>
-              </div>
+            <li class="c-card -subtle c-text-block p-flow__item">
+              <h3 class="c-text-block__title">カウンセリング</h3>
+              <p class="c-text-block__text">
+                施術前に30分ほどお時間をいただき、お体の状態やお悩み・ご希望を丁寧にヒアリング。
+              </p>
             </li>
-            <li class="c-card -subtle p-flow__item">
-              <div class="c-text-block">
-                <h3 class="c-text-block__title">施術</h3>
-                <p class="c-text-block__text">
-                  選択したコースに沿って45〜90分の施術。完全個室で安心してお過ごしください。
-                </p>
-              </div>
+            <li class="c-card -subtle c-text-block p-flow__item">
+              <h3 class="c-text-block__title">施術</h3>
+              <p class="c-text-block__text">
+                選択したコースに沿って45〜90分の施術。完全個室で安心してお過ごしください。
+              </p>
             </li>
-            <li class="c-card -subtle p-flow__item">
-              <div class="c-text-block">
-                <h3 class="c-text-block__title">アフターケア</h3>
-                <p class="c-text-block__text">
-                  施術後は水分補給とリラックスタイム。お体の変化を確かめながらゆっくりとお過ごしください。
-                </p>
-              </div>
+            <li class="c-card -subtle c-text-block p-flow__item">
+              <h3 class="c-text-block__title">アフターケア</h3>
+              <p class="c-text-block__text">
+                施術後は水分補給とリラックスタイム。お体の変化を確かめながらゆっくりとお過ごしください。
+              </p>
             </li>
-            <li class="c-card -subtle p-flow__item">
-              <div class="c-text-block">
-                <h3 class="c-text-block__title">次回のご案内</h3>
-                <p class="c-text-block__text">
-                  お客様のお体に合わせた最適なペースをご提案。ご希望があれば次回のご予約も承ります。
-                </p>
-              </div>
+            <li class="c-card -subtle c-text-block p-flow__item">
+              <h3 class="c-text-block__title">次回のご案内</h3>
+              <p class="c-text-block__text">
+                お客様のお体に合わせた最適なペースをご提案。ご希望があれば次回のご予約も承ります。
+              </p>
             </li>
           </ol>
         </div>


### PR DESCRIPTION
## Summary

mFLOCSS の「単一責任 Block を併記して機能合成」（原則 4）を全 section で統一実装。教材価値の最大化。

### 変更

1. **Problem × 3 + Flow × 5**: 2-level 併記化（li に c-card -subtle + c-text-block + p-*__item 併記、inner div 削除）
2. **Features × 3**: article に c-card -subtle 追加（控えめ card 化、Problem / Flow と調和）
3. **Voice**: 変更なし（既に 3-level で正しい構造）
4. **p-flow.css**: counter badge の grid 配置固定 + h3/p の grid-column: 2 明示配置（後述）
5. **p-problem.css**: コメントを併記パターン表現に更新

### 統一原則

```
「semantic 要素が必要か？」で level 決定
  Yes → 3-level（li + semantic wrapper + content）
  No  → 2-level（li + content）

「責任が直交する Block」を併記で合成
  装飾（c-card）+ 内部レイアウト（c-text-block / c-media-split）+ semantic + Project Element
```

### 各 section のパターン

| Section | Level | 構造 | 併記 Block |
|---|---|---|---|
| Problem / Flow | 2-level | `li.c-card.-subtle.c-text-block.p-*__item` | c-card + c-text-block |
| Voice | 3-level | `li + article.c-card.p-voice__card + blockquote.c-blockquote` | c-card（article 層） |
| Features | 3-level | `li + article.c-card.-subtle.c-media-split.p-features__card` | c-card + c-media-split（article 層） |

### Flow counter badge との共存修正

Flow の li は `c-card.-subtle + c-text-block + p-flow__item` の 3 併記になり、`p-flow__item` は `display: grid; grid-template-columns: auto 1fr` を持つ。inner div 削除後、h3 + p が li の直接子となるため、放置すると auto-flow で p が col 1 row 2（badge の下）に回り込む。

**対応**: `p-flow.css` で
- `::before` に `grid-column: 1; grid-row: 1` 明示
- `& > *` に `grid-column: 2` 明示

c-text-block の `display: flex` は p-flow__item の `display: grid` で上書きされるが、grid の `row-gap` が c-text-block の `gap` と同値（`--space-sm`）なので h3/p の縦間隔は同等に保たれる。

## Why

- **教材価値最大化**: mFLOCSS の「責任ごとに Block、直交時は併記」を全 section で実演
- **判定フロー単純化**: 「semantic 必要？→ level 決定」→「直交 Block 併記」の 2 ステップ
- **再現性**: 新 section 作成時の機械的判断を可能に

## Test plan

- [x] `pnpm run check` 通過（stylelint / eslint / markuplint 全 pass）
- [x] `pnpm run build` 成功（Vite 8.0.3、66ms、gzip 内容変化なし）
- [x] 機械走査（併記パターン × 3/5/3、inner div 残存 × 0/0）
- [ ] ブラウザで Problem / Flow 見た目不変確認
- [ ] ブラウザで Flow counter badge 位置確認（badge 左 + h3/p 右で正常表示）
- [ ] ブラウザで Features 控えめ card 化確認（背景 secondary 色 + 角丸 + padding、影なし）
- [ ] Cloudflare Pages preview pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)