### PR TITLE
fix(v1.2): AR 即時修正 4 件（WCAG 2.4.11 / 命名バグ / LCP / 公開衛生）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.local
 .env
 .DS_Store
+.worker-context.md

--- a/src/404.html
+++ b/src/404.html
@@ -133,7 +133,7 @@
 
     <!-- Back to Top -->
     <a href="#top" class="c-back-to-top" data-back-to-top aria-label="ページの先頭に戻る">
-      <svg class="c-icon" width="20" height="20" aria-hidden="true">
+      <svg class="c-back-to-top__icon" width="20" height="20" aria-hidden="true">
         <use href="/assets/images/icons/chevron-up.svg#icon" />
       </svg>
     </a>

--- a/src/assets/css/component/c-form.css
+++ b/src/assets/css/component/c-form.css
@@ -41,9 +41,10 @@
     transition: border-color var(--duration-normal) var(--ease-out-cubic);
   }
 
-  &:focus {
-    outline: none;
+  &:focus-visible {
     border-color: var(--color-main);
+
+    /* Foundation の :where(:focus-visible) outline リングを温存（WCAG 2.4.11 AA） */
   }
 
   &:user-invalid {

--- a/src/index.html
+++ b/src/index.html
@@ -187,10 +187,10 @@
 
     <main id="main" data-drawer-inert>
       <!-- Hero -->
-      <section class="l-section p-hero" data-immediate="scale-in" aria-labelledby="hero-heading">
+      <section class="l-section p-hero" aria-labelledby="hero-heading">
         <div class="l-inner p-hero__stack">
           <!-- CUSTOMIZE: サービス名・キャッチコピーを差し替え -->
-          <div class="p-hero__content">
+          <div class="p-hero__content" data-immediate="scale-in">
             <h1 class="p-hero__title" id="hero-heading">からだの声を、<br class="u-hidden-pc" />聴く時間。</h1>
             <p class="p-hero__lead">
               忙しい毎日の中で後回しにしてきた自分のケア。<br class="u-hidden-sp" />iluha

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -188,7 +188,7 @@
 
     <!-- Back to Top -->
     <a href="#top" class="c-back-to-top" data-back-to-top aria-label="ページの先頭に戻る">
-      <svg class="c-icon" width="20" height="20" aria-hidden="true">
+      <svg class="c-back-to-top__icon" width="20" height="20" aria-hidden="true">
         <use href="../assets/images/icons/chevron-up.svg#icon" />
       </svg>
     </a>


### PR DESCRIPTION
## Summary

v1.2 starter の AR（対立的レビュー、2026-04-23）で「即時修正（main 統合前の必須）」判定された 4 件を修正。

## 修正内容

| # | ファイル | 修正内容 | 観点 |
|---|---|---|---|
| 1 | `c-form.css` | `:focus { outline: none }` → `:focus-visible`（Foundation リング温存） | WCAG 2.4.11 AA（3 レビュアー収束） |
| 2 | `404.html` / `privacy/index.html` | Back-to-Top SVG クラスを `c-icon` → `c-back-to-top__icon` | 命名規則違反バグ |
| 3 | `index.html` | Hero の `data-immediate="scale-in"` を `section.p-hero` → `div.p-hero__content` に移動 | LCP 規範性（opacity: 0 + fetchpriority="high" 競合） |
| 4 | `.gitignore` | `.worker-context.md` を追加 | 公開リポ衛生 |

## AR 収束指摘（3 レビュアー）

採用 1 は R1 / R2 / R4 の 3 レビュアーが別観点から独立発見した収束指摘で、**最優先**。

## 採用 3 の判断根拠

`<img fetchpriority="high">` が `div.p-hero__media`（`div.p-hero__content` の兄弟要素）に位置することを確認。`.p-hero__content`（テキスト + CTA のみ）に `data-immediate="scale-in"` を限定することで、scale-in UX 効果を維持しつつ LCP 阻害を解消（Option B 採用）。

## .worker-context.md の対応

ファイルは既に git 未追跡（git ls-files で未検出）のため、git rm --cached は不要。.gitignore 追加のみで対応済み。

## Test plan

- [x] `pnpm run lint:css` 通過
- [x] `pnpm run build` 成功
- [ ] キーボード Tab でフォームフォーカスリング確認（実ブラウザ）
- [ ] 404 / privacy の Back-to-Top 表示確認
- [ ] Hero の初期フレーム opacity / LCP 確認

## 関連

AR 結果全文: result-judge.md（セッション 2026-04-23 AR ディレクトリに保存）
残 17 件（v1.0 リリース前 14 + リリース後 3）は別 PR で対応予定。

Generated with Claude Code
