### PR TITLE
chore(v1.2): .worker-context.md クリーンアップ（gitignore 記載削除 + ローカルファイル削除）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ dist/
 *.local
 .env
 .DS_Store
-.worker-context.md


### PR DESCRIPTION
## Summary

PR #140（AR 採用 16）で `.gitignore` に `.worker-context.md` を追加したが、しゅんえい判断により以下を実施:

- `.gitignore` から `.worker-context.md` 記載を削除（ファイルは元々 Git 追跡外のため記載不要）
- ローカルの `.worker-context.md` ファイル自体を削除

## 背景

AR 採用 16 は「公開リポに含まれる Claude Code 内部コンテキストファイル」として指摘されたが、実際には Git 追跡外だった（`git ls-files .worker-context.md` で何も出ない）。そのため `.gitignore` 記載は冗長だった。しゅんえい判断でファイル自体も削除し、完全クリーンアップ。

## Test plan

- [x] `pnpm run lint:css` 通過
- [x] `pnpm run build` 成功
- [x] `.worker-context.md` が存在しないことを確認
- [x] `.gitignore` の他エントリに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)