### PR TITLE
fix(v1.2): CI check workflow に pnpm version 10 を明記

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- `pnpm/action-setup@v4` に `version: 10` を追加し、CI の pnpm バージョン未指定エラーを解消
- `package.json` への `packageManager` 追記は **実施しない**（brands/mflocss.md 方針「packageManager 未設定維持」を遵守）
- ローカル環境 pnpm 10.28.2 と整合。lockfile version 9.0 は pnpm 9+/10+ 互換

## Root cause

セッション 5 PR #144 で CI を追加した際から `version` 指定が欠落しており、全 run で以下のエラーが発生していた:

```
Error: No pnpm version is specified.
Please specify it by one of the following ways:
  - in the GitHub Action config with the key "version"
  - in the package.json with the key "packageManager"
```

## Test plan

- [x] `pnpm/action-setup@v4` に `with: version: 10` が追加されている
- [ ] PR の check run が success（`pnpm install --frozen-lockfile` / `pnpm run check` / `pnpm run build` 全 step exit 0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)