### PR TITLE
fix(v1.2): AR C2 部分 revert + field-sizing フォールバック（starter 方針整合）

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:js": "eslint \"src/**/*.js\" --fix",
     "lint:html": "markuplint \"src/**/*.html\"",
     "format": "prettier --write .",
-    "check": "pnpm run format && pnpm run lint:css && pnpm run lint:js && pnpm run lint:html"
+    "check": "npm run format && npm run lint:css && npm run lint:js && npm run lint:html"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/404.html
+++ b/src/404.html
@@ -47,35 +47,26 @@
           </ul>
           <a href="/#contact" class="c-button -primary p-header__cta">初回体験を予約する</a>
         </nav>
-
-        <button
-          class="c-hamburger p-header__hamburger"
-          type="button"
-          aria-expanded="false"
-          aria-controls="drawer"
-          aria-label="メニュー"
-          data-hamburger
-        >
-          <span class="c-hamburger__line" aria-hidden="true"></span>
-        </button>
       </div>
     </header>
+
+    <!-- Hamburger（header 外、inert 対象外にして drawer 閉じ動線を確保）-->
+    <button
+      class="c-hamburger p-hamburger"
+      data-hamburger
+      type="button"
+      aria-expanded="false"
+      aria-controls="drawer"
+      aria-label="メニュー"
+    >
+      <span class="c-hamburger__line" aria-hidden="true"></span>
+    </button>
 
     <!-- Drawer -->
     <div class="c-overlay" data-drawer-overlay hidden></div>
     <dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title" aria-modal="true">
       <div class="p-drawer__stack">
         <span id="drawer-title" class="u-visually-hidden">ナビゲーションメニュー</span>
-        <button
-          class="c-icon-button -ghost p-drawer__close"
-          type="button"
-          data-drawer-close
-          aria-label="メニューを閉じる"
-        >
-          <svg class="c-icon-button__icon" width="20" height="20" aria-hidden="true">
-            <use href="/assets/images/icons/close.svg#icon" />
-          </svg>
-        </button>
         <nav class="p-drawer__nav" aria-label="ドロワーナビゲーション">
           <ul class="p-drawer__nav-list">
             <li>

--- a/src/assets/css/component/c-form.css
+++ b/src/assets/css/component/c-form.css
@@ -61,22 +61,18 @@
 }
 
 /* NOTE: field-sizing は Baseline 未達（Firefox 145+、2026-04 リリース）。
-   未対応ブラウザでは固定高 textarea になるため、min/max-block-size でサイズ範囲を制限して
-   崩れを抑制している */
+   未対応ブラウザでは手動リサイズでフォールバック */
 textarea.c-form__input {
   field-sizing: content;
   min-block-size: 10lh;
   max-block-size: 20lh;
+  resize: block; /* 未対応ブラウザでユーザーが手動リサイズ */
 }
 
-/* Element: error — :user-invalid 時に表示される SR 対応エラーメッセージ（WCAG 3.3.1） */
-.c-form__error {
-  margin-block-start: var(--space-xs);
-  font-size: var(--font-size-caption);
-  color: var(--color-error);
-
-  &[hidden] {
-    display: none;
+/* field-sizing 対応ブラウザでは自動伸縮するため手動リサイズを無効化 */
+@supports (field-sizing: content) {
+  textarea.c-form__input {
+    resize: none;
   }
 }
 

--- a/src/assets/css/project/p-drawer.css
+++ b/src/assets/css/project/p-drawer.css
@@ -72,9 +72,3 @@
 .p-drawer__cta {
   margin-block-start: var(--space-md);
 }
-
-/* c-icon-button のデフォルト横パディングを縮小してアイコン単体ボタン形状に */
-.p-drawer__close {
-  align-self: flex-end;
-  padding: var(--space-sm);
-}

--- a/src/assets/css/project/p-hamburger.css
+++ b/src/assets/css/project/p-hamburger.css
@@ -1,0 +1,13 @@
+/* Project: p-hamburger — header 外固定配置の hamburger ボタン
+   header が data-drawer-inert 対象のため header 外に配置し、
+   drawer 開閉中も常にフォーカス可能な状態を維持する */
+.p-hamburger {
+  position: fixed;
+  inset-block-start: var(--space-md);
+  inset-inline-end: var(--space-md);
+  z-index: var(--z-header);
+
+  @media (width >= 48rem) {
+    display: none;
+  }
+}

--- a/src/assets/css/project/p-header.css
+++ b/src/assets/css/project/p-header.css
@@ -66,9 +66,3 @@
 .p-header__cta {
   font-size: var(--font-size-caption);
 }
-
-.p-header__hamburger {
-  @media (width >= 48rem) {
-    display: none;
-  }
-}

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -45,6 +45,7 @@
 
 /* Project */
 @import './project/p-header.css' layer(project);
+@import './project/p-hamburger.css' layer(project);
 @import './project/p-drawer.css' layer(project);
 @import './project/p-hero.css' layer(project);
 @import './project/p-problem.css' layer(project);

--- a/src/assets/images/icons/close.svg
+++ b/src/assets/images/icons/close.svg
@@ -1,4 +1,0 @@
-<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-  <line x1="5" y1="5" x2="15" y2="15"/>
-  <line x1="15" y1="5" x2="5" y2="15"/>
-</svg>

--- a/src/assets/scripts/main.js
+++ b/src/assets/scripts/main.js
@@ -95,15 +95,6 @@ function initDrawer(options = {}) {
     });
   });
 
-  // drawer 内の閉じるボタン（header inert 化により hamburger が使えない場合の代替動線）
-  const drawerCloseButton = drawer.querySelector('[data-drawer-close]');
-  if (drawerCloseButton) {
-    drawerCloseButton.addEventListener('click', () => {
-      closeDrawer();
-      hamburgers[0]?.focus({ preventScroll: true });
-    });
-  }
-
   drawerLinks.forEach((link) => {
     link.addEventListener('click', () => {
       const href = link.getAttribute('href');
@@ -204,73 +195,11 @@ function initBackToTop(options = {}) {
   toggleVisibility();
 }
 
-/**
- * フォームバリデーション（:user-invalid → aria-invalid + error container 表示制御）を初期化する。
- * submit 時・invalid イベント時に aria-invalid="true" と error container を表示し、
- * 修正後 input イベントで valid になったら解除する。
- * @param {Object} [options] - カスタマイズオプション
- * @param {string} [options.formSelector='.c-form'] - フォームのセレクター
- */
-function initFormValidation(options = {}) {
-  const { formSelector = '.c-form' } = options;
-
-  const forms = document.querySelectorAll(formSelector);
-  if (forms.length === 0) return;
-
-  forms.forEach((form) => {
-    const fields = form.querySelectorAll(
-      'input[aria-describedby], select[aria-describedby], textarea[aria-describedby]',
-    );
-
-    function showError(field) {
-      field.setAttribute('aria-invalid', 'true');
-      const errorEl = document.getElementById(field.getAttribute('aria-describedby'));
-      if (errorEl) errorEl.hidden = false;
-    }
-
-    function clearError(field) {
-      field.removeAttribute('aria-invalid');
-      const errorEl = document.getElementById(field.getAttribute('aria-describedby'));
-      if (errorEl) errorEl.hidden = true;
-    }
-
-    fields.forEach((field) => {
-      field.addEventListener('invalid', () => showError(field));
-      field.addEventListener('input', () => {
-        if (field.validity.valid) clearError(field);
-      });
-    });
-
-    // fieldset の radio group: submit 失敗時に plan-error を表示
-    const radioGroups = form.querySelectorAll('fieldset[aria-describedby]');
-    radioGroups.forEach((fieldset) => {
-      const radios = fieldset.querySelectorAll('input[type="radio"]');
-      const firstRequired = fieldset.querySelector('input[type="radio"][required]');
-      if (!firstRequired) return;
-
-      firstRequired.addEventListener('invalid', () => {
-        fieldset.setAttribute('aria-invalid', 'true');
-        const errorEl = document.getElementById(fieldset.getAttribute('aria-describedby'));
-        if (errorEl) errorEl.hidden = false;
-      });
-
-      radios.forEach((radio) => {
-        radio.addEventListener('change', () => {
-          fieldset.removeAttribute('aria-invalid');
-          const errorEl = document.getElementById(fieldset.getAttribute('aria-describedby'));
-          if (errorEl) errorEl.hidden = true;
-        });
-      });
-    });
-  });
-}
-
 // 初期化（デフォルト値で動作）
 initDrawer();
 initStagger();
 initScrollAnimation();
 initBackToTop();
-initFormValidation();
 
 // CUSTOMIZE 例:
 // initDrawer({ breakpoint: 1024 });

--- a/src/index.html
+++ b/src/index.html
@@ -160,35 +160,26 @@
           </ul>
           <a class="c-button -primary p-header__cta" href="#contact">初回体験を予約する</a>
         </nav>
-
-        <button
-          class="c-hamburger p-header__hamburger"
-          data-hamburger
-          type="button"
-          aria-expanded="false"
-          aria-controls="drawer"
-          aria-label="メニュー"
-        >
-          <span class="c-hamburger__line" aria-hidden="true"></span>
-        </button>
       </div>
     </header>
+
+    <!-- Hamburger（header 外、inert 対象外にして drawer 閉じ動線を確保）-->
+    <button
+      class="c-hamburger p-hamburger"
+      data-hamburger
+      type="button"
+      aria-expanded="false"
+      aria-controls="drawer"
+      aria-label="メニュー"
+    >
+      <span class="c-hamburger__line" aria-hidden="true"></span>
+    </button>
 
     <!-- Drawer -->
     <div class="c-overlay" data-drawer-overlay hidden></div>
     <dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title" aria-modal="true">
       <div class="p-drawer__stack">
         <span class="u-visually-hidden" id="drawer-title">ナビゲーションメニュー</span>
-        <button
-          class="c-icon-button -ghost p-drawer__close"
-          type="button"
-          data-drawer-close
-          aria-label="メニューを閉じる"
-        >
-          <svg class="c-icon-button__icon" width="20" height="20" aria-hidden="true">
-            <use href="/assets/images/icons/close.svg#icon" />
-          </svg>
-        </button>
         <nav class="p-drawer__nav" aria-label="ドロワーナビゲーション">
           <ul class="p-drawer__nav-list">
             <li>
@@ -632,32 +623,12 @@
             <p class="c-form__note"><span>*</span> のついた項目は必須です</p>
             <div class="c-form__field">
               <label class="c-form__label" for="name">お名前</label>
-              <input
-                class="c-form__input"
-                id="name"
-                name="name"
-                type="text"
-                autocomplete="name"
-                required
-                aria-describedby="name-error"
-              />
-              <span class="c-form__error" id="name-error" role="alert" hidden>お名前を入力してください</span>
+              <input class="c-form__input" id="name" name="name" type="text" autocomplete="name" required />
             </div>
 
             <div class="c-form__field">
               <label class="c-form__label" for="email">メールアドレス</label>
-              <input
-                class="c-form__input"
-                id="email"
-                name="email"
-                type="email"
-                autocomplete="email"
-                required
-                aria-describedby="email-error"
-              />
-              <span class="c-form__error" id="email-error" role="alert" hidden
-                >有効なメールアドレスを入力してください</span
-              >
+              <input class="c-form__input" id="email" name="email" type="email" autocomplete="email" required />
             </div>
 
             <div class="c-form__field">
@@ -667,18 +638,15 @@
 
             <div class="c-form__field">
               <label class="c-form__label" for="category">お問い合わせ種別</label>
-              <select class="c-form__input" id="category" name="category" required aria-describedby="category-error">
+              <select class="c-form__input" id="category" name="category" required>
                 <option value="">選択してください</option>
                 <option value="reservation">初回体験の予約</option>
                 <option value="inquiry">施術に関するお問い合わせ</option>
                 <option value="other">その他</option>
               </select>
-              <span class="c-form__error" id="category-error" role="alert" hidden
-                >お問い合わせ種別を選択してください</span
-              >
             </div>
 
-            <fieldset class="c-form__field" aria-describedby="plan-error">
+            <fieldset class="c-form__field">
               <legend class="c-form__legend">ご希望のプラン</legend>
               <div class="c-form__choice-group">
                 <label class="c-form__choice-label">
@@ -694,30 +662,18 @@
                   リラクゼーション（90分）
                 </label>
               </div>
-              <span class="c-form__error" id="plan-error" role="alert" hidden>プランを選択してください</span>
             </fieldset>
 
             <div class="c-form__field">
               <label class="c-form__label" for="message">メッセージ</label>
-              <textarea
-                class="c-form__input"
-                id="message"
-                name="message"
-                rows="6"
-                required
-                aria-describedby="message-error"
-              ></textarea>
-              <span class="c-form__error" id="message-error" role="alert" hidden>メッセージを入力してください</span>
+              <textarea class="c-form__input" id="message" name="message" rows="6" required></textarea>
             </div>
 
             <div class="c-form__field">
               <label class="c-form__choice-label" for="agree">
-                <input id="agree" name="agree" type="checkbox" required aria-describedby="agree-error" />
+                <input id="agree" name="agree" type="checkbox" required />
                 <a href="/privacy/">プライバシーポリシー</a>に同意する
               </label>
-              <span class="c-form__error" id="agree-error" role="alert" hidden
-                >プライバシーポリシーへの同意が必要です</span
-              >
             </div>
 
             <div class="c-form__actions">

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -87,35 +87,26 @@
           </ul>
           <a href="/#contact" class="c-button -primary p-header__cta">初回体験を予約する</a>
         </nav>
-
-        <button
-          class="c-hamburger p-header__hamburger"
-          type="button"
-          aria-expanded="false"
-          aria-controls="drawer"
-          aria-label="メニュー"
-          data-hamburger
-        >
-          <span class="c-hamburger__line" aria-hidden="true"></span>
-        </button>
       </div>
     </header>
+
+    <!-- Hamburger（header 外、inert 対象外にして drawer 閉じ動線を確保）-->
+    <button
+      class="c-hamburger p-hamburger"
+      data-hamburger
+      type="button"
+      aria-expanded="false"
+      aria-controls="drawer"
+      aria-label="メニュー"
+    >
+      <span class="c-hamburger__line" aria-hidden="true"></span>
+    </button>
 
     <!-- Drawer -->
     <div class="c-overlay" data-drawer-overlay hidden></div>
     <dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title" aria-modal="true">
       <div class="p-drawer__stack">
         <span id="drawer-title" class="u-visually-hidden">ナビゲーションメニュー</span>
-        <button
-          class="c-icon-button -ghost p-drawer__close"
-          type="button"
-          data-drawer-close
-          aria-label="メニューを閉じる"
-        >
-          <svg class="c-icon-button__icon" width="20" height="20" aria-hidden="true">
-            <use href="/assets/images/icons/close.svg#icon" />
-          </svg>
-        </button>
         <nav class="p-drawer__nav" aria-label="ドロワーナビゲーション">
           <ul class="p-drawer__nav-list">
             <li>


### PR DESCRIPTION
## Summary

しゅんえい判断（2026-04-23）に基づき、AR C2 採用項目のうち starter 方針（「独自実装せず browser native / シンプル」）に反する項目を部分 revert。field-sizing は既存の CodePen パターン（@supports ガード）を適用。

## 修正内容

| # | 採用 # | 対応 | 内容 |
|---|---|---|---|
| 1 | 4 revert | npm/pnpm 両対応 | `check` script を `npm run` に戻す（README は npm 表記のため） |
| 2 | 2 + 11 中間案 | hamburger を header 外に移動 | `<header data-drawer-inert>` 維持、hamburger を header と drawer の兄弟に。close ボタン削除（hamburger トグルで十分） |
| 3 | 3 完全 revert | フォーム独自実装削除 | aria-describedby + error container + initFormValidation() を削除、browser native に戻す（PR #124 の方針復帰） |
| 4 | 7 補強 | field-sizing フォールバック | `resize: block` + `@supports (field-sizing: content) { resize: none }` を追加（CodePen パターン準拠） |

## 背景

- **採用 4**: README は npm 表記維持しつつ `check` script が pnpm 固定だった矛盾
- **採用 2 + 11**: header inert で hamburger が効かなくなった / 新規 close ボタン追加が starter の「必要最小限」方針に反する
- **採用 3**: starter は PR #124 で「browser native バリデーションに統一」の方針。aria-describedby + error container の JS 制御は独自実装
- **field-sizing**: user の CodePen で確立された `@supports` ガードパターンが starter にも適切

## WCAG 3.3.1 について

PR #153 は採用 3 で WCAG 3.3.1 Level A 違反を解消した目的だったが、starter はリファレンス実装として「必要最小限 + CUSTOMIZE で拡張可」の方針。WCAG 3.3.1 準拠は browser native バリデーション + CUSTOMIZE コメントで「必要に応じて aria-describedby / error container を追加」のガイドで対応。

## 主な変更ファイル

- `src/assets/css/project/p-hamburger.css` — 新規作成（header 外 fixed 配置）
- `src/assets/images/icons/close.svg` — 削除（close ボタン全廃に伴い不使用）
- `src/index.html` / `src/privacy/index.html` / `src/404.html` — hamburger 移動 + error container 削除
- `src/assets/scripts/main.js` — drawerCloseButton handler + initFormValidation() 削除
- `src/assets/css/component/c-form.css` — .c-form__error 削除 + field-sizing フォールバック

## Test plan

- [x] `pnpm run check` 通過
- [x] `pnpm run build` 成功
- [ ] `npm run check` も動作確認
- [ ] 実ブラウザで hamburger がトグルで drawer 開閉できる
- [ ] Firefox（field-sizing 未対応）で textarea を手動リサイズできる
- [ ] Chrome（field-sizing 対応）で textarea が自動伸縮、resize: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)