### PR TITLE
fix(starter): HTML 側 -primary dead class 削除（PR #170 補修漏れ修正）

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -45,7 +45,7 @@
             <li><a class="p-header__nav-link" href="/#faq">よくある質問</a></li>
             <li><a class="p-header__nav-link" href="/#contact">ご予約</a></li>
           </ul>
-          <a class="c-button -primary p-header__cta" href="/#contact">初回体験を予約する</a>
+          <a class="c-button p-header__cta" href="/#contact">初回体験を予約する</a>
         </nav>
 
         <!-- Hamburger: drawer 開閉中も機能するため data-drawer-inert 対象外 -->
@@ -83,7 +83,7 @@
             </li>
           </ul>
         </nav>
-        <a class="c-button -primary p-drawer__cta" href="/#contact">初回体験を予約する</a>
+        <a class="c-button p-drawer__cta" href="/#contact">初回体験を予約する</a>
       </div>
     </dialog>
 
@@ -99,7 +99,7 @@
             お手数ですが、トップページから目的のページをお探しください。
           </p>
           <div class="p-not-found__actions">
-            <a class="c-button -primary -large p-not-found__cta" href="/">トップページへ戻る</a>
+            <a class="c-button -large p-not-found__cta" href="/">トップページへ戻る</a>
           </div>
         </div>
       </section>

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -85,7 +85,7 @@
             <li><a class="p-header__nav-link" href="/#faq">よくある質問</a></li>
             <li><a class="p-header__nav-link" href="/#contact">ご予約</a></li>
           </ul>
-          <a class="c-button -primary p-header__cta" href="/#contact">初回体験を予約する</a>
+          <a class="c-button p-header__cta" href="/#contact">初回体験を予約する</a>
         </nav>
 
         <!-- Hamburger: drawer 開閉中も機能するため data-drawer-inert 対象外 -->
@@ -123,7 +123,7 @@
             </li>
           </ul>
         </nav>
-        <a class="c-button -primary p-drawer__cta" href="/#contact">初回体験を予約する</a>
+        <a class="c-button p-drawer__cta" href="/#contact">初回体験を予約する</a>
       </div>
     </dialog>
 


### PR DESCRIPTION
## 概要

PR #170「-primary dead class 削除 + p-faq accordion を gap 区切りに変更」で CSS 側の `.c-button.-primary` セレクタは削除されたが、**HTML 側の class 属性で `-primary` が残存**していたため除去する補修 PR。

直前の AR 仕上げで **Critical 指摘**として検出された。

## 修正内容

| ファイル | 修正前 | 修正後 |
|---|---|---|
| `src/404.html:48` | `c-button -primary p-header__cta` | `c-button p-header__cta` |
| `src/404.html:86` | `c-button -primary p-drawer__cta` | `c-button p-drawer__cta` |
| `src/404.html:102` | `c-button -primary -large p-not-found__cta` | `c-button -large p-not-found__cta` |
| `src/privacy/index.html:88` | `c-button -primary p-header__cta` | `c-button p-header__cta` |
| `src/privacy/index.html:126` | `c-button -primary p-drawer__cta` | `c-button p-drawer__cta` |

## 影響範囲

- **動作**: 変化なし（c-button だけで Default = primary 表示。CSS 側は PR #170 で削除済み、dead class）
- **見た目**: 変化なし

## 根拠

- AGENT_GUIDE [shunei 流] L600「Modifier 空ルールは削除する」
- Modifier 命名規約整合性（HTML に書かれているのに CSS 定義がない状態を解消）

## 検証

- 修正前 grep: 5 件（\`grep -rn "\-primary" --include="*.html" .\`）
- 修正後 grep: 0 件

## 関連

- 補修元: PR #170