### PR TITLE
refactor(v1.2): 公開 API 設計統一（motion.css リネーム + c-button デフォルト化 + c-media-split 整理）

### DIFF
--- a/src/assets/css/component/c-button.css
+++ b/src/assets/css/component/c-button.css
@@ -1,6 +1,9 @@
+/* 公開 API:
+     --button-color             (default: var(--color-surface)、= -primary 相当)
+     --button-bg-color          (default: var(--color-accent)、= -primary 相当)
+     --button-border-color      (default: var(--color-accent)、= -primary 相当)
+     --button-hover-bg-color    (default: -primary 相当) */
 .c-button {
-  --_hover-lift: -2px;
-
   display: inline-flex;
   gap: var(--space-sm);
   align-items: center;
@@ -9,11 +12,11 @@
   font-size: inherit;
   font-weight: var(--font-weight-heading);
   line-height: var(--line-height-title);
-  color: var(--button-color);
+  color: var(--button-color, var(--color-surface));
   text-decoration: none;
   cursor: pointer;
-  background-color: var(--button-bg-color);
-  border: var(--border-width) solid var(--button-border-color);
+  background-color: var(--button-bg-color, var(--color-accent));
+  border: var(--border-width) solid var(--button-border-color, var(--color-accent));
   border-radius: var(--radius-lg);
 
   @media (prefers-reduced-motion: no-preference) {
@@ -24,8 +27,8 @@
 
   @media (any-hover: hover) {
     &:hover {
-      background-color: var(--button-hover-bg-color);
-      translate: 0 var(--_hover-lift);
+      background-color: var(--button-hover-bg-color, oklch(from var(--color-accent) calc(l * 1.08) c h));
+      translate: 0 var(--hover-lift);
     }
   }
 
@@ -39,11 +42,9 @@
   }
 }
 
+/* Modifier: -primary（明示的選択マーカー、デフォルトと同じ値のため空ルール） */
 .c-button.-primary {
-  --button-color: var(--color-surface);
-  --button-bg-color: var(--color-accent);
-  --button-border-color: var(--color-accent);
-  --button-hover-bg-color: oklch(from var(--color-accent) calc(l * 1.08) c h);
+  /* スタイルなし（base のデフォルトが primary 相当） */
 }
 
 .c-button.-ghost {

--- a/src/assets/css/component/c-icon-button.css
+++ b/src/assets/css/component/c-icon-button.css
@@ -1,6 +1,9 @@
+/* 公開 API:
+     --button-color             (default: var(--color-surface)、= -primary 相当)
+     --button-bg-color          (default: var(--color-accent)、= -primary 相当)
+     --button-border-color      (default: var(--color-accent)、= -primary 相当)
+     --button-hover-bg-color    (default: -primary 相当) */
 .c-icon-button {
-  --_hover-lift: -2px;
-
   display: inline-flex;
   gap: var(--space-sm);
   align-items: center;
@@ -9,11 +12,11 @@
   font-size: inherit;
   font-weight: var(--font-weight-heading);
   line-height: var(--line-height-title);
-  color: var(--button-color);
+  color: var(--button-color, var(--color-surface));
   text-decoration: none;
   cursor: pointer;
-  background-color: var(--button-bg-color);
-  border: var(--border-width) solid var(--button-border-color);
+  background-color: var(--button-bg-color, var(--color-accent));
+  border: var(--border-width) solid var(--button-border-color, var(--color-accent));
   border-radius: var(--radius-lg);
 
   @media (prefers-reduced-motion: no-preference) {
@@ -24,8 +27,8 @@
 
   @media (any-hover: hover) {
     &:hover {
-      background-color: var(--button-hover-bg-color);
-      translate: 0 var(--_hover-lift);
+      background-color: var(--button-hover-bg-color, oklch(from var(--color-accent) calc(l * 1.08) c h));
+      translate: 0 var(--hover-lift);
     }
   }
 
@@ -45,11 +48,9 @@
   block-size: 1em;
 }
 
+/* Modifier: -primary（明示的選択マーカー、デフォルトと同じ値のため空ルール） */
 .c-icon-button.-primary {
-  --button-color: var(--color-surface);
-  --button-bg-color: var(--color-accent);
-  --button-border-color: var(--color-accent);
-  --button-hover-bg-color: oklch(from var(--color-accent) calc(l * 1.08) c h);
+  /* スタイルなし（base のデフォルトが primary 相当） */
 }
 
 .c-icon-button.-ghost {

--- a/src/assets/css/component/c-media-split.css
+++ b/src/assets/css/component/c-media-split.css
@@ -1,7 +1,6 @@
-/* 公開 API: --media-split-first-order で左右反転（`:nth-child(even)` 等で活用） */
+/* 公開 API:
+     --media-split-first-order  (default: 0、`:nth-child(even)` 等で 1 を set して左右反転) */
 .c-media-split {
-  --_order: var(--media-split-first-order, 0);
-
   display: grid;
   gap: var(--space-xl);
   align-items: center;
@@ -11,7 +10,7 @@
   }
 
   & > :first-child {
-    order: var(--_order);
+    order: var(--media-split-first-order, 0);
   }
 }
 

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -9,7 +9,7 @@
 @import './token/radius.css' layer(token);
 @import './token/shadow.css' layer(token);
 @import './token/z-index.css' layer(token);
-@import './token/ease.css' layer(token);
+@import './token/motion.css' layer(token);
 
 /* Reset: ブラウザ環境の初期化 */
 @import './reset/reset.css' layer(reset);

--- a/src/assets/css/token/ease.css
+++ b/src/assets/css/token/ease.css
@@ -1,7 +1,0 @@
-/* CUSTOMIZE: イージング・デュレーション（プロジェクト横断で共通） */
-:root {
-  --ease-out-cubic: cubic-bezier(0.215, 0.61, 0.355, 1);
-  --ease-out-quart: cubic-bezier(0.165, 0.84, 0.44, 1);
-  --duration-fast: 0.2s;
-  --duration-normal: 0.3s;
-}

--- a/src/assets/css/token/motion.css
+++ b/src/assets/css/token/motion.css
@@ -1,0 +1,8 @@
+/* CUSTOMIZE: イージング・デュレーション・モーション系定数（プロジェクト横断で共通） */
+:root {
+  --ease-out-cubic: cubic-bezier(0.215, 0.61, 0.355, 1);
+  --ease-out-quart: cubic-bezier(0.165, 0.84, 0.44, 1);
+  --duration-fast: 0.2s;
+  --duration-normal: 0.3s;
+  --hover-lift: -2px; /* hover 時の translate Y 値、starter 全 hover Component 共用 */
+}


### PR DESCRIPTION
## Summary

v1.2 starter の公開 API Custom Property 設計を統一。motion.css リネーム + c-button / c-icon-button デフォルト化 + c-media-split 中間変数削除 + `--hover-lift` token 化。

## 修正 4 件

### 1. `token/ease.css` → `token/motion.css` リネーム + `--hover-lift` 追加

ease.css は実質「motion/transition 系」定数を集約していたため、名称を motion.css に変更。将来の motion 系 token 拡張（stagger-delay 等）にも対応。`--hover-lift: -2px` を共有 token として追加。

### 2. c-button / c-icon-button をデフォルト primary 設計に

現状は Modifier 必須設計（`.c-button` 単独ではスタイル未定義）。以下に変更:
- base に `var(--button-color, var(--color-surface))` 等 fallback 内包（= -primary 相当のデフォルト）
- `.-primary` は空ルール placeholder（明示的選択マーカー、starter HTML の記述パターン維持）
- `.-ghost` は現状維持
- `--_hover-lift: -2px` 削除、`var(--hover-lift)` を使用

これで `.c-button` 単独でも primary デザインで機能、Block 単体の教材性確保。

### 3. c-media-split の中間変数削除

`--_order: var(--media-split-first-order, 0)` の中間変数は計算なし・単一箇所使用で機能不要。使用箇所で `var(--media-split-first-order, 0)` を直接使用。全 Component の公開 API pattern 統一。

### 4. 公開 API コメント付与

c-button / c-icon-button / c-media-split の冒頭に `/* 公開 API: ... (default: ...) */` コメント追加。他 Component（c-card / c-prose / c-form / c-text-block）と記述統一。

## 全 Component 公開 API 設計の最終形

| Component | 公開 API | パターン |
|---|---|---|
| c-card | `--card-padding` / `--card-bg` / `--card-radius` / `--card-shadow` / `--card-border` | ✅ var(fallback) at usage |
| c-prose | `--prose-max-inline-size` | ✅ var(fallback) at usage |
| c-form | `--form-actions-margin-top` / `--form-required-mark` | ✅ var(fallback) at usage |
| c-text-block | `--text-block-title-max-inline-size` | ✅ var(fallback) at usage |
| c-media-split | `--media-split-first-order` | ✅ var(fallback) at usage（中間変数削除） |
| **c-button** | `--button-color` / `--button-bg-color` / `--button-border-color` / `--button-hover-bg-color` | ✅ **var(fallback) at usage（本 PR で対応）** |
| **c-icon-button** | 同 c-button | ✅ **var(fallback) at usage（本 PR で対応）** |

全 Component で統一パターン達成。

## Test plan

- [x] `pnpm run check` 通過
- [x] `pnpm run build` 成功
- [x] `--_hover-lift` 残存ゼロ確認
- [x] `ease.css` 参照残存ゼロ確認
- [ ] 実ブラウザで c-button / c-icon-button の hover / active / modifier 動作確認
- [ ] c-media-split の layout 動作確認（Features セクション等）

## 関連

- Issue #116（`var(fallback)` 構文化、starter 実装は本 PR で完結）
- Issue #150（`@property` 宣言、spec #83 結論後に適用予定、独立タスク）

🤖 Generated with [Claude Code](https://claude.com/claude-code)