### PR TITLE
refactor(starter): Component 責任境界純度向上 — c-accordion dead code 削除 + Modifier 空ルール 2 件削除

### DIFF
--- a/src/assets/css/component/c-accordion.css
+++ b/src/assets/css/component/c-accordion.css
@@ -2,10 +2,6 @@
   overflow: hidden;
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--radius-md);
-
-  & + & {
-    border-block-start: none;
-  }
 }
 
 .c-accordion__summary {

--- a/src/assets/css/component/c-button.css
+++ b/src/assets/css/component/c-button.css
@@ -47,11 +47,6 @@
   }
 }
 
-/* Modifier: -primary（明示的選択マーカー、デフォルトと同じ値のため空ルール） */
-.c-button.-primary {
-  /* スタイルなし（base のデフォルトが primary 相当） */
-}
-
 /* Modifier: -ghost */
 .c-button.-ghost {
   --_color: var(--button-color, var(--color-main));

--- a/src/assets/css/component/c-icon-button.css
+++ b/src/assets/css/component/c-icon-button.css
@@ -53,11 +53,6 @@
   block-size: 1em;
 }
 
-/* Modifier: -primary（明示的選択マーカー、デフォルトと同じ値のため空ルール） */
-.c-icon-button.-primary {
-  /* スタイルなし（base のデフォルトが primary 相当） */
-}
-
 /* Modifier: -ghost */
 .c-icon-button.-ghost {
   --_color: var(--icon-button-color, var(--color-main));


### PR DESCRIPTION
## Summary

確定方針に従い、Component 責任境界の純度を向上:

- c-accordion `& + &` 削除（dead code、`<li>` ラッパーで効いていない）
- c-button.-primary / c-icon-button.-primary 空ルール 2 件削除

## 背景: AGENT_GUIDE 逆輸入アプローチの前提

しゅんえい指示「AGENT_GUIDE は starter の原典の一つであり、AGENT_GUIDE → starter 参照は相互参照になる。逆輸入で AGENT_GUIDE に整理する」を採択。本 PR は **starter のコード規範を先行確定** することで、後続の AGENT_GUIDE 修正（逆輸入）の前提条件を整える。

## 変更詳細

### 1. c-accordion `& + &` 削除（dead code）

**HTML 構造**: `<ul class="p-faq__list"><li class="p-faq__item"><details class="c-accordion p-faq__accordion">` で `<li>` がラッパー。c-accordion 同士は **別の `<li>` 配下のため隣接兄弟関係が成立しない**。

**実機能している補正**は `src/assets/css/project/p-faq.css` L19-24:
```css
.p-faq__item {
  /* li wrapper で c-accordion 隣接兄弟ルールが無効化されるため再現 */
  & + & .c-accordion {
    border-block-start: none;
  }
}
```

c-accordion 内の `& + &` は dead code。**責任境界の観点でも**、Component が「複数並べた時の振る舞い」を抱えるのはグループ表示の責任（Project / Layout 層）への侵食。

### 2. Modifier 空ルール 2 件削除

- `.c-button.-primary`（base のデフォルトが primary 相当のため空ルール）
- `.c-icon-button.-primary`（同上）

starter リファレンス実装のシンプル化。HTML テンプレート側の `class="c-button -primary"` 等は明示的選択マーカーとして **維持**（class 列に意図表現が残る）。

## NOT in scope

- `p-faq.css` 全般（実機能補正の維持、AGENT_GUIDE §3.2 例外パターンの実装根拠）
- `c-button.-ghost / .-large` / `c-icon-button.-ghost / .-large` 等の実装ありルール
- HTML テンプレートの class 列

## Test plan

- [x] `pnpm build` 成功（CSS 31.39 kB、bundling 正常）
- [x] 静的解析: 物理プロパティ（`top:/bottom:/left:/right:/border-top:` 等）の単独使用は **starter にゼロ件確認済み**（grep で確認）
- [x] dead code 確認: c-accordion `& + &` は HTML 構造で効いていないことを検証済み
- [ ] preview 視覚回帰確認（しゅんえい側で目視推奨）

## 関連

- 本 PR は v1.2 統合ブランチへ。Claude 自律マージ可（v1.2 = 統合ブランチ）
- 後続: agent-reference リポの AGENT_GUIDE 修正 PR
- 「責任境界優先」原則の適用例

🤖 Generated with [Claude Code](https://claude.com/claude-code)
