### PR TITLE
fix(starter): -primary dead class 削除 + p-faq accordion を gap 区切りに変更（PR #169 補修）

### DIFF
--- a/src/assets/css/project/p-faq.css
+++ b/src/assets/css/project/p-faq.css
@@ -11,16 +11,15 @@
 }
 
 .p-faq__list {
+  display: grid;
   max-inline-size: var(--content-width-narrow);
+  gap: var(--space-md);
   margin-block-start: var(--space-xl-2xl);
   margin-inline: auto;
 }
 
 .p-faq__item {
-  /* li wrapper で c-accordion 隣接兄弟ルールが無効化されるため再現 */
-  & + & .c-accordion {
-    border-block-start: none;
-  }
+  /* スタイルなし（HTML クラスとの対応を維持） */
 }
 
 .p-faq__accordion {

--- a/src/index.html
+++ b/src/index.html
@@ -158,7 +158,7 @@
             <li><a class="p-header__nav-link" href="#faq">よくある質問</a></li>
             <li><a class="p-header__nav-link" href="#contact">ご予約</a></li>
           </ul>
-          <a class="c-button -primary p-header__cta" href="#contact">初回体験を予約する</a>
+          <a class="c-button p-header__cta" href="#contact">初回体験を予約する</a>
         </nav>
 
         <!-- Hamburger: drawer 開閉中も機能するため data-drawer-inert 対象外 -->
@@ -196,7 +196,7 @@
             </li>
           </ul>
         </nav>
-        <a class="c-button -primary p-drawer__cta" href="#contact">初回体験を予約する</a>
+        <a class="c-button p-drawer__cta" href="#contact">初回体験を予約する</a>
       </div>
     </dialog>
 
@@ -212,7 +212,7 @@
               は、内側から整うボディケアサロンです。
             </p>
             <div class="p-hero__actions">
-              <a class="c-icon-button -primary -large p-hero__cta" href="#contact">
+              <a class="c-icon-button -large p-hero__cta" href="#contact">
                 初回体験を予約する
                 <svg class="c-icon-button__icon" width="20" height="20" aria-hidden="true">
                   <use href="/assets/images/icons/arrow-right.svg#icon" />
@@ -536,7 +536,7 @@
               <h2 class="c-text-block__title" id="cta-heading">まずは一度、からだの声を聴いてみませんか？</h2>
               <p class="c-text-block__text">初回体験は 60分 4,400円。カウンセリング込み。無理な勧誘はいたしません。</p>
             </div>
-            <a class="c-button -primary -large p-cta__button" href="#contact">初回体験を予約する</a>
+            <a class="c-button -large p-cta__button" href="#contact">初回体験を予約する</a>
           </div>
         </div>
       </section>
@@ -677,7 +677,7 @@
             </div>
 
             <div class="c-form__actions">
-              <button class="c-button -primary -large" type="submit">送信する</button>
+              <button class="c-button -large" type="submit">送信する</button>
             </div>
           </form>
         </div>


### PR DESCRIPTION
## 概要

PR #169（c-accordion dead code 削除 + Modifier 空ルール 2 件削除）の補修 PR。

CSS 側で `.c-button.-primary` / `.c-icon-button.-primary` セレクタを削除したが、HTML 側の `-primary` class が残存していた（dead class）。また p-faq の border 二重消し補正は gap 化により不要になった。

## 変更内容

### 1. `src/index.html` — dead class 5 箇所削除

- 161: `c-button -primary p-header__cta` → `c-button p-header__cta`
- 199: `c-button -primary p-drawer__cta` → `c-button p-drawer__cta`
- 215: `c-icon-button -primary -large p-hero__cta` → `c-icon-button -large p-hero__cta`
- 539: `c-button -primary -large p-cta__button` → `c-button -large p-cta__button`
- 680: `c-button -primary -large` → `c-button -large`

### 2. `src/assets/css/project/p-faq.css` — gap 化

- `.p-faq__list` に `display: grid` + `gap: var(--space-md)` 追加
- `.p-faq__item` の border 二重消し補正セレクタ削除（gap で不要に）

## 関連

- PR #169 の HTML 整合確認漏れ補修