### PR TITLE
chore(v1.2): AR C3 採用 2-5 + CODING_GUIDE data-drawer-inert 運用基準追記

### DIFF
--- a/CODING_GUIDE.md
+++ b/CODING_GUIDE.md
@@ -94,6 +94,25 @@ CSS 完結のアニメーション。JS を待たず即時再生。LCP 要素（
 
 `dialog.close()` は即座に `display: none` にするため、CSS transition だけでは閉じるアニメーションが効きません。`data-open` 属性でアニメーション状態を JS から制御します（dialog の `open` 属性とは責務が異なります）。実装詳細は `src/assets/scripts/main.js` を参照してください。
 
+### data-drawer-inert — focus trap 対象マーカー
+
+Drawer open 時に **Drawer 外の全てのフォーカス可能要素を `inert` 化**する必要があります（`dialog.show()` は `showModal()` と異なり自動で inert 化しないため、JS から `setAttribute('inert', '')` で制御）。`data-drawer-inert` は「Drawer open 時に inert 化すべき要素」を明示するマーカー属性です。
+
+#### 付与対象
+
+Drawer と Hamburger トリガー**以外**の、フォーカス可能（= Tab 到達可能）な要素すべて。具体的には:
+
+- `<header>` の子要素（logo リンク・nav 等、ただし hamburger と drawer は除外）
+- `<main>` / `<footer>` 等のランドマーク
+- `<header>` 外の常駐要素（`c-back-to-top` 等、自己配置型 Component — spec §5.5）
+- skip-link（Drawer open 中は到達不要のため）
+
+**新規の自己配置型 Component（例: fixed chat widget、cookie banner 等）を追加する際は、必ず `data-drawer-inert` の付与要否を確認してください。**付与漏れがあると Drawer open 中に Tab が Drawer 外へ脱出し、focus trap が破綻します（WCAG 2.1.1 Keyboard A 違反）。
+
+#### JS 側
+
+`querySelectorAll('[data-drawer-inert]')` で全対象要素を取得 → `openDrawer` で `inert` 属性付与、`closeDrawer` で削除するだけ。新規対象を追加しても JS 側の変更は不要です。
+
 ## 空のルールセット
 
 HTML のクラスと CSS のルールセットは 1:1 で対応させます。スタイルが不要なクラスでも、ルールセットを残してコメントで意図を示します。「スタイルを意図的に書かなかった」と「書き忘れた」を区別でき、後から読んだコーダーが誤ってスタイルを追加するミスを防止できます。

--- a/src/assets/css/component/c-button.css
+++ b/src/assets/css/component/c-button.css
@@ -1,3 +1,5 @@
+/* NOTE: c-icon-button も `--button-*` 公開 API を共有（派生関係、c-icon-button.css の DEVIATION 参照） */
+
 /* 公開 API:
      --button-color             (default: var(--color-surface)、= -primary 相当)
      --button-bg-color          (default: var(--color-accent)、= -primary 相当)

--- a/src/assets/css/component/c-form.css
+++ b/src/assets/css/component/c-form.css
@@ -60,8 +60,9 @@
   }
 }
 
-/* NOTE: field-sizing は Baseline 未達（Firefox 145+、2026-04 リリース）。
-   未対応ブラウザでは手動リサイズでフォールバック */
+/* NOTE: field-sizing は Baseline 未達。Chrome 123+ / Safari 26.2+ 対応、Firefox は 2026-04 時点で全バージョン未対応。
+   未対応ブラウザでは resize: block による手動リサイズでフォールバック
+   （https://caniuse.com/mdn-css_properties_field-sizing） */
 textarea.c-form__input {
   field-sizing: content;
   min-block-size: 10lh;

--- a/src/assets/css/component/c-icon-button.css
+++ b/src/assets/css/component/c-icon-button.css
@@ -1,3 +1,8 @@
+/* DEVIATION: spec §6 SHOULD NOT [公開 API プレフィックス含有の回避] の意図的逸脱。
+   c-icon-button は c-button に icon 領域を追加した派生 Component であり、
+   `--button-*` 公開 API を意図的に共有する。
+   上位層で `--button-bg-color` を設定すると両 Component に適用される仕様。 */
+
 /* 公開 API:
      --button-color             (default: var(--color-surface)、= -primary 相当)
      --button-bg-color          (default: var(--color-accent)、= -primary 相当)

--- a/src/assets/css/reset/reset.css
+++ b/src/assets/css/reset/reset.css
@@ -87,7 +87,7 @@
   font: inherit;
   color: inherit;
   letter-spacing: unset;
-  border: 1px solid;
+  border: unset;
   border-radius: unset;
 }
 

--- a/src/assets/scripts/main.js
+++ b/src/assets/scripts/main.js
@@ -178,6 +178,8 @@ function initStagger(options = {}) {
  * @param {number} [options.threshold=300] - 表示を切替えるスクロール量（px）
  */
 function initBackToTop(options = {}) {
+  // NOTE: CSS animation-timeline: scroll() で代替可能だが、opacity/visibility transition と競合するため
+  //       smooth fade UX 維持を優先して JS 実装を選択。@property + calc() 構成での CSS 化は将来検討。
   const { threshold = 300 } = options;
 
   const backToTop = document.querySelector('[data-back-to-top]');


### PR DESCRIPTION
## 背景

AR C3 判定（`/tmp/ar-20260424-starter-c3/result-judge-c3.md`、審判: しゅんえいクローン）の **M 1 件 + L 3 件 + メタ観察 3 件** を一括反映する PR。

採用 1（H — `c-back-to-top` への `data-drawer-inert` 付与）は PR #160（別 PR）で対応済み。本 PR は**残り 4 件 + CODING_GUIDE 運用基準追記**を扱う。

## 修正サマリ

| # | 重要度 | 対象ファイル | 内容 |
|---|---|---|---|
| 採用 2 | M | `component/c-icon-button.css` + `component/c-button.css` | `--button-*` 公開 API 共有の DEVIATION 明記 + 相互参照 NOTE |
| 採用 3 | L | `reset/reset.css` | `border: 1px solid` → `border: unset`（他ルールとの整合性） |
| 採用 4 | L | `component/c-form.css` | `field-sizing` コメントの事実正確化（Firefox 145 未対応を一次確認） |
| 採用 5 | L | `scripts/main.js` (`initBackToTop`) | brands 方針「CSS 優先」への意識的逸脱の NOTE 記録 |
| メタ 3 | — | `CODING_GUIDE.md` | `data-drawer-inert` 運用基準セクション新設（PR #157 副作用の再発防止） |

## field-sizing Baseline 再調査結果

採用 4 の前提確認として、WebSearch + MDN + Can I Use で Firefox の `field-sizing` 対応状況を再検証:

- **Firefox 145 (2025-11-11)** の CSS 新機能: `text-autospace` / `math` font-family / `<select>` 内 `<hr>` のみ。**`field-sizing` は含まれず**
- **Firefox 150 / 151-153** も未対応（Can I Use 2026-03 時点）
- **Chrome 123+ / Safari 26.2+** は対応済み（global usage 82.77%）

→ 旧コメント「Firefox 145+、2026-04 リリース」は**事実誤認**。Firefox 全バージョン未対応に修正し、一次ソース URL（[caniuse](https://caniuse.com/mdn-css_properties_field-sizing)）を付記した。

## `data-drawer-inert` 運用基準明文化の意図

AR C3 メタ観察 3 で、PR #157 の副作用（`c-back-to-top` への `data-drawer-inert` 付与漏れ）の根本原因が「運用基準の未文書化」と判定された。

CODING_GUIDE.md に新セクション **「data-drawer-inert — focus trap 対象マーカー」** を追加し:

- 付与対象の判定規則（header 子要素 / main / footer / 自己配置型 Component / skip-link）
- 新規自己配置型 Component 追加時のチェックリスト
- JS 側の実装不変性（`querySelectorAll('[data-drawer-inert]')` 経由）

を明文化。将来同種の見落としを予防する。

## reset.css の border 変更 visual 退行確認

`:where(button, input, select, textarea) { border: unset; }` 変更による影響:

- `<button>`: `foundation/form.css` が `:where(button) { border: none }` を定義 → 影響なし
- `<input type="text|email|tel">`: 全て `.c-form__input` 経由で `c-form.css` が border 定義 → 影響なし
- `<input type="radio|checkbox">`: `foundation/form.css` が専用 border を定義 → 影響なし
- `<textarea>`: `.c-form__input` 経由 → 影響なし
- `<select>`: `.c-form__input` + `foundation/form.css` → 影響なし

→ 現状 HTML の全フォーム要素は Foundation または Component 層で border を明示定義しており、**visual 退行なし**。

## コメント方針 8 ルール照合

新規追加コメント 4 件を `/comment-audit` の 8 ルールに照らして確認:

| # | コメント | カテゴリ | 判定 |
|---|---|---|---|
| 1 | c-icon-button DEVIATION | 2: DEVIATION | ✅ 残す |
| 2 | c-button NOTE (cross-reference) | 5: 運用注意（starter 固有） | ✅ 残す |
| 3 | c-form field-sizing NOTE (更新) | 5: 運用注意（ブラウザ互換情報 + 一次ソース URL） | ✅ 残す |
| 4 | main.js initBackToTop NOTE | 8: 実装判断記録（brands 方針逸脱） | ✅ 残す |

全て 7 カテゴリ + 実装判断記録の範囲内。D1-D6 削除対象なし。

## 検証

- `pnpm build` ✓ 成功（`dist/assets/main-*.css` 30.45 kB、変更前と同等）
- `pnpm run check` ✓ stylelint / eslint / markuplint 全パス
- AR C3 採用 4 の Firefox 145 field-sizing 検証: WebSearch + MDN + Can I Use による一次ソース確認完了

## 参考

- AR C3 結果: `/tmp/ar-20260424-starter-c3/result-judge-c3.md`
- 採用 1（H）は PR #160 別 PR で対応済み
- 保留 1（Animation 層公開 API 命名）は `mflocss/spec` Issue として別途起票予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)