### PR TITLE
feat(v1.2): v1.0 公開 API Custom Property への @property 宣言追加

### DIFF
--- a/src/assets/css/component/c-button.css
+++ b/src/assets/css/component/c-button.css
@@ -1,9 +1,14 @@
-/* 公開 API:
+/* 公開 API（型宣言は property.css / 実デフォルトは base ルールで set）:
      --button-color             (default: var(--color-surface)、= -primary 相当)
      --button-bg-color          (default: var(--color-accent)、= -primary 相当)
      --button-border-color      (default: var(--color-accent)、= -primary 相当)
      --button-hover-bg-color    (default: -primary 相当) */
 .c-button {
+  --button-color: var(--color-surface);
+  --button-bg-color: var(--color-accent);
+  --button-border-color: var(--color-accent);
+  --button-hover-bg-color: oklch(from var(--color-accent) calc(l * 1.08) c h);
+
   display: inline-flex;
   gap: var(--space-sm);
   align-items: center;
@@ -12,11 +17,11 @@
   font-size: inherit;
   font-weight: var(--font-weight-heading);
   line-height: var(--line-height-title);
-  color: var(--button-color, var(--color-surface));
+  color: var(--button-color);
   text-decoration: none;
   cursor: pointer;
-  background-color: var(--button-bg-color, var(--color-accent));
-  border: var(--border-width) solid var(--button-border-color, var(--color-accent));
+  background-color: var(--button-bg-color);
+  border: var(--border-width) solid var(--button-border-color);
   border-radius: var(--radius-lg);
 
   @media (prefers-reduced-motion: no-preference) {
@@ -27,7 +32,7 @@
 
   @media (any-hover: hover) {
     &:hover {
-      background-color: var(--button-hover-bg-color, oklch(from var(--color-accent) calc(l * 1.08) c h));
+      background-color: var(--button-hover-bg-color);
       translate: 0 var(--hover-lift);
     }
   }

--- a/src/assets/css/component/c-card.css
+++ b/src/assets/css/component/c-card.css
@@ -1,14 +1,18 @@
-/* 公開 API:
+/* 公開 API（型宣言は property.css / 実デフォルトは base ルールで set）:
      --card-padding  (default: var(--space-lg))
      --card-bg       (default: var(--color-surface))
      --card-radius   (default: var(--radius-md))
-     --card-shadow   (default: var(--shadow-sm) var(--color-shadow))
-     --card-border   (default: none) */
+     --card-shadow   (default: var(--shadow-sm) var(--color-shadow)、型未宣言: shorthand)
+     --card-border   (default: none、型未宣言: shorthand) */
 .c-card {
-  padding: var(--card-padding, var(--space-lg));
-  background-color: var(--card-bg, var(--color-surface));
+  --card-padding: var(--space-lg);
+  --card-bg: var(--color-surface);
+  --card-radius: var(--radius-md);
+
+  padding: var(--card-padding);
+  background-color: var(--card-bg);
   border: var(--card-border, none);
-  border-radius: var(--card-radius, var(--radius-md));
+  border-radius: var(--card-radius);
   box-shadow: var(--card-shadow, var(--shadow-sm) var(--color-shadow));
 
   &.-subtle {

--- a/src/assets/css/component/c-form.css
+++ b/src/assets/css/component/c-form.css
@@ -1,7 +1,9 @@
-/* 公開 API:
+/* 公開 API（型宣言は property.css / 実デフォルトは base ルールで set）:
      --form-actions-margin-top  (default: var(--space-md))
-     --form-required-mark       (default: '*') */
+     --form-required-mark       (default: '*'、型未宣言: 文字列リテラル) */
 .c-form {
+  --form-actions-margin-top: var(--space-md);
+
   display: flex;
   flex-direction: column;
   gap: var(--space-lg);
@@ -97,5 +99,5 @@ textarea.c-form__input {
 .c-form__actions {
   display: flex;
   justify-content: center;
-  margin-block-start: var(--form-actions-margin-top, var(--space-md));
+  margin-block-start: var(--form-actions-margin-top);
 }

--- a/src/assets/css/component/c-icon-button.css
+++ b/src/assets/css/component/c-icon-button.css
@@ -1,9 +1,14 @@
-/* 公開 API:
+/* 公開 API（型宣言は property.css / 実デフォルトは base ルールで set）:
      --icon-button-color             (default: var(--color-surface)、= -primary 相当)
      --icon-button-bg-color          (default: var(--color-accent)、= -primary 相当)
      --icon-button-border-color      (default: var(--color-accent)、= -primary 相当)
      --icon-button-hover-bg-color    (default: -primary 相当) */
 .c-icon-button {
+  --icon-button-color: var(--color-surface);
+  --icon-button-bg-color: var(--color-accent);
+  --icon-button-border-color: var(--color-accent);
+  --icon-button-hover-bg-color: oklch(from var(--color-accent) calc(l * 1.08) c h);
+
   display: inline-flex;
   gap: var(--space-sm);
   align-items: center;
@@ -12,11 +17,11 @@
   font-size: inherit;
   font-weight: var(--font-weight-heading);
   line-height: var(--line-height-title);
-  color: var(--icon-button-color, var(--color-surface));
+  color: var(--icon-button-color);
   text-decoration: none;
   cursor: pointer;
-  background-color: var(--icon-button-bg-color, var(--color-accent));
-  border: var(--border-width) solid var(--icon-button-border-color, var(--color-accent));
+  background-color: var(--icon-button-bg-color);
+  border: var(--border-width) solid var(--icon-button-border-color);
   border-radius: var(--radius-lg);
 
   @media (prefers-reduced-motion: no-preference) {
@@ -27,7 +32,7 @@
 
   @media (any-hover: hover) {
     &:hover {
-      background-color: var(--icon-button-hover-bg-color, oklch(from var(--color-accent) calc(l * 1.08) c h));
+      background-color: var(--icon-button-hover-bg-color);
       translate: 0 var(--hover-lift);
     }
   }

--- a/src/assets/css/component/c-media-split.css
+++ b/src/assets/css/component/c-media-split.css
@@ -1,6 +1,8 @@
-/* 公開 API:
+/* 公開 API（型宣言は property.css / 実デフォルトは base ルールで set）:
      --media-split-first-order  (default: 0、`:nth-child(even)` 等で 1 を set して左右反転) */
 .c-media-split {
+  --media-split-first-order: 0;
+
   display: grid;
   gap: var(--space-xl);
   align-items: center;
@@ -10,7 +12,7 @@
   }
 
   & > :first-child {
-    order: var(--media-split-first-order, 0);
+    order: var(--media-split-first-order);
   }
 }
 

--- a/src/assets/css/component/c-prose.css
+++ b/src/assets/css/component/c-prose.css
@@ -1,7 +1,9 @@
 /* 子孫セレクタを許容する例外 Component（CMS 流し込み等、HTML クラス付与不能な用途向け）
-   公開 API: --prose-max-inline-size（読みやすい最大幅、Project 側で上書き可） */
+   公開 API: --prose-max-inline-size（読みやすい最大幅、Project 側で上書き可、型宣言は property.css） */
 .c-prose {
-  max-inline-size: var(--prose-max-inline-size, 40rem);
+  --prose-max-inline-size: 40rem;
+
+  max-inline-size: var(--prose-max-inline-size);
   line-height: var(--line-height-text);
 
   & h2 {

--- a/src/assets/css/property.css
+++ b/src/assets/css/property.css
@@ -1,0 +1,87 @@
+/* 公開 API Custom Properties の型宣言（spec §7 SHOULD / §8 property.css）
+   initial-value は context 非依存の中立値リテラル（var() / light-dark() は仕様上不可）。
+   実デフォルト値は各 Component の base ルールで set する。 */
+
+@property --button-color {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: transparent;
+}
+
+@property --button-bg-color {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: transparent;
+}
+
+@property --button-border-color {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: transparent;
+}
+
+@property --button-hover-bg-color {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: transparent;
+}
+
+@property --icon-button-color {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: transparent;
+}
+
+@property --icon-button-bg-color {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: transparent;
+}
+
+@property --icon-button-border-color {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: transparent;
+}
+
+@property --icon-button-hover-bg-color {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: transparent;
+}
+
+@property --card-padding {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}
+
+@property --card-bg {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: transparent;
+}
+
+@property --card-radius {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}
+
+@property --form-actions-margin-top {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}
+
+@property --media-split-first-order {
+  syntax: '<integer>';
+  inherits: false;
+  initial-value: 0;
+}
+
+@property --prose-max-inline-size {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0;
+}

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -1,4 +1,5 @@
 @import './layer-order.css';
+@import './property.css';
 
 /* Token: デザイン値の定義 + 単位付与（上位層のデザイン値の参照元） */
 @import './token/helpers.css' layer(token);


### PR DESCRIPTION
## Summary

spec PR [#89](https://github.com/mflocss/spec/pull/89) で確定した §7 SHOULD [公開 API 変数への @property 宣言] を starter v1.2 統合ブランチに反映。AR 採用 10（世界水準 AR セッション 5 の spec 確定待ち保留）の解除。

Animation 層（§5.7 SHOULD [Animation 層公開 API の概念名命名]）は事前調査で案 B 準拠確認済みのため本 PR では修正なし（`--stagger-delay` のみ公開 API / `--_duration` はローカル変数 / `scale-in.css` は公開 API なし）。

## Changes

### 新規: `src/assets/css/property.css`（14 件の `@property` 宣言）

spec §8 L842 / L862-864 の規定に従い、`@layer` 外の専用ファイルとして作成。`@import './property.css';` を `layer-order.css` 直後に追加。

| Block | Property | syntax |
|---|---|---|
| c-button | `--button-color` / `-bg-color` / `-border-color` / `-hover-bg-color` | `<color>` ×4 |
| c-icon-button | `--icon-button-color` / `-bg-color` / `-border-color` / `-hover-bg-color` | `<color>` ×4 |
| c-card | `--card-padding` / `--card-radius` | `<length>` ×2 |
| c-card | `--card-bg` | `<color>` |
| c-form | `--form-actions-margin-top` | `<length>` |
| c-media-split | `--media-split-first-order` | `<integer>` |
| c-prose | `--prose-max-inline-size` | `<length>` |

合計 14 件（`<color>` ×9, `<length>` ×4, `<integer>` ×1）。

### 対象外（SHOULD 条件「型チェックが有効」を満たさない公開 API）

- `--card-shadow` / `--card-border` — shorthand（型は `*` のみ、型チェック不能）
- `--form-required-mark` — 文字列リテラル（`content:` プロパティ用）
- `--text-block-title-max-inline-size` — default が `none`（`<length> | none` 混合型）
- `--overlay-z` — default が `auto`（`<integer> | auto` 混合型）

これらは各 Component のコメントで「型未宣言: {理由}」と明示。use-site の `var(x, fallback)` 形式を維持。

### 書き換え: 6 Component（c-button / c-icon-button / c-card / c-form / c-media-split / c-prose）

**技術的制約**: `@property` の `initial-value` は computationally independent 必須（W3C [CSS-PROPERTIES-VALUES-1]）。`var()` や `light-dark()` は仕様上不可。

**対応パターン**:
- `property.css` の `initial-value` は中立値リテラル（`transparent` / `0`）
- 実デフォルトは **Component の base ルール内で `--button-color: var(--color-surface);`** として宣言
- use-site の `var(--foo, fallback)` は fallback を削除（`@property` 登録後は fallback 発動不能になるため）

**例（c-button）**:
```css
/* property.css */
@property --button-color {
  syntax: '<color>';
  inherits: false;
  initial-value: transparent;
}

/* c-button.css */
.c-button {
  --button-color: var(--color-surface);  /* 実デフォルト */
  /* ... */
  color: var(--button-color);  /* fallback なし */
}
.c-button.-ghost {
  --button-color: var(--color-main);  /* override は従来通り */
}
```

### 影響範囲

- ビルド後 CSS: `@property` 14 件が `@layer utility{}` 閉じ後の global scope に配置されることを確認（`}}}` の後）
- Stylelint: pass（`pnpm lint:css`）
- Vite build: success（`pnpm build`、dist/assets/main-*.css 31.93 kB → 差分ほぼなし）
- Project 層からの override パターン（`.p-foo .c-button { --button-color: ...; }` 等）は従来通り動作

## 配置判断の根拠（事前検討案との差異）

事前検討では「推奨: 各 Component.css の冒頭に `@property` を配置」と「OR 専用ファイル集約」の 2 案があった。spec §8 L862-864 が以下を**明示的に規定**している:

> `@property` 宣言（[CSS-PROPERTIES-VALUES-1]）を含む。`@property` の登録スコープに関する W3C 仕様が未確定であり、ビルドツールによる非対応も報告されているため、`@layer` の外に配置する。**層ディレクトリには入れない**。

starter の現状は各 Component.css が `@layer` 無しで書かれ、`style.css` 側で `@import ... layer(component)` により層に入る。Component.css 冒頭に `@property` を置くと `layer(component)` により layer 内に入ってしまうため、spec §8 と矛盾。

→ spec §8 準拠の「専用ファイル `property.css` / `@layer` 外 / 層ディレクトリには入れない」方式を採用。

## Test plan

- [x] 各 `@property` 宣言が `@layer` 外に配置されている（dist CSS で brace 位置検証済み）
- [x] 公開 API のみ対象（Foundation token / ローカル `--_` 変数は対象外）
- [x] `initial-value` は `@property` 仕様に適合（computationally independent / context 非依存の中立値リテラル）
- [x] `pnpm lint:css` pass
- [x] `pnpm build` success
- [x] Modifier override パターン（`.c-button.-ghost` 等）が従来通り機能
- [ ] Chrome / Firefox / Safari で視覚的退行なし（Baseline 2024 Widely Available、手動確認 TODO）
- [ ] Project 層 override パターン（`.p-foo .c-button { --button-color: ...; }`）の挙動確認（手動 TODO）

## 関連

- spec PR [#89](https://github.com/mflocss/spec/pull/89) — Custom Property finalization（§6 SHOULD NOT → §7 SHOULD 統合 + §7 SHOULD [公開 API 変数への @property 宣言] 新設）
- starter 旗艦 PR [#83](https://github.com/mflocss/starter/pull/83) — main 一斉マージまで OPEN 維持、本 PR は v1.2 統合ブランチ積み上げ
- AR 採用 10（世界水準 AR、セッション 5 保留、spec 確定待ち）→ 本 PR で解除

## 純度原則（starter ブランド）

- **必要最小限、CUSTOMIZE で拡張** — 型チェックが有効な公開 API に限定（14/19 件対象、5 件は型未宣言で fallback 維持）
- **教育的リファレンス実装** — `@property` を「書く理由」の長い解説はコードに入れない（書籍側）
- **spec 原則厳密準拠** — `property.css` / `@layer` 外 / 層ディレクトリ不入の 3 要件全遵守
