### PR TITLE
refactor: Reset 冗長カスケード削除（c-table の border-collapse）

### DIFF
--- a/src/css/component/c-table.css
+++ b/src/css/component/c-table.css
@@ -1,6 +1,5 @@
 .c-table {
   inline-size: 100%;
-  border-collapse: collapse;
   font-size: 0.9375rem;
   line-height: var(--line-height-base);
 


### PR DESCRIPTION
## Summary

cortex セッション 5 で作成された `css-cascade-audit` skill のプロパティマップに基づき、Reset layer で既設定済みのプロパティが Component 層で冗長 override されていた箇所を削除した。

元タスクでは 8 項目が想定されていたが、**v1.1 完全準拠リファレンス実装（#50, 2026-03-12）でのリポジトリ刷新により、対象ファイル 3 件（c-form.css / p-faq.css / p-flow.css）が既に削除されていたため、現状で有効な対象は c-table.css の 1 項目のみ**であった。本 PR はその 1 項目を削除する。

## 削除項目

| # | ファイル | 削除内容 | 既設定箇所 |
|---|---------|---------|-----------|
| D | `src/css/component/c-table.css` | `.c-table { border-collapse: collapse }` | Reset `:where(table) { border-collapse: collapse }`（`src/css/foundation/reset.css:91-93`） |

## タスク指示との差分（v1.1 刷新による無効化）

以下の 7 項目は、対象ファイルが v1.1 リファレンス実装刷新で削除済みのため、本 PR スコープ外:

| # | 元対象 | 現状 |
|---|-------|------|
| A | `src/assets/css/component/c-form.css` の `fieldset.c-form__field` ブロック | c-form.css 自体が不存在 |
| B | `src/assets/css/component/c-form.css` の `.c-form__input { font: inherit }` | 同上 |
| C | `src/assets/css/component/c-form.css` の `.c-form__input { color: var(--color-text) }` | 同上 |
| E | `src/assets/css/project/p-faq.css` の `.p-faq__list { padding-inline-start: 0 }` | p-faq.css 自体が不存在 |
| F | `src/assets/css/project/p-faq.css` の `.p-faq__list { list-style-type: none }` | 同上 |
| G | `src/assets/css/project/p-flow.css` の `.p-flow__list { padding-inline-start: 0 }` | p-flow.css 自体が不存在 |
| H | `src/assets/css/project/p-flow.css` の `.p-flow__list { list-style: none }` | 同上 |

※ 現リポは `src/assets/css/` ではなく `src/css/` ディレクトリ構造に統一済み（#50 で移行）。

## 設計判断

- Reset はすでに `:where()` + `unset` / `''` / `inherit` で十分な下地を敷いている。上位 layer で同値を再宣言するのはカスケードの冗長化であり、mFLOCSS spec の「責任の分離」原則にも反する。
- 保持した冗長（意図的、元タスクで明示）:
  - a 要素の `text-decoration: none`（Reset は `unset` = initial underline に戻す挙動のため `none` 明示が必要）
  - button 系の `line-height: var(--line-height-title)`（body 継承 line-height-text の override）

## 追加発見（本 PR スコープ外）

現リポの再スキャンで以下の冗長カスケード候補を検出したが、元タスク 8 項目に含まれないため別タスクで扱う:

- `src/css/project/p-footer.css:24-26` の `.p-footer__nav-list { list-style: none; padding: 0; margin: 0 }`
  - `list-style: none` は Reset の `list-style-type: ''` と同等で冗長の可能性
  - `padding: 0` / `margin: 0` は Reset の `padding-inline-start: unset` / `margin-block: unset` より広範のため削除判断には追加検討が必要

次セッションで `css-cascade-audit` skill のプロパティマップを v1.1 に合わせて再生成 → 再監査を推奨。

## Test plan

- [x] `pnpm run lint:css`（stylelint）エラーなし通過
- [x] `pnpm run build`（vite build）成功
- [ ] demo / index.html でテーブル表示（`dist/layers/`, `dist/contact/` 等）に破綻がないこと目視確認（しゅんえい側）

🤖 Generated with [Claude Code](https://claude.com/claude-code)