### PR TITLE
fix(v1.2): AR C2 フォーム再設計（採用 1/3/12/13）

### DIFF
--- a/src/assets/css/component/c-form.css
+++ b/src/assets/css/component/c-form.css
@@ -66,6 +66,17 @@ textarea.c-form__input {
   max-block-size: 20lh;
 }
 
+/* Element: error — :user-invalid 時に表示される SR 対応エラーメッセージ（WCAG 3.3.1） */
+.c-form__error {
+  margin-block-start: var(--space-xs);
+  font-size: var(--font-size-caption);
+  color: var(--color-error);
+
+  &[hidden] {
+    display: none;
+  }
+}
+
 /* Element: radio / checkbox ラベル（両用） */
 .c-form__choice-label {
   display: flex;

--- a/src/assets/scripts/main.js
+++ b/src/assets/scripts/main.js
@@ -195,11 +195,73 @@ function initBackToTop(options = {}) {
   toggleVisibility();
 }
 
+/**
+ * フォームバリデーション（:user-invalid → aria-invalid + error container 表示制御）を初期化する。
+ * submit 時・invalid イベント時に aria-invalid="true" と error container を表示し、
+ * 修正後 input イベントで valid になったら解除する。
+ * @param {Object} [options] - カスタマイズオプション
+ * @param {string} [options.formSelector='.c-form'] - フォームのセレクター
+ */
+function initFormValidation(options = {}) {
+  const { formSelector = '.c-form' } = options;
+
+  const forms = document.querySelectorAll(formSelector);
+  if (forms.length === 0) return;
+
+  forms.forEach((form) => {
+    const fields = form.querySelectorAll(
+      'input[aria-describedby], select[aria-describedby], textarea[aria-describedby]',
+    );
+
+    function showError(field) {
+      field.setAttribute('aria-invalid', 'true');
+      const errorEl = document.getElementById(field.getAttribute('aria-describedby'));
+      if (errorEl) errorEl.hidden = false;
+    }
+
+    function clearError(field) {
+      field.removeAttribute('aria-invalid');
+      const errorEl = document.getElementById(field.getAttribute('aria-describedby'));
+      if (errorEl) errorEl.hidden = true;
+    }
+
+    fields.forEach((field) => {
+      field.addEventListener('invalid', () => showError(field));
+      field.addEventListener('input', () => {
+        if (field.validity.valid) clearError(field);
+      });
+    });
+
+    // fieldset の radio group: submit 失敗時に plan-error を表示
+    const radioGroups = form.querySelectorAll('fieldset[aria-describedby]');
+    radioGroups.forEach((fieldset) => {
+      const radios = fieldset.querySelectorAll('input[type="radio"]');
+      const firstRequired = fieldset.querySelector('input[type="radio"][required]');
+      if (!firstRequired) return;
+
+      firstRequired.addEventListener('invalid', () => {
+        fieldset.setAttribute('aria-invalid', 'true');
+        const errorEl = document.getElementById(fieldset.getAttribute('aria-describedby'));
+        if (errorEl) errorEl.hidden = false;
+      });
+
+      radios.forEach((radio) => {
+        radio.addEventListener('change', () => {
+          fieldset.removeAttribute('aria-invalid');
+          const errorEl = document.getElementById(fieldset.getAttribute('aria-describedby'));
+          if (errorEl) errorEl.hidden = true;
+        });
+      });
+    });
+  });
+}
+
 // 初期化（デフォルト値で動作）
 initDrawer();
 initStagger();
 initScrollAnimation();
 initBackToTop();
+initFormValidation();
 
 // CUSTOMIZE 例:
 // initDrawer({ breakpoint: 1024 });

--- a/src/index.html
+++ b/src/index.html
@@ -290,7 +290,7 @@
                   <figure class="c-media-split__media">
                     <img
                       src="./assets/images/feature-counseling.webp"
-                      alt=""
+                      alt="カウンセリングルームで施術者が話を聴いている場面"
                       width="480"
                       height="320"
                       loading="lazy"
@@ -314,7 +314,7 @@
                   <figure class="c-media-split__media">
                     <img
                       src="./assets/images/feature-treatment.webp"
-                      alt=""
+                      alt="施術者がベッドに横たわる方の筋膜にアプローチしている様子"
                       width="480"
                       height="320"
                       loading="lazy"
@@ -337,7 +337,7 @@
                   <figure class="c-media-split__media">
                     <img
                       src="./assets/images/feature-private-room.webp"
-                      alt=""
+                      alt="間接照明が灯る静かな完全個室の施術スペース"
                       width="480"
                       height="320"
                       loading="lazy"
@@ -619,15 +619,35 @@
 
           <!-- CUSTOMIZE: 本番バックエンド URL に差し替え。starter はフォーム送信処理を提供しません -->
           <form class="c-form p-contact__form" action="/api/contact" method="post">
-            <p class="c-form__note"><span aria-hidden="true">*</span> は必須項目です</p>
+            <p class="c-form__note"><span>*</span> のついた項目は必須です</p>
             <div class="c-form__field">
               <label class="c-form__label" for="name">お名前</label>
-              <input class="c-form__input" id="name" name="name" type="text" autocomplete="name" required />
+              <input
+                class="c-form__input"
+                id="name"
+                name="name"
+                type="text"
+                autocomplete="name"
+                required
+                aria-describedby="name-error"
+              />
+              <span class="c-form__error" id="name-error" role="alert" hidden>お名前を入力してください</span>
             </div>
 
             <div class="c-form__field">
               <label class="c-form__label" for="email">メールアドレス</label>
-              <input class="c-form__input" id="email" name="email" type="email" autocomplete="email" required />
+              <input
+                class="c-form__input"
+                id="email"
+                name="email"
+                type="email"
+                autocomplete="email"
+                required
+                aria-describedby="email-error"
+              />
+              <span class="c-form__error" id="email-error" role="alert" hidden
+                >有効なメールアドレスを入力してください</span
+              >
             </div>
 
             <div class="c-form__field">
@@ -637,15 +657,18 @@
 
             <div class="c-form__field">
               <label class="c-form__label" for="category">お問い合わせ種別</label>
-              <select class="c-form__input" id="category" name="category" required>
+              <select class="c-form__input" id="category" name="category" required aria-describedby="category-error">
                 <option value="">選択してください</option>
                 <option value="reservation">初回体験の予約</option>
                 <option value="inquiry">施術に関するお問い合わせ</option>
                 <option value="other">その他</option>
               </select>
+              <span class="c-form__error" id="category-error" role="alert" hidden
+                >お問い合わせ種別を選択してください</span
+              >
             </div>
 
-            <fieldset class="c-form__field">
+            <fieldset class="c-form__field" aria-describedby="plan-error">
               <legend class="c-form__legend">ご希望のプラン</legend>
               <div class="c-form__choice-group">
                 <label class="c-form__choice-label">
@@ -661,18 +684,30 @@
                   リラクゼーション（90分）
                 </label>
               </div>
+              <span class="c-form__error" id="plan-error" role="alert" hidden>プランを選択してください</span>
             </fieldset>
 
             <div class="c-form__field">
               <label class="c-form__label" for="message">メッセージ</label>
-              <textarea class="c-form__input" id="message" name="message" rows="6" required></textarea>
+              <textarea
+                class="c-form__input"
+                id="message"
+                name="message"
+                rows="6"
+                required
+                aria-describedby="message-error"
+              ></textarea>
+              <span class="c-form__error" id="message-error" role="alert" hidden>メッセージを入力してください</span>
             </div>
 
             <div class="c-form__field">
-              <div class="c-form__choice-label">
-                <input id="agree" name="agree" type="checkbox" required aria-labelledby="agree-label" />
-                <span id="agree-label"><a href="/privacy/">プライバシーポリシー</a>に同意する</span>
-              </div>
+              <label class="c-form__choice-label" for="agree">
+                <input id="agree" name="agree" type="checkbox" required aria-describedby="agree-error" />
+                <a href="/privacy/">プライバシーポリシー</a>に同意する
+              </label>
+              <span class="c-form__error" id="agree-error" role="alert" hidden
+                >プライバシーポリシーへの同意が必要です</span
+              >
             </div>
 
             <div class="c-form__actions">


### PR DESCRIPTION
## Summary

AR C2 で判明したフォーム全体の欠陥集中（HTML LS 違反 + WCAG 3.3.1 Level A 違反 + C1 回帰 + figcaption 矛盾）を 1 PR でまとめて解消。

| 採用 # | 優先度 | 修正 |
|---|---|---|
| 1 | H 即時 | C1 回帰: `<label for>` 復活 + `<a>` を label 内に残す（HTML LS 準拠）|
| 3 | H 即時 | WCAG 3.3.1 Level A: 全フィールドに aria-describedby + error container + main.js で invalid → aria-invalid + 表示制御 |
| 12 | M v1.0 前 | C1 回帰: form note を「* のついた項目は必須です」に修正、`<span>` ラップで SR 自然読み上げ + markuplint use-list 回避 |
| 13 | M v1.0 前 | `<figure>/<figcaption>` に具体 alt を付与（3 箇所）|

## 背景

AR C2（2026-04-23）で「フォーム実装に複数観点から欠陥集中」と判定。v1.0 リリース blocker。

## 採用 1 設計判断

HTML LS では `<label>` の interactive content 禁止対象は labelable elements のみ（`<button>`, `<input>`, `<select>` 等）。`<a>` は phrasing content であり labelable element ではないため label 内に配置可。リンクと label の activation は各ブラウザが自然に分離（テキスト部クリック→checkbox toggle、リンク部クリック→遷移）。

## 採用 3 設計判断

tel フィールド（任意項目）は `aria-describedby` / error container を付与しない（必須制約なし）。radio group（fieldset）は個別 input ではなく `fieldset[aria-describedby]` で JS が検知する方式を採用。`invalid` イベントは最初の `required` radio に発火するため、これをトリガーにグループ単位の error 表示を実行。

## 採用 12 設計判断

bare `*` テキストノードは markuplint `use-list` ルールで誤検知されるため `<span>*</span>` でラップ。`aria-hidden` は除去し SR が「アスタリスク のついた項目は必須です」と完全文として読み上げるようにした。

## Test plan

- [x] `pnpm run check` 通過
- [x] `pnpm run build` 成功
- [ ] 実ブラウザで「プライバシーポリシー」リンククリック時にリンク遷移、「に同意する」テキストクリック時に checkbox toggle 確認
- [ ] 実ブラウザで email 空送信 → aria-invalid="true" + error container 表示確認
- [ ] SR で「アスタリスク のついた項目は必須です」読み上げ確認
- [ ] figure の alt 情報が SR で読み上げられるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)