### PR TITLE
fix(v1.2): skip-link の属性順を Google Style に統一（404 / privacy）

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -31,7 +31,7 @@
   </head>
   <body id="top">
     <!-- Skip Link -->
-    <a href="#main" class="c-skip-link u-visually-hidden" data-drawer-inert>本文へスキップ</a>
+    <a class="c-skip-link u-visually-hidden" data-drawer-inert href="#main">本文へスキップ</a>
 
     <!-- Header -->
     <header class="l-header p-header">

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -65,7 +65,7 @@
   </head>
   <body id="top">
     <!-- Skip Link -->
-    <a href="#main" class="c-skip-link u-visually-hidden" data-drawer-inert>本文へスキップ</a>
+    <a class="c-skip-link u-visually-hidden" data-drawer-inert href="#main">本文へスキップ</a>
 
     <!-- Header -->
     <header class="l-header p-header">


### PR DESCRIPTION
## Summary

AR 採用 18 — skip-link の HTML 属性順を Google Style に統一。404 / privacy の skip-link を index.html と同じ順序に揃える。

## 修正内容

| ファイル | 現状 | 修正後 |
|---|---|---|
| 404.html:34 | `href → class → data-*` | `class → data-* → href` |
| privacy/index.html:68 | 同上 | 同上 |

index.html:132 は既に Google Style 準拠のため対象外。

## 背景

- AR（2026-04-23）で採用 18 として指摘（v1.0 リリース後扱い）
- しゅんえい判断により「skip-link 統一」として優先着手
- 機能的影響なし（Tab 順 / フォーカス挙動は等価）
- css-html-order-check skill の検証対象として整合

## Test plan

- [x] `pnpm run lint:css` 通過
- [x] `pnpm run build` 成功
- [ ] 実ブラウザで 404 / privacy の skip-link 動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)