### PR TITLE
fix(v1.2): 404 / README 総合クリーンアップ + AR v1.0 後項目 3 件繰り上げ

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Token 層（`src/assets/css/token/`）にデザイン値が集約されていま
 Contact セクション（`src/index.html` 内）のフォームは `action="/api/contact"` を既定値としています。starter 自体は送信処理を提供しないため、外部フォームサービスやバックエンド API に差し替えてください:
 
 ```html
-<form class="c-form p-contact__form" action="https://your-form-service.com/submit" method="post" novalidate>
+<form class="c-form p-contact__form" action="https://your-form-service.com/submit" method="post">
 ```
 
 ## 構造の変更
@@ -196,7 +196,7 @@ src/
 │       └── main.js            # ドロワー・アニメーション・Back to Top
 ├── index.html             # トップページ（Hero〜Contact セクション統合）
 ├── privacy/index.html     # プライバシーポリシー
-└── 404.html               # 404 ページ（参考実装。組み込み時は削除推奨）
+└── 404.html               # 404 ページ（カスタマイズして使う）
 public/                    # ルートパス固定のファイル
 ├── scripts/
 │   └── viewport.js        # ビューポート幅制御（--viewport-min 未満の端末向け）
@@ -229,6 +229,13 @@ Starter 開発（Contribute）の場合は pnpm 推奨。詳細は [CONTRIBUTING
 - **自分のプロジェクトで有効化する場合**: `.github/workflows/check.yml` の `jobs.check.if` 行を削除してください
 
 これにより「starter 本体の品質ゲート」と「ユーザーに優しいテンプレート」の両立を実現しています。
+
+## 設計判断の詳細
+
+starter で採用している設計判断（Component 原則・順序ルール・コメント方針・命名規則等）の詳細は以下を参照してください:
+
+- [mFLOCSS 仕様書](https://mflocss.dev) — 公式規範（MUST / SHOULD / MAY、無料）
+- [そのFLOCSS、なぜそこに書いた？](https://zenn.dev/shunei/books/mflocss-design) — 公式書籍、判断基準の詳細解説（Zenn、一部無料・全編有料）
 
 ## 関連リンク
 

--- a/src/404.html
+++ b/src/404.html
@@ -1,33 +1,33 @@
 <!doctype html>
 <!--
-  CUSTOMIZE: このファイルは mFLOCSS starter 単体運用時の参考実装です。
-             組み込み時は既存サイトの 404 を使用し、このファイルは削除してください。
+  CUSTOMIZE: 404 ページのデザインやメッセージを自由に調整できます。
+             組み込み先サイトのヘッダー・フッター構造と一致するように改変してください。
 -->
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script src="/scripts/viewport.js"></script>
-    <meta name="format-detection" content="telephone=no,address=no,email=no" />
-    <!-- CUSTOMIZE: ダークモード不要なら content="light" に -->
-    <meta name="color-scheme" content="light dark" />
-    <meta name="robots" content="noindex,follow" />
     <!-- CUSTOMIZE: ページタイトル・説明文を差し替え -->
     <title>ページが見つかりません — iluha</title>
     <meta
       name="description"
       content="お探しのページは移動または削除された可能性があります。iluha のトップページから目的のページをお探しください。"
     />
-    <!-- CUSTOMIZE: token/color.css のメインカラーに合わせて変更 -->
-    <meta name="theme-color" content="#5b7a5e" />
-    <!-- Favicon -->
+    <meta name="format-detection" content="telephone=no,address=no,email=no" />
+    <!-- CUSTOMIZE: ダークモード不要なら content="light" に -->
+    <meta name="color-scheme" content="light dark" />
+    <meta name="robots" content="noindex,follow" />
+    <!-- CUSTOMIZE: token/color.css のメインカラーに合わせて変更（ライト / ダークそれぞれ指定） -->
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#5b7a5e" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#1a2e1f" />
+    <!-- Styles -->
+    <link rel="stylesheet" href="/assets/css/style.css" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <!-- Styles -->
-    <link rel="stylesheet" href="/assets/css/style.css" />
     <!-- Scripts -->
     <script type="module" src="/assets/scripts/main.js"></script>
+    <script src="/scripts/viewport.js"></script>
   </head>
   <body id="top">
     <!-- Skip Link -->
@@ -89,10 +89,10 @@
     <main id="main" tabindex="-1" data-drawer-inert>
       <section class="l-section p-not-found" aria-labelledby="not-found-heading">
         <div class="l-inner p-not-found__inner">
-          <div class="c-section-heading p-not-found__heading">
-            <p>404</p>
-            <h1 id="not-found-heading">ページが見つかりません</h1>
-          </div>
+          <hgroup class="c-section-heading p-not-found__heading">
+            <p class="c-section-heading__eyebrow">404</p>
+            <h1 id="not-found-heading" class="c-section-heading__title">ページが見つかりません</h1>
+          </hgroup>
           <p class="p-not-found__lead">
             お探しのページは移動または削除された可能性があります。<br />
             お手数ですが、トップページから目的のページをお探しください。

--- a/src/index.html
+++ b/src/index.html
@@ -12,8 +12,9 @@
     <meta name="format-detection" content="telephone=no,address=no,email=no" />
     <!-- CUSTOMIZE: ダークモード不要なら content="light" に -->
     <meta name="color-scheme" content="light dark" />
-    <!-- CUSTOMIZE: token/color.css のメインカラーに合わせて変更 -->
-    <meta name="theme-color" content="#5b7a5e" />
+    <!-- CUSTOMIZE: token/color.css のメインカラーに合わせて変更（ライト / ダークそれぞれ指定） -->
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#5b7a5e" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#1a2e1f" />
     <!-- OGP -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="iluha — からだの声を、聴く時間。" />
@@ -458,7 +459,7 @@
                 <span class="c-stat__label">リピート率</span>
               </li>
               <li class="c-stat p-numbers__item">
-                <span class="c-stat__value" translate="no">+15<span class="c-stat__unit">min</span></span>
+                <span class="c-stat__value" translate="no">+15<span class="c-stat__unit" lang="en">min</span></span>
                 <span class="c-stat__label">初回カウンセリングの充実度</span>
               </li>
             </ul>

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -12,8 +12,9 @@
     <meta name="format-detection" content="telephone=no,address=no,email=no" />
     <!-- CUSTOMIZE: ダークモード不要なら content="light" に -->
     <meta name="color-scheme" content="light dark" />
-    <!-- CUSTOMIZE: token/color.css のメインカラーに合わせて変更 -->
-    <meta name="theme-color" content="#5b7a5e" />
+    <!-- CUSTOMIZE: token/color.css のメインカラーに合わせて変更（ライト / ダークそれぞれ指定） -->
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#5b7a5e" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#1a2e1f" />
     <!-- OGP -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="プライバシーポリシー — iluha" />


### PR DESCRIPTION
## Summary

しゅんえい指摘（2026-04-23）に基づく 404 対応漏れ + README 古い記述の修正 + AR で v1.0 リリース後扱いだった 3 件を繰り上げて同 PR で対応。

## 修正内容（8 件）

### 404 対応漏れ（2 件）

| # | 対象 | 修正 |
|---|---|---|
| 1 | 404.html L2-5 CUSTOMIZE | 「削除してください」→「カスタマイズして使う」 |
| 2 | 404.html `<head>` 順序 | PR #145（採用 9）と同じ Google Web Fundamentals 順に整列 |

### README 古い記述 / 追加（3 件）

| # | 対象 | 修正 |
|---|---|---|
| 3 | README L102 | `novalidate` 削除（PR #124 以降の実装と整合） |
| 4 | README L199 | 「404.html 削除推奨」→「カスタマイズして使う」 |
| 5 | README 新規 | 「## 設計判断の詳細」セクション追加（spec 無料 + 書籍一部無料・全編有料の 2 段参照） |

### AR v1.0 リリース後項目繰り上げ（3 件）

| # | 採用 # | 対象 | 修正 |
|---|---|---|---|
| 6 | 20 | 404.html heading | `<div>` + `<p>` + `<h1>` → `<hgroup>` + `__eyebrow` + `__title` 統一 |
| 7 | 17 | 全 3 HTML `<meta theme-color>` | `media` 属性付きで light / dark 両対応 |
| 8 | 19 | index.html "min" | `lang="en"` 付与（WCAG 3.1.2） |

## 背景

しゅんえい指摘「404 対応漏れ」を起点に全 404 固有項目 + README 古記述 + v1.0 後項目を一括整理。AR 採用項目は残り採用 10（@property、spec Issue #83 結論待ち）のみとなる。

## Test plan

- [x] `pnpm run check` 通過
- [x] `pnpm run build` 成功
- [ ] 実ブラウザで 404 ページの構造確認
- [ ] Dark mode で theme-color が切り替わることを確認
- [ ] SR で "min" が英語読みされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)