### PR TITLE
chore(v1.2): AR C2 採用 4-6 修正（check スクリプト / CHANGELOG 日付 + links）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,7 @@
 
 mFLOCSS starter の変更履歴。[Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) 形式に準拠し、[Semantic Versioning](https://semver.org/lang/ja/) に従う。
 
-## [Unreleased]
-
-（次期バージョンの変更内容はここに追記）
-
-## [1.0.0] - YYYY-MM-DD
+## [Unreleased] (v1.0 リリース予定)
 
 初回正式リリース。
 
@@ -24,3 +20,5 @@ mFLOCSS starter の変更履歴。[Keep a Changelog](https://keepachangelog.com/
 - Community health files（CHANGELOG / CONTRIBUTING / SECURITY / CODE_OF_CONDUCT）
 - GitHub Actions CI（starter 本体のみ発動、Fork / Clone 時は自動 skip）
 - Issue テンプレート（bug report / feature request）
+
+[Unreleased]: https://github.com/mflocss/starter/compare/v1.0.0...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,13 @@ Node.js LTS 以降を推奨。
 - 既存 Component / Project のパターンを踏襲
 - コメント方針は CSS 内コメント / PR body 参照
 
+## リリース時の手順
+
+1. `CHANGELOG.md` の `## [Unreleased]` セクション見出しを `## [x.y.z] - YYYY-MM-DD` に置換（リリース実日付を記入）
+2. `## [Unreleased]` セクションをファイル先頭に新設（空の状態で追加）
+3. ファイル末尾の link references を更新（`[Unreleased]` の比較 URL と `[x.y.z]` のタグ URL を追加）
+4. `git tag vx.y.z` でリリースタグを切る
+
 ## 行動規範
 
 本プロジェクトは [Contributor Covenant 2.1](./CODE_OF_CONDUCT.md) を採用します。

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:js": "eslint \"src/**/*.js\" --fix",
     "lint:html": "markuplint \"src/**/*.html\"",
     "format": "prettier --write .",
-    "check": "npm run format && npm run lint:css && npm run lint:js && npm run lint:html"
+    "check": "pnpm run format && pnpm run lint:css && pnpm run lint:js && pnpm run lint:html"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary

AR C2 採用 4-6（OSS 基盤 3 件、軽量機械修正）を対応。

| 採用 # | 修正 |
|---|---|
| 4 | `package.json` の `check` scripts を `npm run` → `pnpm run` 統一 |
| 5 | CHANGELOG の `## [1.0.0] - YYYY-MM-DD` を `## [Unreleased] (v1.0 リリース予定)` に変更、CONTRIBUTING にリリース手順追記 |
| 6 | CHANGELOG 末尾に link references 追加（Keep a Changelog v1.1.0 準拠） |

## AR C2 判定

- v1.2 → main 統合 blocker（H 即時 6 件の一部）
- 残 H 即時 3 件（採用 1 / 2-11 / 3）はフォーム再設計 PR + Drawer モーダル性 PR で別対応

## 変更詳細

**採用 4（package.json）**  
CI / CONTRIBUTING が pnpm 前提にもかかわらず `check` スクリプトが `npm run` を使用していた二重構造を解消。

**採用 5（CHANGELOG）**  
v1.0 未リリースのためプレースホルダー `YYYY-MM-DD` が公開時に外観欠陥となる問題を解消。既存の `## [Unreleased]`（空プレースホルダー）と `## [1.0.0] - YYYY-MM-DD` を `## [Unreleased] (v1.0 リリース予定)` に統合。v1.0 tag 切り時に CONTRIBUTING の手順に従い実日付に置換する運用。

**採用 6（CHANGELOG link references）**  
Keep a Changelog v1.1.0 準拠の `[Unreleased]` link reference を末尾に追加。`## [1.0.0]` セクション削除のため `[Unreleased]` のみ追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)