### PR TITLE
fix(starter): v1.0.1 Minor patch — AR #177 9件対応

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -66,7 +66,7 @@
     <div class="c-overlay" data-drawer-overlay hidden></div>
     <dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title" aria-modal="true">
       <div class="p-drawer__stack">
-        <span id="drawer-title" class="u-visually-hidden">ナビゲーションメニュー</span>
+        <span class="u-visually-hidden" id="drawer-title">ナビゲーションメニュー</span>
         <nav class="p-drawer__nav" aria-label="ドロワーナビゲーション">
           <ul class="p-drawer__nav-list">
             <li>
@@ -92,7 +92,7 @@
         <div class="l-inner p-not-found__inner">
           <hgroup class="c-section-heading p-not-found__heading">
             <p class="c-section-heading__eyebrow">404</p>
-            <h1 id="not-found-heading" class="c-section-heading__title">ページが見つかりません</h1>
+            <h1 class="c-section-heading__title" id="not-found-heading">ページが見つかりません</h1>
           </hgroup>
           <p class="p-not-found__lead">
             お探しのページは移動または削除された可能性があります。<br />

--- a/src/assets/css/component/c-overlay.css
+++ b/src/assets/css/component/c-overlay.css
@@ -1,10 +1,11 @@
+/* 公開 API:
+     --overlay-z  (default: auto) */
 /*
  * DEVIATION: spec §5.5 SHOULD NOT [外部レイアウト影響プロパティの排除] の例外。
  *   自己配置型 Component（spec §5.5 例外条項）として position: fixed を宣言。
  *   ビューポート全体被覆がこの Component の機能本質（機能本質の担保 / 配置基準の独立性を満たす）。
  *
  * 汎用オーバーレイ。ドロワー・モーダル・ライトボックス等で再利用可能。
- * --overlay-z で z-index を利用側から上書き可能。
  */
 .c-overlay {
   --_z: var(--overlay-z, auto);

--- a/src/assets/css/component/c-overlay.css
+++ b/src/assets/css/component/c-overlay.css
@@ -1,5 +1,6 @@
 /* 公開 API:
      --overlay-z  (default: auto) */
+
 /*
  * DEVIATION: spec §5.5 SHOULD NOT [外部レイアウト影響プロパティの排除] の例外。
  *   自己配置型 Component（spec §5.5 例外条項）として position: fixed を宣言。

--- a/src/assets/css/layout/l-section.css
+++ b/src/assets/css/layout/l-section.css
@@ -1,3 +1,6 @@
+/* 公開 API:
+     --section-padding-min  (default: var(--section-standard-min))
+     --section-padding-max  (default: var(--section-standard-max)) */
 .l-section {
   --section-padding-min: var(--section-standard-min);
   --section-padding-max: var(--section-standard-max);

--- a/src/assets/css/project/p-faq.css
+++ b/src/assets/css/project/p-faq.css
@@ -12,8 +12,8 @@
 
 .p-faq__list {
   display: grid;
-  max-inline-size: var(--content-width-narrow);
   gap: var(--space-md);
+  max-inline-size: var(--content-width-narrow);
   margin-block-start: var(--space-xl-2xl);
   margin-inline: auto;
 }

--- a/src/assets/css/project/p-flow.css
+++ b/src/assets/css/project/p-flow.css
@@ -18,6 +18,7 @@
 }
 
 .p-flow__item {
+  /* c-text-block の display: flex / gap を意図的に grid で上書き（番号バッジの列配置が必要なため） */
   display: grid;
   grid-template-columns: auto 1fr;
   gap: var(--space-sm) var(--space-lg);

--- a/src/assets/css/project/p-footer.css
+++ b/src/assets/css/project/p-footer.css
@@ -30,7 +30,10 @@
   font-size: var(--font-size-caption);
   color: var(--color-text-light);
   text-decoration: none;
-  transition: color var(--duration-fast) var(--ease-out-cubic);
+
+  @media (prefers-reduced-motion: no-preference) {
+    transition: color var(--duration-fast) var(--ease-out-cubic);
+  }
 
   @media (any-hover: hover) {
     &:hover {

--- a/src/index.html
+++ b/src/index.html
@@ -620,7 +620,7 @@
 
           <!-- CUSTOMIZE: 本番バックエンド URL に差し替え。starter はフォーム送信処理を提供しません -->
           <form class="c-form p-contact__form" action="/api/contact" method="post">
-            <p class="c-form__note"><span>*</span> のついた項目は必須です</p>
+            <p class="c-form__note"><span aria-hidden="true">*</span> のついた項目は必須です</p>
             <div class="c-form__field">
               <label class="c-form__label" for="name">お名前</label>
               <input class="c-form__input" id="name" name="name" type="text" autocomplete="name" required />

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -106,7 +106,7 @@
     <div class="c-overlay" data-drawer-overlay hidden></div>
     <dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title" aria-modal="true">
       <div class="p-drawer__stack">
-        <span id="drawer-title" class="u-visually-hidden">ナビゲーションメニュー</span>
+        <span class="u-visually-hidden" id="drawer-title">ナビゲーションメニュー</span>
         <nav class="p-drawer__nav" aria-label="ドロワーナビゲーション">
           <ul class="p-drawer__nav-list">
             <li>
@@ -131,7 +131,7 @@
       <!-- CUSTOMIZE: プライバシーポリシーの内容を差し替え -->
       <section class="l-section p-privacy" aria-labelledby="privacy-heading">
         <div class="l-inner p-privacy__inner">
-          <h1 id="privacy-heading" class="p-privacy__title">プライバシーポリシー</h1>
+          <h1 class="p-privacy__title" id="privacy-heading">プライバシーポリシー</h1>
 
           <div class="c-prose p-privacy__body">
             <h2>個人情報の取り扱いについて</h2>


### PR DESCRIPTION
## 概要

starter#177 の Minor 9 件を一括修正。AR レポート（docs/ar-2026-04-30-v12-finishing.md）に記載の Minor 8 件 + wp-starter#12 連動 2 件のうち実装対象 9 件。

## 修正内容

### M1-2: l-section.css 公開 API コメントブロック追加
- `--section-padding-min` / `--section-padding-max` に c-* Component と同じ `/* 公開 API: */` 形式コメントを追加

### M3-1: index.html — c-form__note `<span>*</span>` に `aria-hidden="true"` 追加
- CSS `::after` で必須フィールドラベルにも `*` が付与されるため、ノート中の `*` は視覚的装飾文字
- スクリーンリーダーの "アスタリスク" 読み上げを除去し可読性向上（WCAG 3.3.2 ベストプラクティス）

### M4-1〜4: HTML 属性順 id-first → class-first 修正（PR #167 補修漏れ）
- `404.html` L69: `span#drawer-title` class-first 化
- `404.html` L95: `h1#not-found-heading` class-first 化
- `privacy/index.html` L109: `span#drawer-title` class-first 化
- `privacy/index.html` L134: `h1#privacy-heading` class-first 化

### M5-1: p-flow.css — display/gap override 意図をコメントで明示
- `p-flow__item` は `c-text-block` と組み合わせて使用されるが、番号バッジの列配置に grid が必要なため意図的に `display: flex` / `gap` を上書きしている旨をコメントで明確化

### 共通連動 (wp-starter#12 同期)
- **c-overlay 公開 API ヘッダコメント追加**: `--overlay-z` に `/* 公開 API: */` 形式コメントを追加
- **p-footer transition モーションガード**: `p-footer__nav-link` の `transition: color` を `@media (prefers-reduced-motion: no-preference)` でラップ

> **注記**: AR v1.2 finishing レポートでは `p-footer__nav-link` の color-only transition はガード不要（CODING_GUIDE準拠）として ✅ Pass でした。本 PR では cortex 指示（wp-starter#12 同期）に従い保守的なガードパターンで統一しています。

## stylelint auto-fix

- `c-overlay.css`: コメントブロック間の空行追加
- `p-faq.css`: プロパティ順を recess-order 準拠に修正（pre-existing issue）

## チェックリスト

- [x] 9 件の Minor 修正（M1-2, M3-1, M4-1〜4, M5-1, c-overlay comment, p-footer guard）
- [x] stylelint エラーなし
- [x] eslint エラーなし
- [x] spec §5.7 prefers-reduced-motion ガード原則準拠
- [x] 公開 API コメント形式 spec §7 準拠
- [x] HTML 属性順 class-first（3 順序ルール準拠）

## スコープ外

- **M1-1**: `--section-padding-min/max` → `--l-section-padding-min/max` 命名変更は全 Project ファイルへの影響が大きくしゅんえい判断推奨（AR レポート記載通り）

🤖 Generated with [Claude Code](https://claude.com/claude-code)