### PR TITLE
refactor(v1.0): 他 HTML ファイル（404 / privacy）のコメント精査

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -20,7 +20,6 @@
     />
     <!-- CUSTOMIZE: token/color.css のメインカラーに合わせて変更 -->
     <meta name="theme-color" content="#5b7a5e" />
-    <!-- NOTE: 404 ページは canonical / OGP 不要（noindex のため） -->
     <!-- Favicon -->
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
@@ -34,7 +33,6 @@
     <!-- Skip Link -->
     <a href="#main" class="c-skip-link u-visually-hidden" data-drawer-inert>本文へスキップ</a>
 
-    <!-- NOTE: ヘッダー・フッターは全ページ共通。変更時は全ファイルに反映すること -->
     <!-- Header -->
     <header class="l-header p-header">
       <div class="l-inner p-header__bar">

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -31,7 +31,6 @@
     <meta property="og:site_name" content="iluha" />
     <meta property="og:locale" content="ja_JP" />
     <meta name="twitter:card" content="summary_large_image" />
-    <!-- NOTE: twitter:title / twitter:description / twitter:image は未設定の場合 og:* が fallback として使われるため省略 -->
     <!-- Favicon -->
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
@@ -68,7 +67,6 @@
     <!-- Skip Link -->
     <a href="#main" class="c-skip-link u-visually-hidden" data-drawer-inert>本文へスキップ</a>
 
-    <!-- NOTE: ヘッダー・フッターは全ページ共通。変更時は全ファイルに反映すること -->
     <!-- Header -->
     <header class="l-header p-header">
       <div class="l-inner p-header__bar">


### PR DESCRIPTION
## Summary

index.html で精査済みのコメントルール（8 ルール）を、他 HTML ファイル（404.html / privacy/index.html）にも適用。運用 NOTE や仕様解説の 4 箇所を削除。

### 削除（4 箇所）

- **404.html L23**: `<!-- NOTE: 404 ページは canonical / OGP 不要（noindex のため） -->` — SEO 一般常識（ルール 2）
- **404.html L37**: `<!-- NOTE: ヘッダー・フッターは全ページ共通... -->` — ルール 8 廃止
- **privacy/index.html L34**: `<!-- NOTE: twitter:* ... og:* が fallback -->` — PR #129 で index.html から削除済（ルール 2）
- **privacy/index.html L71**: `<!-- NOTE: ヘッダー・フッターは全ページ共通... -->` — ルール 8 廃止

## Why

PR #129, #135 は index.html のみ対象だった。他 HTML（404.html / privacy/index.html）に同じ問題コメントが残っていたため、同じルールで削除。全 HTML でコメント方針の一貫性を担保。

## Test plan

- [x] `pnpm run check` 通過
- [x] `pnpm run build` 成功
- [x] 削除対象の grep 確認（全 0）
- [x] CUSTOMIZE コメントは維持（404.html: 5 箇所、privacy/index.html: 9 箇所）

🤖 Generated with [Claude Code](https://claude.com/claude-code)