### PR TITLE
fix(v1.2): scroll anchor の二重オフセット解消 + scroll-padding の reduced-motion 外し

### DIFF
--- a/src/assets/css/foundation/base.css
+++ b/src/assets/css/foundation/base.css
@@ -46,6 +46,8 @@
 }
 
 :where(:root) {
+  scroll-padding-block-start: var(--header-size);
+
   &:has(:modal),
   &:has(dialog[open]) {
     overflow: hidden;
@@ -55,6 +57,5 @@
 @media (prefers-reduced-motion: no-preference) {
   :where(:root) {
     scroll-behavior: smooth;
-    scroll-padding-block-start: var(--header-size);
   }
 }

--- a/src/assets/css/layout/l-section.css
+++ b/src/assets/css/layout/l-section.css
@@ -3,5 +3,4 @@
   --section-padding-max: var(--section-standard-max);
 
   padding-block: clamp(var(--section-padding-min), 3.462vi + 3.1346rem, var(--section-padding-max));
-  scroll-margin-block-start: var(--header-size);
 }


### PR DESCRIPTION
## 背景

セクションリンク（アンカー）ジャンプ時にヘッダー下からさらに `--header-size` 分のスペースが余分に空く不具合を発見。

## 原因

2 箇所でヘッダー分のオフセットが指定され、ブラウザの CSSOM View Module 仕様により両方が加算されていた:

- `src/assets/css/foundation/base.css` — `:where(:root) { scroll-padding-block-start: var(--header-size) }`（スクロールコンテナの内側余白）
- `src/assets/css/layout/l-section.css` — `.l-section { scroll-margin-block-start: var(--header-size) }`（target 要素の外側余白）

両者は独立して効くため、`.l-section` アンカーで `--header-size × 2` のオフセットが発生。

### 副次問題

`scroll-padding-block-start` が `@media (prefers-reduced-motion: no-preference)` ガード内に含まれていたため、reduced-motion 環境でアンカー着地位置がヘッダー裏に潜っていた。`scroll-behavior: smooth` のみがアニメーション関連でガード対象であるべきで、`scroll-padding`（着地位置の補正）は常時有効であるべき。

## 修正

### 1. `src/assets/css/layout/l-section.css`

- `scroll-margin-block-start: var(--header-size)` を削除
- `:where(:root)` の `scroll-padding-block-start` に集約（スクロールコンテナ側で一元管理）

### 2. `src/assets/css/foundation/base.css`

- `scroll-padding-block-start` を `@media (prefers-reduced-motion: no-preference)` ガードの外へ移動
- `scroll-behavior: smooth` のみガード内に残す

## 検証

- `pnpm build` 成功（CSS コンパイルエラーなし）
- 生成 CSS で `scroll-padding-block-start` が 1 箇所のみ・reduced-motion ガード外に配置されていることを確認
- `scroll-margin` がビルド成果物から消えていることを確認
- `scroll-behavior: smooth` のみ `@media (prefers-reduced-motion: no-preference)` 内に残留することを確認

## 参考

- CSSOM View Module: `scroll-margin` / `scroll-padding` は独立加算（両方指定すると二重オフセット）
- `prefers-reduced-motion` はアニメーション挙動のみ抑制すべきで、レイアウト補正（scroll-padding）は reduce 時も維持すべき