### PR TITLE
chore(v1.2): ドキュメント調整 + rolldown workaround を repo .npmrc に移管

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ dist/
 *.local
 .env
 .DS_Store
-package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,27 @@
+# ===========================================================================
+# pnpm configuration for mflocss/starter
+# ===========================================================================
+#
+# minimum-release-age-exclude: rolldown (vite 8 の依存) が 3 日以内リリースで
+# `minimum-release-age` 安全機能に引っかかるため、一時的にバイパス。
+# 2026-04-23 追加、rolldown 安定化 or vite の依存更新で削除予定。
+#
+# pnpm 専用の設定（npm / yarn には無効）。グローバル ~/.npmrc には影響しない。
+
+minimum-release-age-exclude[]=rolldown
+minimum-release-age-exclude[]=@rolldown/binding-android-arm64
+minimum-release-age-exclude[]=@rolldown/binding-darwin-arm64
+minimum-release-age-exclude[]=@rolldown/binding-darwin-x64
+minimum-release-age-exclude[]=@rolldown/binding-freebsd-x64
+minimum-release-age-exclude[]=@rolldown/binding-linux-arm-gnueabihf
+minimum-release-age-exclude[]=@rolldown/binding-linux-arm64-gnu
+minimum-release-age-exclude[]=@rolldown/binding-linux-arm64-musl
+minimum-release-age-exclude[]=@rolldown/binding-linux-ppc64-gnu
+minimum-release-age-exclude[]=@rolldown/binding-linux-s390x-gnu
+minimum-release-age-exclude[]=@rolldown/binding-linux-x64-gnu
+minimum-release-age-exclude[]=@rolldown/binding-linux-x64-musl
+minimum-release-age-exclude[]=@rolldown/binding-openharmony-arm64
+minimum-release-age-exclude[]=@rolldown/binding-wasm32-wasi
+minimum-release-age-exclude[]=@rolldown/binding-win32-arm64-msvc
+minimum-release-age-exclude[]=@rolldown/binding-win32-x64-msvc
+minimum-release-age-exclude[]=@rolldown/pluginutils

--- a/README.md
+++ b/README.md
@@ -208,11 +208,15 @@ public/                    # ルートパス固定のファイル
 
 ## パッケージマネージャー
 
-本 starter は内部的に **pnpm** を使用して開発されており、`pnpm-lock.yaml` が commit されています。ただしエンドユーザーは **npm / pnpm / yarn** のいずれでも動作します:
+本 starter は pnpm で開発されており、`pnpm-lock.yaml` が commit されています。エンドユーザーは **npm / pnpm / yarn** のいずれでも動作します:
 
-- 本 README の手順は **npm** 前提（初心者向けの最低障壁）
+- 本 README の手順は **npm** で記述（Node.js 同梱ツールのため追加インストール不要）
 - `pnpm install` でも動作（付属の `pnpm-lock.yaml` で高速・再現可能インストール）
-- `npm install` でも動作（`pnpm-lock.yaml` は無視され、独自に `package-lock.json` を生成）
+- `npm install` でも動作（`pnpm-lock.yaml` は無視され、独自に `package-lock.json` がローカル生成される）
+
+### 生成された lockfile の扱い
+
+`npm install` した場合、`package-lock.json` が生成されます。これを commit するかどうかは、あなたのプロジェクトの方針で判断してください（個人プロジェクト・チーム開発では一般的に commit します）。
 
 Starter 開発（Contribute）の場合は pnpm 推奨。詳細は [CONTRIBUTING.md](./CONTRIBUTING.md) 参照。
 
@@ -221,7 +225,7 @@ Starter 開発（Contribute）の場合は pnpm 推奨。詳細は [CONTRIBUTING
 本リポジトリには `.github/workflows/check.yml` で `pnpm run check` + `pnpm run build` を検証する CI が設定されています。
 
 - **本体リポ（mflocss/starter）**: PR / push 時に自動発動
-- **Fork / Clone したリポ**: `if: github.repository == 'mflocss/starter'` の条件で**自動 skip**（初心者が意図せず Actions が走らない設計）
+- **Fork / Clone したリポ**: `if: github.repository == 'mflocss/starter'` の条件で**自動 skip**（Fork 直後に Actions が意図せず走らない設計）
 - **自分のプロジェクトで有効化する場合**: `.github/workflows/check.yml` の `jobs.check.if` 行を削除してください
 
 これにより「starter 本体の品質ゲート」と「ユーザーに優しいテンプレート」の両立を実現しています。


### PR DESCRIPTION
## Summary

しゅんえい指摘（2026-04-23）に基づく v1.2 ドキュメント / 設定の微調整 4 件:

1. **表現見直し**: 「初心者向けの最低障壁」等、ユーザーを下に見る語感を中立表現に
2. **`.gitignore` から `package-lock.json` 削除**: 個人プロジェクトで commit する一般運用を尊重
3. **README のパッケージマネージャー節を改訂**: npm 使用時の package-lock.json 扱いガイド追加
4. **repo-level `.npmrc` 新設**: rolldown workaround を user 環境（~/.npmrc）から repo に移管

## 背景

### rolldown workaround 移管

PR #146 で `pnpm install` 時に `vite@8.0.10` の依存 `rolldown@1.0.0-rc.17` が pnpm の `minimum-release-age=4320`（3 日）に引っかかった。当時 user の `~/.npmrc` で workaround したが、user 環境を汚染する構造だったため:

- user の `~/.npmrc` は元に戻した（rolldown 関連 17 行削除）
- repo 直下に `.npmrc` 新設 → starter 内で完結、CI でも動作保証

rolldown 安定化 or vite の依存更新で、この `.npmrc` は将来削除予定。

### gitignore 見直し

個人プロジェクト・チーム開発では `package-lock.json` を commit するのが npm の一般的な運用。starter 配布時に `.gitignore` に入れておくとユーザーが clone 後に編集する手間が発生する。デフォルトは「ユーザー自由」の方が親切。README に lockfile の扱い方ガイドを追加。

## Test plan

- [x] `pnpm install --frozen-lockfile` 成功
- [x] `pnpm run check` 通過
- [x] `pnpm run build` 成功
- [ ] 次回 CI 発動で repo .npmrc が `minimum-release-age` をバイパスできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)