### PR TITLE
fix(v1.2): c-back-to-top に data-drawer-inert 追加（AR C3 採用 1 / PR #157 副作用修正）

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -133,7 +133,7 @@
     </footer>
 
     <!-- Back to Top -->
-    <a href="#top" class="c-back-to-top" data-back-to-top aria-label="ページの先頭に戻る">
+    <a class="c-back-to-top" data-back-to-top data-drawer-inert href="#top" aria-label="ページの先頭に戻る">
       <svg class="c-back-to-top__icon" width="20" height="20" aria-hidden="true">
         <use href="/assets/images/icons/chevron-up.svg#icon" />
       </svg>

--- a/src/index.html
+++ b/src/index.html
@@ -712,7 +712,7 @@
     </footer>
 
     <!-- Back to Top -->
-    <a class="c-back-to-top" data-back-to-top href="#top" aria-label="ページの先頭に戻る">
+    <a class="c-back-to-top" data-back-to-top data-drawer-inert href="#top" aria-label="ページの先頭に戻る">
       <svg class="c-back-to-top__icon" width="20" height="20" aria-hidden="true">
         <use href="/assets/images/icons/chevron-up.svg#icon" />
       </svg>

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -194,7 +194,7 @@
     </footer>
 
     <!-- Back to Top -->
-    <a href="#top" class="c-back-to-top" data-back-to-top aria-label="ページの先頭に戻る">
+    <a class="c-back-to-top" data-back-to-top data-drawer-inert href="#top" aria-label="ページの先頭に戻る">
       <svg class="c-back-to-top__icon" width="20" height="20" aria-hidden="true">
         <use href="/assets/images/icons/chevron-up.svg#icon" />
       </svg>


### PR DESCRIPTION
## 背景

AR C3（2026-04-24）の**採用 1（H 重要度、WCAG 2.1.1 Keyboard Level A）**対応。

セッション 5 PR #157 で `data-drawer-inert` の付与粒度を「header 全体」→「子要素個別」に変更した際、`<header>` 外要素である `<a class=\"c-back-to-top\">` への同属性展開が漏れた。

AR C3 結果: `/tmp/ar-20260424-starter-c3/result-judge-c3.md` 採用 1

## 原因

`data-visible` 付与でスクロール後に Back-to-Top が可視化された状態で Drawer を開くと、Tab が以下のように脱出する:

```
Drawer → ハンバーガー → <Drawer 外の c-back-to-top へ脱出>
```

結果として focus trap が破綻し、WCAG 2.1.1（全機能のキーボード操作）に抵触。

## 修正内容

3 HTML の `<a class=\"c-back-to-top\">` に `data-drawer-inert` 属性を追加:

- `src/index.html`
- `src/404.html`
- `src/privacy/index.html`

あわせて属性順を **3 順序ルール**（class → data-* → 機能属性 → aria-*、Google HTML Style 準拠）に統一（`404.html` / `privacy/index.html` は `href` と `class` の順序が乱れていたため）。

### 修正前 / 修正後

```diff
- <a class=\"c-back-to-top\" data-back-to-top href=\"#top\" aria-label=\"ページの先頭に戻る\">
+ <a class=\"c-back-to-top\" data-back-to-top data-drawer-inert href=\"#top\" aria-label=\"ページの先頭に戻る\">
```

## 検証

- Drawer 開閉時の Tab 動作: Drawer → ハンバーガー のループ内で c-back-to-top に逃げない（focus trap 成立）
- `main.js` の `querySelectorAll('[data-drawer-inert]')` は属性ベースのため新規要素を自動取得、JS 側改修不要

## 副作用

**なし**。data-drawer-inert は inert 化対象のマーカー属性であり、Drawer が閉じている時は影響ゼロ。

## 参考

- AR C3 判定結果: `/tmp/ar-20260424-starter-c3/result-judge-c3.md`
- PR #157（原因となった粒度変更）: https://github.com/mflocss/starter/pull/157