### PR TITLE
fix(v1.2): AR C2 採用 7/10/15 修正（field-sizing コメント + SVG パス統一 + reduced-motion ガード）

### DIFF
--- a/src/assets/css/component/c-back-to-top.css
+++ b/src/assets/css/component/c-back-to-top.css
@@ -25,7 +25,6 @@
   background-color: var(--color-main);
   border-radius: var(--radius-full);
   opacity: 0;
-  transition: background-color var(--duration-fast) var(--ease-out-cubic);
 
   @media (prefers-reduced-motion: no-preference) {
     transition:

--- a/src/assets/css/component/c-form.css
+++ b/src/assets/css/component/c-form.css
@@ -60,6 +60,9 @@
   }
 }
 
+/* NOTE: field-sizing は Baseline 未達（Firefox 145+、2026-04 リリース）。
+   未対応ブラウザでは固定高 textarea になるため、min/max-block-size でサイズ範囲を制限して
+   崩れを抑制している */
 textarea.c-form__input {
   field-sizing: content;
   min-block-size: 10lh;

--- a/src/assets/css/project/p-drawer.css
+++ b/src/assets/css/project/p-drawer.css
@@ -57,7 +57,10 @@
   font-size: var(--font-size-nav-lg);
   color: var(--color-text);
   text-decoration: none;
-  transition: color var(--duration-fast) var(--ease-out-cubic);
+
+  @media (prefers-reduced-motion: no-preference) {
+    transition: color var(--duration-fast) var(--ease-out-cubic);
+  }
 
   @media (any-hover: hover) {
     &:hover {

--- a/src/assets/css/project/p-header.css
+++ b/src/assets/css/project/p-header.css
@@ -51,7 +51,10 @@
   font-size: var(--font-size-caption);
   color: var(--_link-color);
   text-decoration: none;
-  transition: color var(--duration-fast) var(--ease-out-cubic);
+
+  @media (prefers-reduced-motion: no-preference) {
+    transition: color var(--duration-fast) var(--ease-out-cubic);
+  }
 
   @media (any-hover: hover) {
     &:hover {

--- a/src/index.html
+++ b/src/index.html
@@ -224,7 +224,7 @@
               <a class="c-icon-button -primary -large p-hero__cta" href="#contact">
                 初回体験を予約する
                 <svg class="c-icon-button__icon" width="20" height="20" aria-hidden="true">
-                  <use href="./assets/images/icons/arrow-right.svg#icon" />
+                  <use href="/assets/images/icons/arrow-right.svg#icon" />
                 </svg>
               </a>
               <a class="c-button -ghost -large p-hero__sub-cta" href="#features">選ばれる理由を見る</a>
@@ -563,7 +563,7 @@
                 <summary class="c-accordion__summary">
                   施術に痛みはありますか？
                   <svg class="c-accordion__icon" width="20" height="20" aria-hidden="true">
-                    <use href="./assets/images/icons/chevron-down.svg#icon" />
+                    <use href="/assets/images/icons/chevron-down.svg#icon" />
                   </svg>
                 </summary>
                 <div class="c-accordion__content">
@@ -578,7 +578,7 @@
                 <summary class="c-accordion__summary">
                   どのくらいの頻度で通えばいいですか？
                   <svg class="c-accordion__icon" width="20" height="20" aria-hidden="true">
-                    <use href="./assets/images/icons/chevron-down.svg#icon" />
+                    <use href="/assets/images/icons/chevron-down.svg#icon" />
                   </svg>
                 </summary>
                 <div class="c-accordion__content">
@@ -593,7 +593,7 @@
                 <summary class="c-accordion__summary">
                   予約の変更やキャンセルはできますか？
                   <svg class="c-accordion__icon" width="20" height="20" aria-hidden="true">
-                    <use href="./assets/images/icons/chevron-down.svg#icon" />
+                    <use href="/assets/images/icons/chevron-down.svg#icon" />
                   </svg>
                 </summary>
                 <div class="c-accordion__content">
@@ -606,7 +606,7 @@
                 <summary class="c-accordion__summary">
                   男性も利用できますか？
                   <svg class="c-accordion__icon" width="20" height="20" aria-hidden="true">
-                    <use href="./assets/images/icons/chevron-down.svg#icon" />
+                    <use href="/assets/images/icons/chevron-down.svg#icon" />
                   </svg>
                 </summary>
                 <div class="c-accordion__content">
@@ -758,7 +758,7 @@
     <!-- Back to Top -->
     <a class="c-back-to-top" data-back-to-top href="#top" aria-label="ページの先頭に戻る">
       <svg class="c-back-to-top__icon" width="20" height="20" aria-hidden="true">
-        <use href="./assets/images/icons/chevron-up.svg#icon" />
+        <use href="/assets/images/icons/chevron-up.svg#icon" />
       </svg>
     </a>
   </body>

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -205,7 +205,7 @@
     <!-- Back to Top -->
     <a href="#top" class="c-back-to-top" data-back-to-top aria-label="ページの先頭に戻る">
       <svg class="c-back-to-top__icon" width="20" height="20" aria-hidden="true">
-        <use href="../assets/images/icons/chevron-up.svg#icon" />
+        <use href="/assets/images/icons/chevron-up.svg#icon" />
       </svg>
     </a>
   </body>


### PR DESCRIPTION
## Summary

AR C2 一貫性修正 3 件を 1 PR でまとめて対応。機械的修正のため軽量。

| 採用 # | ファイル | 修正内容 |
|---|---|---|
| 7 | c-form.css L63-66 | `field-sizing: content` に Firefox 互換 NOTE コメント追加 |
| 10 | 全 3 HTML | SVG `<use href>` を絶対パス `/assets/images/icons/...` に統一 |
| 15 | c-back-to-top.css / p-header.css / p-drawer.css | transition を `@media (prefers-reduced-motion: no-preference)` 内に移動（既存規約に統一） |

## 背景

AR C2（2026-04-23）判定。いずれも starter の**教育責務・規範性**を高める一貫性修正。

## Test plan

- [x] `pnpm run check` 通過
- [x] `pnpm run build` 成功
- [ ] 実ブラウザで動作回帰なしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)