### PR TITLE
fix(v1.2): AR C2 採用 2 + 11（Drawer モーダル性 — header inert + 閉じるボタン）

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -34,7 +34,7 @@
     <a class="c-skip-link u-visually-hidden" data-drawer-inert href="#main">本文へスキップ</a>
 
     <!-- Header -->
-    <header class="l-header p-header">
+    <header class="l-header p-header" data-drawer-inert>
       <div class="l-inner p-header__bar">
         <a href="/" class="p-header__logo" translate="no">iluha</a>
 
@@ -66,6 +66,16 @@
     <dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title" aria-modal="true">
       <div class="p-drawer__stack">
         <span id="drawer-title" class="u-visually-hidden">ナビゲーションメニュー</span>
+        <button
+          class="c-icon-button -ghost p-drawer__close"
+          type="button"
+          data-drawer-close
+          aria-label="メニューを閉じる"
+        >
+          <svg class="c-icon-button__icon" width="20" height="20" aria-hidden="true">
+            <use href="/assets/images/icons/close.svg#icon" />
+          </svg>
+        </button>
         <nav class="p-drawer__nav" aria-label="ドロワーナビゲーション">
           <ul class="p-drawer__nav-list">
             <li>

--- a/src/assets/css/project/p-drawer.css
+++ b/src/assets/css/project/p-drawer.css
@@ -69,3 +69,9 @@
 .p-drawer__cta {
   margin-block-start: var(--space-md);
 }
+
+/* c-icon-button のデフォルト横パディングを縮小してアイコン単体ボタン形状に */
+.p-drawer__close {
+  align-self: flex-end;
+  padding: var(--space-sm);
+}

--- a/src/assets/images/icons/close.svg
+++ b/src/assets/images/icons/close.svg
@@ -1,0 +1,4 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+  <line x1="5" y1="5" x2="15" y2="15"/>
+  <line x1="15" y1="5" x2="5" y2="15"/>
+</svg>

--- a/src/assets/scripts/main.js
+++ b/src/assets/scripts/main.js
@@ -95,6 +95,15 @@ function initDrawer(options = {}) {
     });
   });
 
+  // drawer 内の閉じるボタン（header inert 化により hamburger が使えない場合の代替動線）
+  const drawerCloseButton = drawer.querySelector('[data-drawer-close]');
+  if (drawerCloseButton) {
+    drawerCloseButton.addEventListener('click', () => {
+      closeDrawer();
+      hamburgers[0]?.focus({ preventScroll: true });
+    });
+  }
+
   drawerLinks.forEach((link) => {
     link.addEventListener('click', () => {
       const href = link.getAttribute('href');

--- a/src/index.html
+++ b/src/index.html
@@ -146,7 +146,7 @@
     <a class="c-skip-link u-visually-hidden" data-drawer-inert href="#main">本文へスキップ</a>
 
     <!-- Header -->
-    <header class="l-header p-header">
+    <header class="l-header p-header" data-drawer-inert>
       <div class="l-inner p-header__bar">
         <!-- CUSTOMIZE: サービス名を差し替え -->
         <a class="p-header__logo" href="/" translate="no">iluha</a>
@@ -179,6 +179,16 @@
     <dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title" aria-modal="true">
       <div class="p-drawer__stack">
         <span class="u-visually-hidden" id="drawer-title">ナビゲーションメニュー</span>
+        <button
+          class="c-icon-button -ghost p-drawer__close"
+          type="button"
+          data-drawer-close
+          aria-label="メニューを閉じる"
+        >
+          <svg class="c-icon-button__icon" width="20" height="20" aria-hidden="true">
+            <use href="/assets/images/icons/close.svg#icon" />
+          </svg>
+        </button>
         <nav class="p-drawer__nav" aria-label="ドロワーナビゲーション">
           <ul class="p-drawer__nav-list">
             <li>

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -74,7 +74,7 @@
     <a class="c-skip-link u-visually-hidden" data-drawer-inert href="#main">本文へスキップ</a>
 
     <!-- Header -->
-    <header class="l-header p-header">
+    <header class="l-header p-header" data-drawer-inert>
       <div class="l-inner p-header__bar">
         <a href="/" class="p-header__logo" translate="no">iluha</a>
 
@@ -106,6 +106,16 @@
     <dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title" aria-modal="true">
       <div class="p-drawer__stack">
         <span id="drawer-title" class="u-visually-hidden">ナビゲーションメニュー</span>
+        <button
+          class="c-icon-button -ghost p-drawer__close"
+          type="button"
+          data-drawer-close
+          aria-label="メニューを閉じる"
+        >
+          <svg class="c-icon-button__icon" width="20" height="20" aria-hidden="true">
+            <use href="/assets/images/icons/close.svg#icon" />
+          </svg>
+        </button>
         <nav class="p-drawer__nav" aria-label="ドロワーナビゲーション">
           <ul class="p-drawer__nav-list">
             <li>


### PR DESCRIPTION
## Summary

AR C2 で判明した Drawer モーダル性の欠陥（header inert 未適用 + 閉じるボタン欠落）を 1 PR でまとめて修正。

| 採用 # | 優先度 | 修正 |
|---|---|---|
| 2 | H 即時 | 全 3 HTML の `<header>` に `data-drawer-inert` 追加 → drawer 展開中の header inert 化 |
| 11 | H 即時 | drawer 内に `c-icon-button -ghost p-drawer__close` ベースの閉じるボタン追加（全 3 HTML）+ main.js に click handler + p-drawer.css に `__close` スタイル |

## 背景

AR C2（2026-04-23）で「Drawer モーダル封じ込めパターンの欠陥」と判定。採用 2 と 11 は同時修正前提（採用 2 だけ適用すると Esc キー以外の閉じる動線がなくなる）。

close.svg は既存 SVG sprite と同スタイル（`stroke="currentColor"` ベース、20×20 viewBox）で新規作成。

## Test plan

- [x] `pnpm run check` 通過（markuplint 全 3 ファイル passed）
- [x] `pnpm run build` 成功（close.svg が dist に含まれている）
- [ ] 実ブラウザで drawer 展開中、header 内 logo / nav / hamburger が Tab キーで focus 取得不可を確認
- [ ] drawer 内の閉じるボタンをクリック → drawer 閉じる
- [ ] VoiceOver iOS スワイプで drawer 内の要素のみアクセス可能（background inert 動作）

🤖 Generated with [Claude Code](https://claude.com/claude-code)