### PR TITLE
fix(starter): 公開 API 名 --l-section-padding-* → --section-padding-* に revert（spec L695 準拠）

### DIFF
--- a/src/assets/css/layout/l-section.css
+++ b/src/assets/css/layout/l-section.css
@@ -1,9 +1,9 @@
 /* 公開 API:
-     --l-section-padding-min    (default: var(--section-standard-min))
-     --l-section-padding-max    (default: var(--section-standard-max)) */
+     --section-padding-min    (default: var(--section-standard-min))
+     --section-padding-max    (default: var(--section-standard-max)) */
 .l-section {
-  --_padding-min: var(--l-section-padding-min, var(--section-standard-min));
-  --_padding-max: var(--l-section-padding-max, var(--section-standard-max));
+  --_padding-min: var(--section-padding-min, var(--section-standard-min));
+  --_padding-max: var(--section-padding-max, var(--section-standard-max));
 
   padding-block: clamp(var(--_padding-min), 3.462vi + 3.1346rem, var(--_padding-max));
 }

--- a/src/assets/css/project/p-cta.css
+++ b/src/assets/css/project/p-cta.css
@@ -1,6 +1,6 @@
 .p-cta {
-  --l-section-padding-min: var(--section-wide-min);
-  --l-section-padding-max: var(--section-wide-max);
+  --section-padding-min: var(--section-wide-min);
+  --section-padding-max: var(--section-wide-max);
 
   /* c-text-block 公開 API override: CTA の見出しを適度な幅で折り返す */
   --text-block-title-max-inline-size: 600px;

--- a/src/assets/css/project/p-numbers.css
+++ b/src/assets/css/project/p-numbers.css
@@ -1,6 +1,6 @@
 .p-numbers {
-  --l-section-padding-min: var(--section-narrow-min);
-  --l-section-padding-max: var(--section-narrow-max);
+  --section-padding-min: var(--section-narrow-min);
+  --section-padding-max: var(--section-narrow-max);
 
   background-color: var(--color-bg-secondary);
 }

--- a/src/assets/css/project/p-problem.css
+++ b/src/assets/css/project/p-problem.css
@@ -1,6 +1,6 @@
 .p-problem {
-  --l-section-padding-min: var(--section-narrow-min);
-  --l-section-padding-max: var(--section-narrow-max);
+  --section-padding-min: var(--section-narrow-min);
+  --section-padding-max: var(--section-narrow-max);
 }
 
 .p-problem__inner {


### PR DESCRIPTION
## 目的

PR #180 で変更した公開 API 名 `--l-section-padding-min/max` を `--section-padding-min/max` に戻す。

spec §6 L695「公開 API は `--{対象}-{名前}`、`{対象}` は Block 名からプレフィックス（`l-`/`c-`/`p-`）除外」原則に違反していたため。

## 修正内容

| ファイル | 変更内容 |
|---|---|
| `l-section.css` | コメント + `var()` 参照: `--l-section-padding-*` → `--section-padding-*` |
| `p-cta.css` | override 変数名: `--l-section-padding-*` → `--section-padding-*` |
| `p-numbers.css` | 同上 |
| `p-problem.css` | 同上 |

Block 冒頭 `--_padding-min/max` の private alias 構造（Z パターン）は維持。

## 確認

- `grep -rn "l-section-padding" src/`: **修正前 10件 → 修正後 0件** ✅
- stylelint: **エラーなし** ✅
- build: **✓ built in 267ms** ✅

## spec 根拠

- spec §6 L695: 公開 API は `--{Block名からプレフィックス除外}-{名前}` 形式

## 整合状況

wp-starter tc / agent-reference / mflocss.dev は元から `--section-padding-*` を採用。starter のみが PR #180 で乖離していたため、本 PR で統一。

🤖 Generated with [Claude Code](https://claude.com/claude-code)