### PR TITLE
refactor(starter): l-section Z パターン命名整合化 — --l-section-padding-min/max (#178)

### DIFF
--- a/src/assets/css/layout/l-section.css
+++ b/src/assets/css/layout/l-section.css
@@ -1,9 +1,9 @@
 /* 公開 API:
-     --section-padding-min  (default: var(--section-standard-min))
-     --section-padding-max  (default: var(--section-standard-max)) */
+     --l-section-padding-min    (default: var(--section-standard-min))
+     --l-section-padding-max    (default: var(--section-standard-max)) */
 .l-section {
-  --section-padding-min: var(--section-standard-min);
-  --section-padding-max: var(--section-standard-max);
+  --_padding-min: var(--l-section-padding-min, var(--section-standard-min));
+  --_padding-max: var(--l-section-padding-max, var(--section-standard-max));
 
-  padding-block: clamp(var(--section-padding-min), 3.462vi + 3.1346rem, var(--section-padding-max));
+  padding-block: clamp(var(--_padding-min), 3.462vi + 3.1346rem, var(--_padding-max));
 }

--- a/src/assets/css/project/p-cta.css
+++ b/src/assets/css/project/p-cta.css
@@ -1,6 +1,6 @@
 .p-cta {
-  --section-padding-min: var(--section-wide-min);
-  --section-padding-max: var(--section-wide-max);
+  --l-section-padding-min: var(--section-wide-min);
+  --l-section-padding-max: var(--section-wide-max);
 
   /* c-text-block 公開 API override: CTA の見出しを適度な幅で折り返す */
   --text-block-title-max-inline-size: 600px;

--- a/src/assets/css/project/p-numbers.css
+++ b/src/assets/css/project/p-numbers.css
@@ -1,6 +1,6 @@
 .p-numbers {
-  --section-padding-min: var(--section-narrow-min);
-  --section-padding-max: var(--section-narrow-max);
+  --l-section-padding-min: var(--section-narrow-min);
+  --l-section-padding-max: var(--section-narrow-max);
 
   background-color: var(--color-bg-secondary);
 }

--- a/src/assets/css/project/p-problem.css
+++ b/src/assets/css/project/p-problem.css
@@ -1,6 +1,6 @@
 .p-problem {
-  --section-padding-min: var(--section-narrow-min);
-  --section-padding-max: var(--section-narrow-max);
+  --l-section-padding-min: var(--section-narrow-min);
+  --l-section-padding-max: var(--section-narrow-max);
 }
 
 .p-problem__inner {


### PR DESCRIPTION
## 概要

`l-section.css` の Custom Property 命名を Z パターン整合形に変更し、参照側の Project ファイルを一括更新。

## 変更内容

### `l-section.css` — Z パターン整合形

**Before**:
```css
.l-section {
  --section-padding-min: var(--section-standard-min);
  --section-padding-max: var(--section-standard-max);
  padding-block: clamp(var(--section-padding-min), 3.462vi + 3.1346rem, var(--section-padding-max));
}
```

**After**:
```css
/* 公開 API:
     --l-section-padding-min    (default: var(--section-standard-min))
     --l-section-padding-max    (default: var(--section-standard-max)) */
.l-section {
  --_padding-min: var(--l-section-padding-min, var(--section-standard-min));
  --_padding-max: var(--l-section-padding-max, var(--section-standard-max));
  padding-block: clamp(var(--_padding-min), 3.462vi + 3.1346rem, var(--_padding-max));
}
```

### Project ファイル（3 件 6 箇所）

- `p-numbers.css`: `--section-padding-min/max` → `--l-section-padding-min/max`
- `p-cta.css`: 同上
- `p-problem.css`: 同上

### 副次的修正

- `p-faq.css`: `stylelint --fix` による CSS プロパティ順序修正（recess-order: `gap` → `max-inline-size`）

## 命名根拠

spec §7 の公開 API 命名規則 `--{対象}-{名前}` を適用し、Layout Block `l-section` を対象とした命名。

**暫定注記**: 現行 spec §7 の例（`--section-padding`）と一時的に乖離するが、spec/agent-reference 側の更新が進行中のため、本 PR では starter 側を先行実装。

## 確認

- [x] `grep -rn "section-padding-min\|section-padding-max" src/` の旧命名: 0 件
- [x] `pnpm run lint:css` — stylelint エラーなし
- [x] `pnpm run lint:js` — eslint エラーなし
- [x] `pnpm run build` — ビルド成功 (`✓ built in 272ms`)

## 参照

- Closes #178
- AR レポート: `docs/ar-2026-04-30-v12-finishing.md` M1-1
- spec §7 公開 API 命名
- agent-reference AGENT_GUIDE.md §Z パターン
- spec/agent-reference 側の Layout 層 Z パターン規範化（進行中）