### PR TITLE
fix(v1.2): 公開 API Custom Properties の var(fallback) 構文化（c-form / c-text-block）

### DIFF
--- a/src/assets/css/component/c-form.css
+++ b/src/assets/css/component/c-form.css
@@ -1,7 +1,7 @@
-/* 公開 API: --form-actions-margin-top（送信ボタン前の余白） */
+/* 公開 API:
+     --form-actions-margin-top  (default: var(--space-md))
+     --form-required-mark       (default: '*') */
 .c-form {
-  --form-actions-margin-top: var(--space-md);
-
   display: flex;
   flex-direction: column;
   gap: var(--space-lg);
@@ -87,5 +87,5 @@ textarea.c-form__input {
 .c-form__actions {
   display: flex;
   justify-content: center;
-  margin-block-start: var(--form-actions-margin-top);
+  margin-block-start: var(--form-actions-margin-top, var(--space-md));
 }

--- a/src/assets/css/component/c-text-block.css
+++ b/src/assets/css/component/c-text-block.css
@@ -1,14 +1,13 @@
+/* 公開 API:
+     --text-block-title-max-inline-size  (default: none、使う側（project 層）が制御) */
 .c-text-block {
-  /* 公開 API: title 最大幅を使う側（project 層）が制御する */
-  --text-block-title-max-inline-size: none;
-
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
 }
 
 .c-text-block__title {
-  max-inline-size: var(--text-block-title-max-inline-size);
+  max-inline-size: var(--text-block-title-max-inline-size, none);
 }
 
 .c-text-block__text {


### PR DESCRIPTION
## Summary

v1.0 blocker として、c-form / c-text-block の公開 API Custom Properties を `var(fallback)` 構文に統一。親継承パターンが機能しない correctness bug を修正（Issue #116 の残作業）。

## 背景

「公開 API」と謳いながら、基本 selector で `--xxx: <value>;` として再宣言していたため、親要素から上書きしても shadow されて効かない状態だった。

```css
/* bug 例 */
.c-form { --form-actions-margin-top: var(--space-md); }  /* ← 自身で宣言 */
.p-contact { --form-actions-margin-top: 2rem; }  /* ← 効かない */
```

## 修正

| Component | 修正内容 |
|---|---|
| c-form | `.c-form` から `--form-actions-margin-top` 再宣言削除。`.c-form__actions` の使用箇所に `var(fallback)` 付与 |
| c-text-block | `.c-text-block` から `--text-block-title-max-inline-size` 再宣言削除。`.c-text-block__title` の使用箇所に `var(fallback)` 付与 |

## 他 Component の状態

- ✅ c-card / c-prose / c-media-split: 既に `var(fallback)` 構文化済（PR #110）
- ✅ c-card `.-subtle` Modifier 内: Modifier 必須設計、基本 selector 再宣言なし（走査確認済）
- ⚠️ c-button / c-icon-button: Modifier 必須設計（別議論、v1.1 検討継続）

## Test plan

- [x] `pnpm run check` 通過
- [x] `pnpm run build` 成功
- [ ] 3 パターン動作確認:
  - Default（親で set なし、modifier なし）: fallback 値が適用される
  - Modifier（例: `.c-card.-subtle`）: modifier 内の値が適用される
  - 親継承（`.parent { --xxx: value; }`）: 親の値が子 Component に継承される ← **今回修正で機能化**

## Issue 関連

Issue #116（v1.1 検討: `var(fallback)` 構文化）の starter 本体実装分を本 PR で v1.0 完結。
Issue #116 は「spec 反映 / 書籍反映」として v1.1 へ残タスクをリネーム or クローズ → 新 Issue 再起票予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)