### PR TITLE
fix(v1.2): AR E a11y 4 件修正（WCAG 2.2 AA 準拠強化）

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -86,7 +86,7 @@
       </div>
     </dialog>
 
-    <main id="main" data-drawer-inert>
+    <main id="main" tabindex="-1" data-drawer-inert>
       <section class="l-section p-not-found" aria-labelledby="not-found-heading">
         <div class="l-inner p-not-found__inner">
           <div class="c-section-heading p-not-found__heading">

--- a/src/assets/css/component/c-form.css
+++ b/src/assets/css/component/c-form.css
@@ -7,6 +7,13 @@
   gap: var(--space-lg);
 }
 
+/* Element: note — フォーム冒頭の必須マーク説明（WCAG 3.3.2 Labels or Instructions） */
+.c-form__note {
+  margin-block-end: var(--space-md);
+  font-size: var(--font-size-caption);
+  color: var(--color-text-light);
+}
+
 /* Element: label + input ラッパー（label / fieldset 両構造に対応） */
 .c-form__field {
   display: flex;
@@ -23,9 +30,10 @@
   font-weight: var(--font-weight-heading);
 }
 
-/* 必須マーク: --form-required-mark で「*」→「必須」等に切替可能（公開 API） */
+/* 必須マーク: --form-required-mark で「*」→「必須」等に切替可能（公開 API）。choice-label は ::before で前置（checkbox の前に表示） */
 .c-form__field:has(:required) > .c-form__label::after,
-.c-form__field:has(:required) > .c-form__legend::after {
+.c-form__field:has(:required) > .c-form__legend::after,
+.c-form__field:has(:required) > .c-form__choice-label::before {
   color: var(--color-error);
   content: var(--form-required-mark, '*');
 }

--- a/src/index.html
+++ b/src/index.html
@@ -185,7 +185,7 @@
       </div>
     </dialog>
 
-    <main id="main" data-drawer-inert>
+    <main id="main" tabindex="-1" data-drawer-inert>
       <!-- Hero -->
       <section class="l-section p-hero" aria-labelledby="hero-heading">
         <div class="l-inner p-hero__stack">
@@ -605,6 +605,9 @@
 
           <!-- CUSTOMIZE: 本番バックエンド URL に差し替え。starter はフォーム送信処理を提供しません -->
           <form class="c-form p-contact__form" action="/api/contact" method="post">
+            <p class="c-form__note">
+              <span aria-hidden="true">*</span> は必須項目です
+            </p>
             <div class="c-form__field">
               <label class="c-form__label" for="name">お名前</label>
               <input class="c-form__input" id="name" name="name" type="text" autocomplete="name" required />
@@ -654,10 +657,10 @@
             </div>
 
             <div class="c-form__field">
-              <label class="c-form__choice-label">
-                <input id="agree" name="agree" type="checkbox" required />
-                <a href="/privacy/">プライバシーポリシー</a>に同意する
-              </label>
+              <div class="c-form__choice-label">
+                <input id="agree" name="agree" type="checkbox" required aria-labelledby="agree-label" />
+                <span id="agree-label"><a href="/privacy/">プライバシーポリシー</a>に同意する</span>
+              </div>
             </div>
 
             <div class="c-form__actions">

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -120,7 +120,7 @@
       </div>
     </dialog>
 
-    <main id="main" data-drawer-inert>
+    <main id="main" tabindex="-1" data-drawer-inert>
       <!-- CUSTOMIZE: プライバシーポリシーの内容を差し替え -->
       <section class="l-section p-privacy" aria-labelledby="privacy-heading">
         <div class="l-inner p-privacy__inner">


### PR DESCRIPTION
## Summary

v1.2 starter の AR E バッチ（a11y 4 件）を修正。WCAG 2.2 AA 準拠をリファレンス実装として確立。

## 修正内容

| # | ファイル | 修正 | WCAG |
|---|---|---|---|
| 採用 4 | 全 HTML の `<main>` | `tabindex="-1"` 付与 | 2.4.1 Bypass Blocks |
| 採用 5 | `index.html` フォーム | `<label>` 内 `<a>` を `<div>` + `aria-labelledby` パターンに | 4.1.2 Name Role Value |
| 採用 6 | `c-form.css` | `.c-form__choice-label::before` に必須マーク | 3.3.2 Labels or Instructions |
| 採用 7 | `index.html` + `c-form.css` | フォーム冒頭に「`*` は必須項目です」説明 | 3.3.2 Labels or Instructions |

## Test plan

- [x] `pnpm run lint:css` 通過
- [x] `pnpm run build` 成功
- [ ] キーボードで skip link → `<main>` フォーカス移動確認（実ブラウザ）
- [ ] 同意 checkbox のリンクと checkbox が独立して動作することを確認
- [ ] 同意 checkbox に `*` 表示確認
- [ ] SR（VoiceOver 等）でフォーム冒頭の説明が読み上げられる確認

## 関連

AR 結果: 採用 21 件中、E バッチ 4 件を本 PR で対応。残は F（OSS インフラ 4）/ G（head+meta 3）/ H（picture+AVIF, @property 2）で順次対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)