### PR TITLE
refactor(v1.0): Reset / Foundation 冗長カスケード削除（8 項目）

### DIFF
--- a/src/assets/css/component/c-form.css
+++ b/src/assets/css/component/c-form.css
@@ -14,12 +14,6 @@
   gap: var(--space-xs);
 }
 
-fieldset.c-form__field {
-  padding: 0;
-  margin: 0;
-  border: 0;
-}
-
 /* Element: label / legend（見出し扱いのタイポグラフィを共通化） */
 .c-form__label,
 .c-form__legend {
@@ -39,8 +33,6 @@ fieldset.c-form__field {
 /* Element: 入力装飾（input / textarea / select 共通のビジュアル定義） */
 .c-form__input {
   padding: var(--space-sm) var(--space-md);
-  font: inherit;
-  color: var(--color-text);
   background-color: var(--color-surface);
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--radius-sm);

--- a/src/assets/css/component/c-table.css
+++ b/src/assets/css/component/c-table.css
@@ -1,6 +1,5 @@
 .c-table {
   inline-size: 100%;
-  border-collapse: collapse;
 
   & th,
   & td {

--- a/src/assets/css/project/p-faq.css
+++ b/src/assets/css/project/p-faq.css
@@ -12,10 +12,8 @@
 
 .p-faq__list {
   max-inline-size: var(--content-width-narrow);
-  padding-inline-start: 0;
   margin-block-start: var(--space-xl-2xl);
   margin-inline: auto;
-  list-style-type: none;
 }
 
 .p-faq__item {

--- a/src/assets/css/project/p-flow.css
+++ b/src/assets/css/project/p-flow.css
@@ -13,9 +13,7 @@
 .p-flow__list {
   display: grid;
   gap: var(--space-lg);
-  padding-inline-start: 0;
   margin-block-start: var(--space-xl-2xl);
-  list-style: none;
   counter-reset: step;
 }
 


### PR DESCRIPTION
## Summary

Reset / Foundation layer で既設定済みのプロパティが Component / Project 層で冗長 override されている箇所を削除。cortex セッション 5（2026-04-23）の `css-cascade-audit` skill に基づく監査結果。

## 削除項目

| ファイル | 削除内容 | Reset / Foundation 根拠 |
|---|---|---|
| c-form.css | `fieldset.c-form__field { padding/margin/border: 0 }` ブロック全体 | Reset `:where(fieldset)` で全て unset 済 |
| c-form.css | `.c-form__input { font: inherit }` | Reset `:where(button, input, select, textarea) { font: inherit }` |
| c-form.css | `.c-form__input { color: var(--color-text) }` | Reset `color: inherit` + body 継承 |
| c-table.css | `.c-table { border-collapse: collapse }` | Reset `:where(table) { border-collapse: collapse }` |
| p-faq.css | `padding-inline-start: 0` + `list-style-type: none` | Reset `:where(ul, ol, menu)` で unset 済 |
| p-flow.css | `padding-inline-start: 0` + `list-style: none` | 同上 |

## 保持項目（意図的）

- `p-drawer.css` の `margin: 0` on dialog → UA default `margin: auto` override
- `a` の `text-decoration: none` → Reset `unset` は initial（underline）に戻すため明示 `none` 必要
- button 系の `line-height: var(--line-height-title)` → body line-height-text を override

## Test plan

- [x] `pnpm run lint:css` 通過
- [x] `pnpm run build` 成功
- [ ] 実ブラウザで form / table / faq / flow の見た目回帰なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)