### PR TITLE
fix(v1.2): AR G head/meta 3 件整備（preload 順序 / Twitter Card / Font ガイド）

### DIFF
--- a/src/assets/css/token/typography.css
+++ b/src/assets/css/token/typography.css
@@ -1,6 +1,26 @@
 :root {
-  /* CUSTOMIZE: フォントファミリー */
-  --font-family: 'Noto Sans JP', 'Hiragino Sans', 'Hiragino Kaku Gothic ProN', meiryo, sans-serif;
+  /* CUSTOMIZE: Font selection
+   *
+   * Noto Sans JP を使う場合、以下いずれかで読み込み:
+   *
+   * A) Google Fonts CDN（手軽）: <link> を index.html <head> に追加
+   *    <link rel="preconnect" href="https://fonts.googleapis.com">
+   *    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+   *    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet">
+   *
+   * B) セルフホスト（推奨、パフォーマンス高）: WOFF2 を配信 + @font-face 宣言
+   *    @font-face {
+   *      font-family: 'Noto Sans JP';
+   *      src: url('/assets/fonts/noto-sans-jp.woff2') format('woff2');
+   *      font-display: swap;
+   *      font-weight: 100 900;
+   *    }
+   *
+   * 読み込みなしの場合: システムフォント（system-ui）にフォールバック
+   */
+  --font-family:
+    'Noto Sans JP', system-ui, -apple-system, blinkmacsystemfont, 'Hiragino Kaku Gothic ProN', 'Yu Gothic', meiryo,
+    sans-serif;
 
   /* CUSTOMIZE: 流体タイポグラフィ（viewport-min → viewport-max の直線的な補間） */
   --font-size-h1: clamp(calc(32 * var(--px)), 2.308vi + 1.4231rem, calc(56 * var(--px)));

--- a/src/index.html
+++ b/src/index.html
@@ -3,20 +3,17 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script src="/scripts/viewport.js"></script>
-    <meta name="format-detection" content="telephone=no,address=no,email=no" />
-    <!-- CUSTOMIZE: ダークモード不要なら content="light" に -->
-    <meta name="color-scheme" content="light dark" />
     <!-- CUSTOMIZE: ページタイトル・説明文を差し替え -->
     <title>iluha — からだの声を、聴く時間。</title>
     <meta
       name="description"
       content="iluha（イルハ）は、30代・40代の女性のための完全個室ボディケアサロン。カウンセリング重視の施術で、内側からからだを整えます。初回体験 60分 4,400円。"
     />
+    <meta name="format-detection" content="telephone=no,address=no,email=no" />
+    <!-- CUSTOMIZE: ダークモード不要なら content="light" に -->
+    <meta name="color-scheme" content="light dark" />
     <!-- CUSTOMIZE: token/color.css のメインカラーに合わせて変更 -->
     <meta name="theme-color" content="#5b7a5e" />
-    <!-- CUSTOMIZE: 本番 URL に差し替え -->
-    <link rel="canonical" href="https://example.com/" />
     <!-- OGP -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="iluha — からだの声を、聴く時間。" />
@@ -31,16 +28,32 @@
     <meta property="og:site_name" content="iluha" />
     <meta property="og:locale" content="ja_JP" />
     <meta name="twitter:card" content="summary_large_image" />
-    <!-- Favicon -->
+    <meta name="twitter:title" content="iluha — からだの声を、聴く時間。" />
+    <meta
+      name="twitter:description"
+      content="30代・40代の女性のための完全個室ボディケアサロン。カウンセリング重視の施術で、内側からからだを整えます。初回体験 60分 4,400円。"
+    />
+    <meta name="twitter:image" content="https://example.com/ogp.png" />
+    <!-- CUSTOMIZE: og:* と同値でほとんどの場合 OK。Twitter 専用の差別化が必要な場合のみ変更 -->
+    <!-- CUSTOMIZE: 本番 URL に差し替え -->
+    <link rel="canonical" href="https://example.com/" />
+    <!-- CUSTOMIZE: フォント読み込み
+       Google Fonts を使う場合、ここに以下を追加:
+       <link rel="preconnect" href="https://fonts.googleapis.com">
+       <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+       <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet">
+       詳細: src/assets/css/token/typography.css の CUSTOMIZE コメント参照
+    -->
+    <!-- CUSTOMIZE: LCP 画像を差し替える場合は href + type を更新、image/jpeg image/png image/avif に対応可 -->
+    <link rel="preload" as="image" type="image/webp" href="/assets/images/hero-main.webp" fetchpriority="high" />
+    <!-- Styles -->
+    <link rel="stylesheet" href="/assets/css/style.css" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <link rel="preload" as="image" href="/assets/images/hero-main.webp" fetchpriority="high" />
-    <!-- Styles -->
-    <link rel="stylesheet" href="/assets/css/style.css" />
-
     <!-- Scripts -->
     <script type="module" src="/assets/scripts/main.js"></script>
+    <script src="/scripts/viewport.js"></script>
 
     <!-- CUSTOMIZE: 構造化データの各値を本番情報に差し替え -->
     <script type="application/ld+json">

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -3,20 +3,17 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script src="/scripts/viewport.js"></script>
-    <meta name="format-detection" content="telephone=no,address=no,email=no" />
-    <!-- CUSTOMIZE: ダークモード不要なら content="light" に -->
-    <meta name="color-scheme" content="light dark" />
     <!-- CUSTOMIZE: ページタイトル・説明文を差し替え -->
     <title>プライバシーポリシー — iluha</title>
     <meta
       name="description"
       content="iluha のプライバシーポリシー。施術前後にお預かりする個人情報（氏名・連絡先）の収集目的、第三者提供の方針、お問い合わせ窓口を明記しています。"
     />
+    <meta name="format-detection" content="telephone=no,address=no,email=no" />
+    <!-- CUSTOMIZE: ダークモード不要なら content="light" に -->
+    <meta name="color-scheme" content="light dark" />
     <!-- CUSTOMIZE: token/color.css のメインカラーに合わせて変更 -->
     <meta name="theme-color" content="#5b7a5e" />
-    <!-- CUSTOMIZE: 本番 URL に差し替え -->
-    <link rel="canonical" href="https://example.com/privacy/" />
     <!-- OGP -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="プライバシーポリシー — iluha" />
@@ -31,15 +28,23 @@
     <meta property="og:site_name" content="iluha" />
     <meta property="og:locale" content="ja_JP" />
     <meta name="twitter:card" content="summary_large_image" />
-    <!-- Favicon -->
+    <meta name="twitter:title" content="プライバシーポリシー — iluha" />
+    <meta
+      name="twitter:description"
+      content="iluha のプライバシーポリシー。施術前後にお預かりする個人情報（氏名・連絡先）の収集目的、第三者提供の方針、お問い合わせ窓口を明記しています。"
+    />
+    <meta name="twitter:image" content="https://example.com/ogp.png" />
+    <!-- CUSTOMIZE: og:* と同値でほとんどの場合 OK。Twitter 専用の差別化が必要な場合のみ変更 -->
+    <!-- CUSTOMIZE: 本番 URL に差し替え -->
+    <link rel="canonical" href="https://example.com/privacy/" />
+    <!-- Styles -->
+    <link rel="stylesheet" href="/assets/css/style.css" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <!-- Styles -->
-    <link rel="stylesheet" href="/assets/css/style.css" />
-
     <!-- Scripts -->
     <script type="module" src="/assets/scripts/main.js"></script>
+    <script src="/scripts/viewport.js"></script>
 
     <!-- CUSTOMIZE: 構造化データの URL を本番 URL に差し替え -->
     <script type="application/ld+json">


### PR DESCRIPTION
## Summary

v1.2 starter の AR G バッチ（head/meta 軽量 3 件）を整備。Google Web Fundamentals 準拠の head 構造 + SNS プレビュー完全化 + フォント実装ガイドを確立。

## 修正内容

| # | ファイル | 修正 |
|---|---|---|
| 採用 9 | `src/index.html` | `<head>` 内の順序を Google Web Fundamentals 推奨順に整列、`<link rel="preload" as="image">` に `type="image/webp"` 追加 |
| 採用 11 | `src/index.html` + `src/privacy/index.html` | Twitter Card `twitter:title` / `twitter:description` / `twitter:image` 3 タグ追加 |
| 採用 12 | `src/assets/css/token/typography.css` + `src/index.html` | Noto Sans JP 実装ガイド（Google Fonts / セルフホスト両対応）CUSTOMIZE コメント拡充 |

## 意図的除外

- **採用 8（picture + AVIF + srcset/sizes）は starter 対象外**（しゅんえい判断、2026-04-23、cortex #236 OA-5 に移動）
- そのため採用 9 の `imagesrcset` / `imagesizes` 属性は追加しない（AVIF 画像生成を前提としないため）

## Test plan

- [x] `npm run check` 通過
- [x] `npm run build` 成功
- [ ] Twitter Card Validator で index / privacy のプレビュー確認
- [ ] LCP（Lighthouse）で preload 順序改善を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)