### PR TITLE
refactor(v1.2): c-icon-button の公開 API を --icon-button-* に正規化（DEVIATION 解消）

### DIFF
--- a/src/assets/css/component/c-button.css
+++ b/src/assets/css/component/c-button.css
@@ -1,5 +1,3 @@
-/* NOTE: c-icon-button も `--button-*` 公開 API を共有（派生関係、c-icon-button.css の DEVIATION 参照） */
-
 /* 公開 API:
      --button-color             (default: var(--color-surface)、= -primary 相当)
      --button-bg-color          (default: var(--color-accent)、= -primary 相当)

--- a/src/assets/css/component/c-icon-button.css
+++ b/src/assets/css/component/c-icon-button.css
@@ -1,13 +1,8 @@
-/* DEVIATION: spec §6 SHOULD NOT [公開 API プレフィックス含有の回避] の意図的逸脱。
-   c-icon-button は c-button に icon 領域を追加した派生 Component であり、
-   `--button-*` 公開 API を意図的に共有する。
-   上位層で `--button-bg-color` を設定すると両 Component に適用される仕様。 */
-
 /* 公開 API:
-     --button-color             (default: var(--color-surface)、= -primary 相当)
-     --button-bg-color          (default: var(--color-accent)、= -primary 相当)
-     --button-border-color      (default: var(--color-accent)、= -primary 相当)
-     --button-hover-bg-color    (default: -primary 相当) */
+     --icon-button-color             (default: var(--color-surface)、= -primary 相当)
+     --icon-button-bg-color          (default: var(--color-accent)、= -primary 相当)
+     --icon-button-border-color      (default: var(--color-accent)、= -primary 相当)
+     --icon-button-hover-bg-color    (default: -primary 相当) */
 .c-icon-button {
   display: inline-flex;
   gap: var(--space-sm);
@@ -17,11 +12,11 @@
   font-size: inherit;
   font-weight: var(--font-weight-heading);
   line-height: var(--line-height-title);
-  color: var(--button-color, var(--color-surface));
+  color: var(--icon-button-color, var(--color-surface));
   text-decoration: none;
   cursor: pointer;
-  background-color: var(--button-bg-color, var(--color-accent));
-  border: var(--border-width) solid var(--button-border-color, var(--color-accent));
+  background-color: var(--icon-button-bg-color, var(--color-accent));
+  border: var(--border-width) solid var(--icon-button-border-color, var(--color-accent));
   border-radius: var(--radius-lg);
 
   @media (prefers-reduced-motion: no-preference) {
@@ -32,7 +27,7 @@
 
   @media (any-hover: hover) {
     &:hover {
-      background-color: var(--button-hover-bg-color, oklch(from var(--color-accent) calc(l * 1.08) c h));
+      background-color: var(--icon-button-hover-bg-color, oklch(from var(--color-accent) calc(l * 1.08) c h));
       translate: 0 var(--hover-lift);
     }
   }
@@ -59,10 +54,10 @@
 }
 
 .c-icon-button.-ghost {
-  --button-color: var(--color-main);
-  --button-bg-color: transparent;
-  --button-border-color: var(--color-main);
-  --button-hover-bg-color: oklch(from var(--color-main) l c h / 8%);
+  --icon-button-color: var(--color-main);
+  --icon-button-bg-color: transparent;
+  --icon-button-border-color: var(--color-main);
+  --icon-button-hover-bg-color: oklch(from var(--color-main) l c h / 8%);
 }
 
 .c-icon-button.-large {


### PR DESCRIPTION
## Summary

- PR #161 で追加した DEVIATION コメント（`--button-*` 公開 API 共有）を解消し、spec §7 SHOULD [公開 API 変数の命名規則遵守] の正規形に準拠
- `c-icon-button.css` の公開 API を `--button-*` → `--icon-button-*` に全件 rename（8 箇所）
- `c-button.css` の NOTE コメント削除（DEVIATION 解消により不要）
- 上位層で `c-button` / `c-icon-button` を独立してカスタマイズ可能になる
- **Breaking change**: v1.0 リリース前の正規化、影響範囲は starter 内のみ（grep 確認済）

### 変更根拠

spec §7 SHOULD（PR #84 統合後）: 公開 API のカスタムプロパティ名は `--{Block 名}-{プロパティ名}` 形式が正規形。`.c-icon-button` の Block 名は `icon-button` のため `--icon-button-*` が正しい。

### 影響範囲確認

- `p-hero.css` の `.p-hero__sub-cta` が `--button-*` を使用するが、これは `.c-button` 向けの意図的な override（HTML で `.c-button -ghost -large` のみを含む）。変更不要を確認済み。
- HTML / JS: 変更なし（grep 確認済）

## Test plan

- [x] `pnpm build` 成功
- [x] `pnpm run check`（markuplint / eslint）全件 passed
- [x] `--button-*` の c-icon-button.css 内残留ゼロを grep 確認
- [x] comment-audit 8 ルール準拠確認
- [x] AR（独立レビュー）評価 A 取得
- [ ] `pnpm dev` でブラウザ visual 確認（c-icon-button の color / bg / border / hover / modifier 動作）

🤖 Generated with [Claude Code](https://claude.com/claude-code)