### PR TITLE
refactor(v1.0): コメント精査第3弾（8ルール厳格適用、Block役割説明削除）

### DIFF
--- a/src/assets/css/component/c-card.css
+++ b/src/assets/css/component/c-card.css
@@ -1,5 +1,4 @@
-/* Block: 装飾だけを担う汎用カード（c-text-block / c-media-split 等と併記）
-   公開 API:
+/* 公開 API:
      --card-padding  (default: var(--space-lg))
      --card-bg       (default: var(--color-surface))
      --card-radius   (default: var(--radius-md))

--- a/src/assets/css/component/c-form.css
+++ b/src/assets/css/component/c-form.css
@@ -1,5 +1,4 @@
-/* Block: フォーム全体の縦並びレイアウト
-   公開 API: --form-actions-margin-top（送信ボタン前の余白） */
+/* 公開 API: --form-actions-margin-top（送信ボタン前の余白） */
 .c-form {
   --form-actions-margin-top: var(--space-md);
 

--- a/src/assets/css/component/c-media-split.css
+++ b/src/assets/css/component/c-media-split.css
@@ -1,5 +1,4 @@
-/* Block: 画像 + コンテンツの 2 カラムレイアウトパターン
-   公開 API: --media-split-first-order で左右反転（`:nth-child(even)` 等で活用） */
+/* 公開 API: --media-split-first-order で左右反転（`:nth-child(even)` 等で活用） */
 .c-media-split {
   --_order: var(--media-split-first-order, 0);
 

--- a/src/assets/css/component/c-prose.css
+++ b/src/assets/css/component/c-prose.css
@@ -1,7 +1,5 @@
-/* Block: リッチテキスト本文（CMS / プライバシーポリシー / 利用規約 / ブログ記事等に使用）
-   子孫セレクタを許容する例外 Component。HTML 構造にクラスを付与できない CMS 流し込みに対応する。
-   public API: --prose-max-inline-size（読みやすい最大幅、Project 側で上書き可）
-     API 命名は spec §6「公開 API: --{対象}-{名前}」に準拠（プレフィックス c- / p- / l- は含まない）。 */
+/* 子孫セレクタを許容する例外 Component（CMS 流し込み等、HTML クラス付与不能な用途向け）
+   公開 API: --prose-max-inline-size（読みやすい最大幅、Project 側で上書き可） */
 .c-prose {
   max-inline-size: var(--prose-max-inline-size, 40rem);
   line-height: var(--line-height-text);
@@ -15,7 +13,6 @@
     margin-block-start: var(--space-md);
   }
 
-  /* h2 直下の段落・リストはタイトルと近接させる（視覚的グルーピング） */
   & h2 + :is(p, ul) {
     margin-block-start: var(--space-sm);
   }

--- a/src/assets/css/project/p-contact.css
+++ b/src/assets/css/project/p-contact.css
@@ -16,8 +16,6 @@
   text-align: center;
 }
 
-/* フォーム全体の外部配置（最大幅・上余白・中央寄せ）は Project 側が保持。
-   縦並び / gap 等の内部レイアウトは Component（c-form）が担当。 */
 .p-contact__form {
   --_form-max: 640px;
 
@@ -26,17 +24,7 @@
   margin-inline: auto;
 }
 
-/* Project 固有 Element（Component 化しない装飾・配置） */
-
-/* 同意確認リンク（プライバシーポリシー）は p-contact 固有の装飾 */
 .p-contact__form a {
   color: var(--color-main);
   text-decoration: underline;
 }
-
-/* TEACHING: Project が Component Element を文脈依存に上書きする場合は、子孫セレクタで対応する。
-   例:
-     .p-contact__form .c-form__input {
-       border-radius: var(--radius-md);
-     }
-   Component の公開 API（--form-required-mark 等）を使って差し替える方法も推奨される。 */

--- a/src/assets/css/project/p-drawer.css
+++ b/src/assets/css/project/p-drawer.css
@@ -2,13 +2,13 @@
   --overlay-z: calc(var(--z-drawer) - 1);
 }
 
-/* show() を使用（showModal() だとヘッダーが背面に隠れる） */
+/* show() で非モーダル表示（showModal() はヘッダー背面隠蔽） */
 .p-drawer {
   --_panel-size: min(max(85vi, calc(var(--viewport-min) * var(--px))), calc(100vi - 48px));
 
   position: fixed;
   inset: 0;
-  inset-inline-start: auto; /* UA の inset-inline-start: 0 を打ち消す */
+  inset-inline-start: auto;
   z-index: var(--z-drawer);
   inline-size: var(--_panel-size);
   max-inline-size: none;

--- a/src/assets/css/project/p-faq.css
+++ b/src/assets/css/project/p-faq.css
@@ -12,8 +12,6 @@
 
 .p-faq__list {
   max-inline-size: var(--content-width-narrow);
-
-  /* WHY: <ul> の既定マーカー・字下げを除去。並列項目としての semantics は保ったまま見た目をフラットに */
   padding-inline-start: 0;
   margin-block-start: var(--space-xl-2xl);
   margin-inline: auto;
@@ -21,8 +19,7 @@
 }
 
 .p-faq__item {
-  /* WHY: <li> で包んだことで c-accordion の「隣接兄弟で二重ボーダーを解消」ルールが効かなくなる。
-     並列に積層した FAQ の見た目は Project の合成責任なので、ここで境界線を解消する */
+  /* li wrapper で c-accordion 隣接兄弟ルールが無効化されるため再現 */
   & + & .c-accordion {
     border-block-start: none;
   }

--- a/src/assets/css/project/p-flow.css
+++ b/src/assets/css/project/p-flow.css
@@ -13,29 +13,19 @@
 .p-flow__list {
   display: grid;
   gap: var(--space-lg);
-
-  /* WHY: <ol> の既定パディングを除去し、カード左端を l-inner 基準に揃える */
   padding-inline-start: 0;
   margin-block-start: var(--space-xl-2xl);
-
-  /* WHY: ブラウザ既定の番号表示を無効化し、::before で独自の円形バッジを描画する */
   list-style: none;
   counter-reset: step;
 }
 
-/* WHY: li が c-card.-subtle + c-text-block を併記（2-level 構造、責任直交併記）。
-   padding / background / border-radius は c-card.-subtle、タイポ縦積み（row-gap）は c-text-block、
-   ここは grid + counter badge の「ステップ番号描画」固有の責任に絞る。
-   c-text-block の display: flex は p-flow__item の display: grid で上書きされるが、
-   grid の row-gap が c-text-block の gap と同値（space-sm）なので h3 + p の縦間隔は同等に保たれる。 */
+/* counter badge（::before）を grid col 1、コンテンツを col 2 に分離 */
 .p-flow__item {
   display: grid;
   grid-template-columns: auto 1fr;
   gap: var(--space-sm) var(--space-lg);
   counter-increment: step;
 
-  /* WHY: CSS counter でステップ番号を円形バッジとして視覚化。
-     grid-column: 1 / grid-row: 1 で左上に固定し、h3 + p の折り返しに影響されない。 */
   &::before {
     display: flex;
     grid-row: 1;
@@ -53,8 +43,6 @@
     border-radius: var(--radius-full);
   }
 
-  /* WHY: ::before 以外の直接子（h3 + p）を column 2 に揃える。
-     grid auto-flow では p が col 1 row 2（badge 下）に回り込むため明示配置で回避。 */
   & > * {
     grid-column: 2;
   }

--- a/src/assets/css/project/p-header.css
+++ b/src/assets/css/project/p-header.css
@@ -5,7 +5,7 @@
   border-block-end: var(--border-width) solid var(--color-border);
   backdrop-filter: blur(var(--_blur));
 
-  /* ドロワー表示中はヘッダーを不透明に（背面コンテンツの透けを防止） */
+  /* ドロワー表示時の背面透け防止 */
   :root:has(dialog[open]) & {
     background-color: var(--color-bg);
     backdrop-filter: none;

--- a/src/assets/css/project/p-hero.css
+++ b/src/assets/css/project/p-hero.css
@@ -43,7 +43,7 @@
 }
 
 .p-hero__sub-cta {
-  /* WHY: Hero 背景のグラデーション上でもテキストとボーダーの可読性を確保するため、ダークモード時は text 色に寄せる。c-button 公開 API 経由で注入し、プロパティ直上書きを避ける */
+  /* Hero グラデーション上のダークモード可読性調整（c-button 公開 API override） */
   --button-color: light-dark(var(--color-main), var(--color-text));
   --button-border-color: light-dark(var(--color-main), var(--color-text));
 }

--- a/src/assets/css/project/p-pricing.css
+++ b/src/assets/css/project/p-pricing.css
@@ -10,18 +10,13 @@
   /* スタイルなし（HTML クラスとの対応を維持） */
 }
 
-/* WHY: 幅広 table の横スクロール対策（Project 責務、Component 化しない理由:
-   min-inline-size がコンテンツ依存。tabindex="0" でキーボードフォーカスが
-   当たるため :focus-visible のリング描画は reset / foundation 既定で担保） */
 .p-pricing__table-wrapper {
   margin-block-start: var(--space-xl-2xl);
   overflow-x: auto;
 }
 
 .p-pricing__table {
-  /* WHY: iluha の 3 カラム料金表がここで横スクロールに切り替わる閾値。
-     コンテンツ依存の値なので Component 化せず Project に留める
-     （inline-size / border-collapse / セル装飾は c-table に委譲） */
+  /* 3 列表示 vs 横スクロールの切替閾値 */
   min-inline-size: 40rem;
 }
 

--- a/src/assets/css/project/p-privacy.css
+++ b/src/assets/css/project/p-privacy.css
@@ -10,7 +10,6 @@
   font-weight: var(--font-weight-heading);
 }
 
-/* タイトルと本文の間隔のみ Project 責任（本文内のタイポグラフィは c-prose が担う） */
 .p-privacy__body {
   margin-block-start: var(--space-lg);
 }

--- a/src/index.html
+++ b/src/index.html
@@ -131,7 +131,6 @@
     <!-- Skip Link -->
     <a class="c-skip-link u-visually-hidden" data-drawer-inert href="#main">本文へスキップ</a>
 
-    <!-- NOTE: ヘッダー・フッターは全ページ共通。変更時は全ファイルに反映すること -->
     <!-- Header -->
     <header class="l-header p-header">
       <div class="l-inner p-header__bar">


### PR DESCRIPTION
## Summary

コメント方針を 8 ルールに整理・厳格適用。starter のコメントを最終形に。

### 8 ルール

**残す**:
- ルール 3: 例外的・逸脱的な実装（DEVIATION）
- ルール 4: インターフェース（公開 API）
- ルール 5: 区切り的なラベル（セクション labels）
- ルール 6: CUSTOMIZE（ユーザー編集ガイド）
- ルール 7: 空ルール placeholder（現状表記維持）

**削除**:
- ルール 1: ファイル・クラス名から自明
- ルール 2: 一般的なコード・実装で自明
- ルール 8 廃止: 運用情報・保守注意も自明として削除

### 主な変更

- `index.html`: 運用 NOTE コメント削除
- Project 層の WHY / TEACHING コメント削除（p-contact / p-flow / p-faq / p-drawer / p-privacy / p-pricing）
- Project 層の短縮（p-flow / p-faq / p-header / p-hero / p-pricing / p-drawer）
- Block 役割説明削除（c-card / c-form / c-media-split）、公開 API のみ残す
- c-prose.css: Block 役割削除、例外 Component 記述に簡潔化

## Why

starter の責任境界:
- **spec**: 原則・仕様記述
- **書籍**: 教育・解説・WHY
- **starter のコード**: 実装 + starter 特有情報（CUSTOMIZE / DEVIATION / 公開 API / placeholder / 構造ラベル）

8 ルール厳格適用でコメントをこの責任境界に最終整合。

## Test plan

- [x] `pnpm run check` 通過（markuplint / stylelint / eslint / prettier）
- [x] `pnpm run build` 成功（65ms）
- [x] HTML 運用 NOTE 削除確認（grep 0件）
- [x] Project 層 WHY 残存ゼロ確認
- [x] TEACHING 削除確認（全 0）
- [x] Block 役割説明削除確認（c-card / c-form / c-media-split）
- [x] 公開 API 維持確認（c-card / c-form / c-media-split / c-prose 各 1件以上）
- [x] 空ルール placeholder 維持確認（15件）
- [x] CUSTOMIZE 維持確認（index.html 21件）
- [x] DEVIATION 維持確認（c-back-to-top 1件、foundation/form.css NOTE 2件）
- [ ] ブラウザで視覚差なし確認
- [ ] Cloudflare Pages preview pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)