### PR TITLE
refactor(v1.0): コメント精査最終（CSS 自明解説 2 件削除）

### DIFF
--- a/src/assets/css/component/c-card.css
+++ b/src/assets/css/component/c-card.css
@@ -11,7 +11,6 @@
   border-radius: var(--card-radius, var(--radius-md));
   box-shadow: var(--card-shadow, var(--shadow-sm) var(--color-shadow));
 
-  /* 控えめバリエーション（影なし、背景のみで区切る） */
   &.-subtle {
     --card-bg: var(--color-bg-secondary);
     --card-shadow: none;

--- a/src/assets/css/project/p-flow.css
+++ b/src/assets/css/project/p-flow.css
@@ -19,7 +19,6 @@
   counter-reset: step;
 }
 
-/* counter badge（::before）を grid col 1、コンテンツを col 2 に分離 */
 .p-flow__item {
   display: grid;
   grid-template-columns: auto 1fr;


### PR DESCRIPTION
## Summary

コメント精査最終仕上げ。CSS で完全に self-documenting な解説コメント 2 件を削除。

### 削除

- `c-card.css` L14: `/* 控えめバリエーション（影なし、背景のみで区切る） */` — `--card-shadow: none` + `--card-bg: secondary` から自明
- `p-flow.css` L22: `/* counter badge（::before）を grid col 1、コンテンツを col 2 に分離 */` — `grid-template-columns: auto 1fr` + `&::before` から自明

## Why

コメント方針 8 ルールのルール 2「一般的なコード・実装で自明」に該当。CSS 自体で意図が完全に伝わるコメントは削除、冗長化を排除。

## 残す確定（維持）

- HTML: CUSTOMIZE × 21、構造ラベル（全て ルール 5 / 6 適合）
- CSS: 公開 API 明示、DEVIATION、Element 識別子（c-form の Element: 役割説明は form 特殊性を考慮して残す）、空ルール placeholder、実装判断記録

## Test plan

- [x] `pnpm run check` 通過
- [x] `pnpm run build` 成功
- [x] 削除対象の grep 確認（両ファイルとも 0）
- [x] 残すべきコメント維持確認（CUSTOMIZE × 21、公開 API × 5 ファイル）

🤖 Generated with [Claude Code](https://claude.com/claude-code)