### PR TITLE
fix(starter): c-form --form-link-color 公開 API 化 + c-skip-link 内部統合 (agent-guide-review B, #2)

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -31,7 +31,7 @@
   </head>
   <body id="top">
     <!-- Skip Link -->
-    <a class="c-skip-link u-visually-hidden" data-drawer-inert href="#main">本文へスキップ</a>
+    <a class="c-skip-link" data-drawer-inert href="#main">本文へスキップ</a>
 
     <!-- Header -->
     <header class="l-header p-header">

--- a/src/assets/css/component/c-form.css
+++ b/src/assets/css/component/c-form.css
@@ -1,8 +1,10 @@
 /* 公開 API:
      --form-actions-margin-top  (default: var(--space-md))
-     --form-required-mark       (default: '*') */
+     --form-required-mark       (default: '*')
+     --form-link-color          (default: var(--color-link)) */
 .c-form {
   --_actions-margin-top: var(--form-actions-margin-top, var(--space-md));
+  --_link-color: var(--form-link-color, var(--color-link));
 
   display: flex;
   flex-direction: column;
@@ -97,4 +99,11 @@ textarea.c-form__input {
   display: flex;
   justify-content: center;
   margin-block-start: var(--_actions-margin-top);
+}
+
+/* フォーム内リンク（プライバシーポリシー等、クラス付与なしで使われることが多い子孫 <a>）
+   Reset で color / text-decoration-line が unset されるため Block 内で正規化 */
+.c-form a {
+  color: var(--_link-color);
+  text-decoration: underline;
 }

--- a/src/assets/css/component/c-skip-link.css
+++ b/src/assets/css/component/c-skip-link.css
@@ -14,6 +14,19 @@
   background-color: var(--color-main);
   border-radius: var(--radius-sm);
 
+  /* u-visually-hidden 相当の視覚的非表示を内部統合（Component 単体で機能完結、display: none / visibility: hidden を使わず SR からは常に読み上げ可） */
+  &:not(:focus, :active, :focus-within) {
+    position: absolute;
+    inline-size: 1px;
+    block-size: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    white-space: nowrap;
+    border: 0;
+    clip-path: inset(50%);
+  }
+
   &:focus-visible {
     position: fixed;
     inset-block-start: var(--space-sm);

--- a/src/assets/css/project/p-contact.css
+++ b/src/assets/css/project/p-contact.css
@@ -18,13 +18,9 @@
 
 .p-contact__form {
   --_form-max: 640px;
+  --form-link-color: var(--color-main);
 
   max-inline-size: var(--_form-max);
   margin-block-start: var(--space-xl-2xl);
   margin-inline: auto;
-}
-
-.p-contact__form a {
-  color: var(--color-main);
-  text-decoration: underline;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -143,7 +143,7 @@
   </head>
   <body id="top">
     <!-- Skip Link -->
-    <a class="c-skip-link u-visually-hidden" data-drawer-inert href="#main">本文へスキップ</a>
+    <a class="c-skip-link" data-drawer-inert href="#main">本文へスキップ</a>
 
     <!-- Header -->
     <header class="l-header p-header">

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -71,7 +71,7 @@
   </head>
   <body id="top">
     <!-- Skip Link -->
-    <a class="c-skip-link u-visually-hidden" data-drawer-inert href="#main">本文へスキップ</a>
+    <a class="c-skip-link" data-drawer-inert href="#main">本文へスキップ</a>
 
     <!-- Header -->
     <header class="l-header p-header">


### PR DESCRIPTION
## 採用根拠

starter v1.2 agent-guide-review（2026-04-26）の **保留 B** + **採用 H #2** をしゅんえい方針確定後に実装。

- **保留 B**: `.p-contact__form a` 子孫セレクタ → **公開 API 化**（教材リファレンスとして例外条項拡大を避ける）
- **採用 H #2**: c-skip-link / u-visually-hidden 責任分離 → **c-skip-link 内部統合**（Component が機能本質を完結、保留 A 混在維持方針と整合）

## 修正内容

### 保留 B: c-form 公開 API `--form-link-color`

- `c-form.css`: `--form-link-color` 公開 API 新設（default: `var(--color-link)`）
  - Z パターンで `--_link-color` に private 化
  - `.c-form a` 子孫セレクタで Reset 後の `color` / `text-decoration` を正規化（Reset 層が両プロパティを `unset` するため）
- `p-contact.css`: `.p-contact__form a { ... }` 子孫セレクタを削除し、`--form-link-color: var(--color-main)` で公開 API 上書きに変換

### 採用 H #2: c-skip-link 内部統合

- `c-skip-link.css`: `u-visually-hidden` 相当の `:not(:focus, :active, :focus-within)` ガードを Block 内部に統合
  - `display: none` / `visibility: hidden` を使わず `clip-path: inset(50%)` ベースで実装（スクリーンリーダー常時読み上げ維持）
  - Component 単体で「視覚的非表示 + focus 時可視化」を完結
- `index.html` / `404.html` / `privacy/index.html`: `u-visually-hidden` クラスを削除（`class="c-skip-link"` のみに）

## 検証結果

```
grep -n "p-contact__form a" src/assets/css/project/p-contact.css  → 0 hit ✓
grep -n "form-link-color" src/assets/css/component/c-form.css     → 2 hit（公開 API 定義）✓
grep -n "form-link-color" src/assets/css/project/p-contact.css    → 1 hit（Project 上書き）✓
grep -nE "c-skip-link.*u-visually-hidden" src/**/*.html            → 0 hit ✓
grep -n "clip-path" src/assets/css/component/c-skip-link.css      → 1 hit（内部統合確認）✓
```

## スコープ外（本 PR 対象外）

- H #2 に関連する `u-visually-hidden.css`（utility 層）自体は変更なし（他箇所での利用が残る）
- 保留 A（全 Component 公開 API 必須化 vs 最小主義）は「混在維持」で確定、別途対応不要