### PR TITLE
fix(starter): HTML 属性順統一 + c-prose AGENT_GUIDE S2-4 参照追加 (agent-guide-review #1, #3)

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -36,16 +36,16 @@
     <!-- Header -->
     <header class="l-header p-header">
       <div class="l-inner p-header__bar">
-        <a href="/" class="p-header__logo" data-drawer-inert translate="no">iluha</a>
+        <a class="p-header__logo" data-drawer-inert href="/" translate="no">iluha</a>
 
         <nav class="p-header__nav" data-drawer-inert aria-label="メインナビゲーション">
           <ul class="p-header__nav-list">
-            <li><a href="/#features" class="p-header__nav-link">特徴</a></li>
-            <li><a href="/#voice" class="p-header__nav-link">お客様の声</a></li>
-            <li><a href="/#faq" class="p-header__nav-link">よくある質問</a></li>
-            <li><a href="/#contact" class="p-header__nav-link">ご予約</a></li>
+            <li><a class="p-header__nav-link" href="/#features">特徴</a></li>
+            <li><a class="p-header__nav-link" href="/#voice">お客様の声</a></li>
+            <li><a class="p-header__nav-link" href="/#faq">よくある質問</a></li>
+            <li><a class="p-header__nav-link" href="/#contact">ご予約</a></li>
           </ul>
-          <a href="/#contact" class="c-button -primary p-header__cta">初回体験を予約する</a>
+          <a class="c-button -primary p-header__cta" href="/#contact">初回体験を予約する</a>
         </nav>
 
         <!-- Hamburger: drawer 開閉中も機能するため data-drawer-inert 対象外 -->
@@ -70,20 +70,20 @@
         <nav class="p-drawer__nav" aria-label="ドロワーナビゲーション">
           <ul class="p-drawer__nav-list">
             <li>
-              <a href="/#features" class="p-drawer__nav-link">特徴</a>
+              <a class="p-drawer__nav-link" href="/#features">特徴</a>
             </li>
             <li>
-              <a href="/#voice" class="p-drawer__nav-link">お客様の声</a>
+              <a class="p-drawer__nav-link" href="/#voice">お客様の声</a>
             </li>
             <li>
-              <a href="/#faq" class="p-drawer__nav-link">よくある質問</a>
+              <a class="p-drawer__nav-link" href="/#faq">よくある質問</a>
             </li>
             <li>
-              <a href="/#contact" class="p-drawer__nav-link">ご予約</a>
+              <a class="p-drawer__nav-link" href="/#contact">ご予約</a>
             </li>
           </ul>
         </nav>
-        <a href="/#contact" class="c-button -primary p-drawer__cta">初回体験を予約する</a>
+        <a class="c-button -primary p-drawer__cta" href="/#contact">初回体験を予約する</a>
       </div>
     </dialog>
 
@@ -99,7 +99,7 @@
             お手数ですが、トップページから目的のページをお探しください。
           </p>
           <div class="p-not-found__actions">
-            <a href="/" class="c-button -primary -large p-not-found__cta">トップページへ戻る</a>
+            <a class="c-button -primary -large p-not-found__cta" href="/">トップページへ戻る</a>
           </div>
         </div>
       </section>
@@ -110,19 +110,19 @@
       <div class="l-inner p-footer__stack">
         <nav class="p-footer__nav" aria-label="フッターナビゲーション">
           <ul class="p-footer__nav-list">
-            <li><a href="/#features" class="p-footer__nav-link">特徴</a></li>
-            <li><a href="/#voice" class="p-footer__nav-link">お客様の声</a></li>
-            <li><a href="/#faq" class="p-footer__nav-link">よくある質問</a></li>
-            <li><a href="/#contact" class="p-footer__nav-link">ご予約</a></li>
+            <li><a class="p-footer__nav-link" href="/#features">特徴</a></li>
+            <li><a class="p-footer__nav-link" href="/#voice">お客様の声</a></li>
+            <li><a class="p-footer__nav-link" href="/#faq">よくある質問</a></li>
+            <li><a class="p-footer__nav-link" href="/#contact">ご予約</a></li>
             <li>
-              <a href="/privacy/" class="p-footer__nav-link">プライバシーポリシー</a>
+              <a class="p-footer__nav-link" href="/privacy/">プライバシーポリシー</a>
             </li>
           </ul>
         </nav>
         <!-- CUSTOMIZE: 住所・電話番号・営業時間を差し替え -->
         <address class="p-footer__address">
           〒xxx-xxxx 東京都渋谷区○○ x-x-x ○○ビル 3F<br />
-          <a href="tel:03-xxxx-xxxx" class="p-footer__tel" translate="no">TEL: 03-xxxx-xxxx</a><br />
+          <a class="p-footer__tel" href="tel:03-xxxx-xxxx" translate="no">TEL: 03-xxxx-xxxx</a><br />
           営業時間: 10:00〜20:00（最終受付 19:00）<br />
           定休日: 毎週水曜日
         </address>

--- a/src/assets/css/component/c-prose.css
+++ b/src/assets/css/component/c-prose.css
@@ -1,4 +1,5 @@
 /* 子孫セレクタを許容する例外 Component（CMS 流し込み等、HTML クラス付与不能な用途向け）
+   AGENT_GUIDE S2-4 例外: https://github.com/mflocss/agent-reference/blob/feature/agent-guide-initial-draft/AGENT_GUIDE.md
    公開 API:
      --prose-max-inline-size  (default: 40rem) */
 .c-prose {

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -76,16 +76,16 @@
     <!-- Header -->
     <header class="l-header p-header">
       <div class="l-inner p-header__bar">
-        <a href="/" class="p-header__logo" data-drawer-inert translate="no">iluha</a>
+        <a class="p-header__logo" data-drawer-inert href="/" translate="no">iluha</a>
 
         <nav class="p-header__nav" data-drawer-inert aria-label="メインナビゲーション">
           <ul class="p-header__nav-list">
-            <li><a href="/#features" class="p-header__nav-link">特徴</a></li>
-            <li><a href="/#voice" class="p-header__nav-link">お客様の声</a></li>
-            <li><a href="/#faq" class="p-header__nav-link">よくある質問</a></li>
-            <li><a href="/#contact" class="p-header__nav-link">ご予約</a></li>
+            <li><a class="p-header__nav-link" href="/#features">特徴</a></li>
+            <li><a class="p-header__nav-link" href="/#voice">お客様の声</a></li>
+            <li><a class="p-header__nav-link" href="/#faq">よくある質問</a></li>
+            <li><a class="p-header__nav-link" href="/#contact">ご予約</a></li>
           </ul>
-          <a href="/#contact" class="c-button -primary p-header__cta">初回体験を予約する</a>
+          <a class="c-button -primary p-header__cta" href="/#contact">初回体験を予約する</a>
         </nav>
 
         <!-- Hamburger: drawer 開閉中も機能するため data-drawer-inert 対象外 -->
@@ -110,20 +110,20 @@
         <nav class="p-drawer__nav" aria-label="ドロワーナビゲーション">
           <ul class="p-drawer__nav-list">
             <li>
-              <a href="/#features" class="p-drawer__nav-link">特徴</a>
+              <a class="p-drawer__nav-link" href="/#features">特徴</a>
             </li>
             <li>
-              <a href="/#voice" class="p-drawer__nav-link">お客様の声</a>
+              <a class="p-drawer__nav-link" href="/#voice">お客様の声</a>
             </li>
             <li>
-              <a href="/#faq" class="p-drawer__nav-link">よくある質問</a>
+              <a class="p-drawer__nav-link" href="/#faq">よくある質問</a>
             </li>
             <li>
-              <a href="/#contact" class="p-drawer__nav-link">ご予約</a>
+              <a class="p-drawer__nav-link" href="/#contact">ご予約</a>
             </li>
           </ul>
         </nav>
-        <a href="/#contact" class="c-button -primary p-drawer__cta">初回体験を予約する</a>
+        <a class="c-button -primary p-drawer__cta" href="/#contact">初回体験を予約する</a>
       </div>
     </dialog>
 
@@ -171,19 +171,19 @@
       <div class="l-inner p-footer__stack">
         <nav class="p-footer__nav" aria-label="フッターナビゲーション">
           <ul class="p-footer__nav-list">
-            <li><a href="/#features" class="p-footer__nav-link">特徴</a></li>
-            <li><a href="/#voice" class="p-footer__nav-link">お客様の声</a></li>
-            <li><a href="/#faq" class="p-footer__nav-link">よくある質問</a></li>
-            <li><a href="/#contact" class="p-footer__nav-link">ご予約</a></li>
+            <li><a class="p-footer__nav-link" href="/#features">特徴</a></li>
+            <li><a class="p-footer__nav-link" href="/#voice">お客様の声</a></li>
+            <li><a class="p-footer__nav-link" href="/#faq">よくある質問</a></li>
+            <li><a class="p-footer__nav-link" href="/#contact">ご予約</a></li>
             <li>
-              <a href="/privacy/" class="p-footer__nav-link" aria-current="page">プライバシーポリシー</a>
+              <a class="p-footer__nav-link" href="/privacy/" aria-current="page">プライバシーポリシー</a>
             </li>
           </ul>
         </nav>
         <!-- CUSTOMIZE: 住所・電話番号・営業時間を差し替え -->
         <address class="p-footer__address">
           〒xxx-xxxx 東京都渋谷区○○ x-x-x ○○ビル 3F<br />
-          <a href="tel:03-xxxx-xxxx" class="p-footer__tel" translate="no">TEL: 03-xxxx-xxxx</a><br />
+          <a class="p-footer__tel" href="tel:03-xxxx-xxxx" translate="no">TEL: 03-xxxx-xxxx</a><br />
           営業時間: 10:00〜20:00（最終受付 19:00）<br />
           定休日: 毎週水曜日
         </address>


### PR DESCRIPTION
## 採用根拠

starter v1.2 レビュー（2026-04-26、AGENT_GUIDE 効果検証含む）で採用判定された **H #1 + H #3** の反映。

レビュー対象 commit: `6978685`

---

## 修正内容

### H #1: HTML 属性順統一（class 先優先、index.html 準拠）

`index.html` を基準（`class="..." href="..."` 順）に統一。

| ファイル | 修正前（href-first 件数） | 修正後 |
|---|---|---|
| `src/404.html` | 18 件 | **0 件** |
| `src/privacy/index.html` | 17 件 | **0 件** |

根拠: 「3 順序ルール（class 記載順 / HTML 属性順 / CSS 定義順）」の統一方針

### H #3: c-prose 子孫セレクタ例外コメント強化

`src/assets/css/component/c-prose.css` 冒頭コメントに AGENT_GUIDE S2-4 例外条項 URL を 1 行追記。

```diff
 /* 子孫セレクタを許容する例外 Component（CMS 流し込み等、HTML クラス付与不能な用途向け）
+   AGENT_GUIDE S2-4 例外: https://github.com/mflocss/agent-reference/blob/feature/agent-guide-initial-draft/AGENT_GUIDE.md
    公開 API:
      --prose-max-inline-size  (default: 40rem) */
```

---

## 検証結果

```
grep -E '<a\s+href="[^"]*"\s+class=' src/404.html → 0 hit ✅
grep -E '<a\s+href="[^"]*"\s+class=' src/privacy/index.html → 0 hit ✅
c-prose.css AGENT_GUIDE S2-4 参照行追加: yes ✅
```

修正ファイル数: 3 件（404.html / privacy/index.html / c-prose.css）

---

## スコープ外（今回対象外）

- **H #2（c-skip-link / u-visually-hidden 責任分離）**: 保留 A（全 Component 公開 API 必須化方針と連動）のしゅんえい判断後に別 PR で対応

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)