### PR TITLE
chore(v1.2): 直近 10 コミットの説明的コメントを除外（starter 最小主義）

### DIFF
--- a/src/assets/css/component/c-button.css
+++ b/src/assets/css/component/c-button.css
@@ -1,14 +1,8 @@
-/* 公開 API（Block 冒頭で public → private 代入、fallback で Default 指定）:
-     --button-color             (default: var(--color-surface)、= -primary 相当)
-     --button-bg-color          (default: var(--color-accent)、= -primary 相当)
-     --button-border-color      (default: var(--color-accent)、= -primary 相当)
-     --button-hover-bg-color    (default: -primary 相当)
-
-   WHY private 分離（Z パターン）:
-   Block 本体で公開 API を再宣言すると local declaration が inherited value を shadow するため、
-   親要素で `--button-bg-color: red` を set しても子 .c-button に継承されない（Issue #116）。
-   公開 API は Block 内で set せず private 変数（--_*）に fallback 付きで代入することで
-   4 パターン（Default / Modifier / use-site override / 親継承）全てを動作させる。 */
+/* 公開 API:
+     --button-color             (default: var(--color-surface))
+     --button-bg-color          (default: var(--color-accent))
+     --button-border-color      (default: var(--color-accent))
+     --button-hover-bg-color    (default: oklch(from var(--color-accent) calc(l * 1.08) c h)) */
 .c-button {
   --_color: var(--button-color, var(--color-surface));
   --_bg-color: var(--button-bg-color, var(--color-accent));
@@ -58,7 +52,7 @@
   /* スタイルなし（base のデフォルトが primary 相当） */
 }
 
-/* Modifier: -ghost（fallback 差し替えで default 値を上書き、親継承時は親値が勝つ） */
+/* Modifier: -ghost */
 .c-button.-ghost {
   --_color: var(--button-color, var(--color-main));
   --_bg-color: var(--button-bg-color, transparent);

--- a/src/assets/css/component/c-card.css
+++ b/src/assets/css/component/c-card.css
@@ -1,10 +1,9 @@
-/* 公開 API（Block 冒頭で public → private 代入、fallback で Default 指定）:
+/* 公開 API:
      --card-padding  (default: var(--space-lg))
      --card-bg       (default: var(--color-surface))
      --card-radius   (default: var(--radius-md))
      --card-shadow   (default: var(--shadow-sm) var(--color-shadow))
-     --card-border   (default: none)
-   WHY private 分離の理由は c-button.css 冒頭参照 */
+     --card-border   (default: none) */
 .c-card {
   --_padding: var(--card-padding, var(--space-lg));
   --_bg: var(--card-bg, var(--color-surface));
@@ -18,7 +17,7 @@
   border-radius: var(--_radius);
   box-shadow: var(--_shadow);
 
-  /* Modifier: -subtle（fallback 差し替えで default 値を上書き、親継承時は親値が勝つ） */
+  /* Modifier: -subtle */
   &.-subtle {
     --_bg: var(--card-bg, var(--color-bg-secondary));
     --_shadow: var(--card-shadow, none);

--- a/src/assets/css/component/c-form.css
+++ b/src/assets/css/component/c-form.css
@@ -1,7 +1,6 @@
-/* 公開 API（Block 冒頭で public → private 代入、fallback で Default 指定）:
+/* 公開 API:
      --form-actions-margin-top  (default: var(--space-md))
-     --form-required-mark       (default: '*')
-   WHY private 分離の理由は c-button.css 冒頭参照 */
+     --form-required-mark       (default: '*') */
 .c-form {
   --_actions-margin-top: var(--form-actions-margin-top, var(--space-md));
 
@@ -33,10 +32,7 @@
   font-weight: var(--font-weight-heading);
 }
 
-/* 必須マーク: --form-required-mark で「*」→「必須」等に切替可能（公開 API）。choice-label は ::before で前置（checkbox の前に表示）。
-   WHY use-site で fallback 構文を直接使用:
-   このルールは Element セレクタ（__label / __legend / __choice-label）のため Block 冒頭の --_actions-margin-top と同じ要素スコープを共有しない。
-   Z パターンの private 分離は Block 本体でのみ成立する。Element ルールでは use-site fallback で親継承を成立させる。 */
+/* 必須マーク: --form-required-mark で「*」→「必須」等に切替可能（公開 API）。choice-label は ::before で前置（checkbox の前に表示） */
 .c-form__field:has(:required) > .c-form__label::after,
 .c-form__field:has(:required) > .c-form__legend::after,
 .c-form__field:has(:required) > .c-form__choice-label::before {
@@ -66,14 +62,11 @@
   }
 }
 
-/* NOTE: field-sizing は Baseline 未達。Chrome 123+ / Safari 26.2+ 対応、Firefox は 2026-04 時点で全バージョン未対応。
-   未対応ブラウザでは resize: block による手動リサイズでフォールバック
-   （https://caniuse.com/mdn-css_properties_field-sizing） */
 textarea.c-form__input {
   field-sizing: content;
   min-block-size: 10lh;
   max-block-size: 20lh;
-  resize: block; /* 未対応ブラウザでユーザーが手動リサイズ */
+  resize: block;
 }
 
 @supports (field-sizing: content) {
@@ -99,8 +92,7 @@ textarea.c-form__input {
   margin-block-start: var(--space-xs);
 }
 
-/* Element: 送信ボタン配置ラッパー（中央寄せ default、Project 側で上書き可）。
-   Block 冒頭で宣言した --_actions-margin-top を参照（private 変数は子孫 Element に継承される） */
+/* Element: 送信ボタン配置ラッパー（中央寄せ default、Project 側で上書き可） */
 .c-form__actions {
   display: flex;
   justify-content: center;

--- a/src/assets/css/component/c-icon-button.css
+++ b/src/assets/css/component/c-icon-button.css
@@ -1,9 +1,8 @@
-/* 公開 API（Block 冒頭で public → private 代入、fallback で Default 指定）:
-     --icon-button-color             (default: var(--color-surface)、= -primary 相当)
-     --icon-button-bg-color          (default: var(--color-accent)、= -primary 相当)
-     --icon-button-border-color      (default: var(--color-accent)、= -primary 相当)
-     --icon-button-hover-bg-color    (default: -primary 相当)
-   WHY private 分離の理由は c-button.css 冒頭参照 */
+/* 公開 API:
+     --icon-button-color             (default: var(--color-surface))
+     --icon-button-bg-color          (default: var(--color-accent))
+     --icon-button-border-color      (default: var(--color-accent))
+     --icon-button-hover-bg-color    (default: oklch(from var(--color-accent) calc(l * 1.08) c h)) */
 .c-icon-button {
   --_color: var(--icon-button-color, var(--color-surface));
   --_bg-color: var(--icon-button-bg-color, var(--color-accent));
@@ -59,7 +58,7 @@
   /* スタイルなし（base のデフォルトが primary 相当） */
 }
 
-/* Modifier: -ghost（fallback 差し替えで default 値を上書き、親継承時は親値が勝つ） */
+/* Modifier: -ghost */
 .c-icon-button.-ghost {
   --_color: var(--icon-button-color, var(--color-main));
   --_bg-color: var(--icon-button-bg-color, transparent);

--- a/src/assets/css/component/c-media-split.css
+++ b/src/assets/css/component/c-media-split.css
@@ -1,6 +1,5 @@
-/* 公開 API（Block 冒頭で public → private 代入、fallback で Default 指定）:
-     --media-split-first-order  (default: 0、`:nth-child(even)` 等で 1 を set して左右反転)
-   WHY private 分離の理由は c-button.css 冒頭参照 */
+/* 公開 API:
+     --media-split-first-order  (default: 0、`:nth-child(even)` 等で 1 を set して左右反転) */
 .c-media-split {
   --_first-order: var(--media-split-first-order, 0);
 

--- a/src/assets/css/component/c-prose.css
+++ b/src/assets/css/component/c-prose.css
@@ -1,7 +1,6 @@
 /* 子孫セレクタを許容する例外 Component（CMS 流し込み等、HTML クラス付与不能な用途向け）
-   公開 API（Block 冒頭で public → private 代入、fallback で Default 指定）:
-     --prose-max-inline-size  (default: 40rem、読みやすい最大幅、Project 側で上書き可)
-   WHY private 分離の理由は c-button.css 冒頭参照 */
+   公開 API:
+     --prose-max-inline-size  (default: 40rem) */
 .c-prose {
   --_max-inline-size: var(--prose-max-inline-size, 40rem);
 


### PR DESCRIPTION
## 目的

PR #155〜#164（v1.2 統合ブランチ直近 10 コミット）で追加された説明的コメントを、comment-audit 方針（7 カテゴリ）で精査し除外。

## 除外パターン

| # | パターン | 対象ファイル |
|---|---------|------------|
| 1 | Block 冒頭括弧書き「（Block 冒頭で public → private 代入...）」 | 全 6 Component |
| 2 | WHY private 分離（Z パターン）: ブロック（4 行） | c-button |
| 3 | 「WHY private 分離の理由は c-button.css 冒頭参照」1 行 | c-card / c-form / c-icon-button / c-media-split / c-prose |
| 4 | 公開 API 内注記「= -primary 相当」（actual default 値に置換） | c-button / c-icon-button |
| 5 | Modifier ラベルの動作説明括弧「（fallback 差し替えで...）」 | c-button / c-card / c-icon-button |
| 6 | c-form 必須マーク WHY ブロック（Z パターン Element スコープ説明 3 行） | c-form |
| 7 | c-form field-sizing NOTE（Baseline 未達・URL・inline コメント） | c-form |
| 8 | c-form __actions Element コメントの追加行 | c-form |

## 残したもの

- **公開 API リスト**: var 名 + default 値（API ドキュメント）
- **Modifier セクションラベル**: `/* Modifier: -ghost */` 最小形式
- **DEVIATION**: c-prose 子孫セレクタ許容 / c-back-to-top 固定配置（変更なし）
- **CUSTOMIZE ヒント**: c-media-split `（`:nth-child(even)` 等で 1 を set して左右反転)` （PR #155 以前から存在）
- **BEM Element ラベル / 空ルール placeholder**: 既存の pre-#155 形式をそのまま保持

## 設計意図の保管先

Z パターンの詳細（4 パターン全動作・Issue #116 背景）は:
- コミット履歴 / PR #164 説明

starter コード内は最小主義を維持。

## 検証

- `pnpm run check` ✅ pass（stylelint / eslint / markuplint）
- `pnpm run build` ✅ pass（57ms）
- dist CSS: コメント削除のみ（ルール自体は不変）
- 変更: 6 files changed, 24 insertions(+), 42 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)