### PR TITLE
docs(starter): c-prose コメント記法を c-overlay 形式（分離形）に統一 + AGENT_GUIDE URL 削除 (#182)

### DIFF
--- a/src/assets/css/component/c-prose.css
+++ b/src/assets/css/component/c-prose.css
@@ -1,7 +1,10 @@
-/* 子孫セレクタを許容する例外 Component（CMS 流し込み等、HTML クラス付与不能な用途向け）
-   AGENT_GUIDE S2-4 例外: https://github.com/mflocss/agent-reference/blob/feature/agent-guide-initial-draft/AGENT_GUIDE.md
-   公開 API:
+/* 公開 API:
      --prose-max-inline-size  (default: 40rem) */
+
+/*
+ * 子孫セレクタを許容する例外 Component（CMS 流し込み等、HTML クラス付与不能な用途向け）。
+ * spec §5.4 / agent-reference S2-4（子孫セレクタ許容例外）参照。
+ */
 .c-prose {
   --_max-inline-size: var(--prose-max-inline-size, 40rem);
 

--- a/src/assets/css/component/c-prose.css
+++ b/src/assets/css/component/c-prose.css
@@ -3,7 +3,7 @@
 
 /*
  * 子孫セレクタを許容する例外 Component（CMS 流し込み等、HTML クラス付与不能な用途向け）。
- * spec §5.5 / agent-reference S2-4（子孫セレクタ許容例外）参照。
+ * agent-reference S2-4（子孫セレクタ許容例外）参照。
  */
 .c-prose {
   --_max-inline-size: var(--prose-max-inline-size, 40rem);

--- a/src/assets/css/component/c-prose.css
+++ b/src/assets/css/component/c-prose.css
@@ -3,7 +3,7 @@
 
 /*
  * 子孫セレクタを許容する例外 Component（CMS 流し込み等、HTML クラス付与不能な用途向け）。
- * spec §5.4 / agent-reference S2-4（子孫セレクタ許容例外）参照。
+ * spec §5.5 / agent-reference S2-4（子孫セレクタ許容例外）参照。
  */
 .c-prose {
   --_max-inline-size: var(--prose-max-inline-size, 40rem);


### PR DESCRIPTION
## 概要

Issue #182 対応。c-prose.css のコメント記法（異形・混在）を c-overlay.css の標準分離形に統一し、ドラフトブランチ直リンク URL を削除。

## 修正対象

**c-prose.css のみ（1 ファイル）**

## 変更内容

### Before
```css
/* 子孫セレクタを許容する例外 Component（CMS 流し込み等、HTML クラス付与不能な用途向け）
   AGENT_GUIDE S2-4 例外: https://github.com/mflocss/agent-reference/blob/feature/agent-guide-initial-draft/AGENT_GUIDE.md
   公開 API:
     --prose-max-inline-size  (default: 40rem) */
.c-prose {
```

### After
```css
/* 公開 API:
     --prose-max-inline-size  (default: 40rem) */

/*
 * 子孫セレクタを許容する例外 Component（CMS 流し込み等、HTML クラス付与不能な用途向け）。
 * agent-reference S2-4（子孫セレクタ許容例外）参照。
 */
.c-prose {
```

### 変更方針

- **公開 API ブロック**を冒頭に移動（c-overlay 標準分離形に合わせる）
- **説明ブロック**を分離形の複数行コメントに変更（文末句点、`*` 始まり）
- **AGENT_GUIDE URL 削除**: ドラフトブランチ参照はリンク切れリスク → `agent-reference S2-4 参照` の一般表記に変更
- **spec §5.x 参照削除**: AR C1 で「spec §5.5 には子孫セレクタ許容の規則が存在しない」と判定 → c-overlay の `DEVIATION: spec §5.5 SHOULD NOT` パターンとは異なり、c-prose の場合は spec 上の禁止規則が存在しないため spec 参照を誤情報として削除。根拠は agent-reference S2-4 のみ。

独自の記法・順序・空行配置を導入せず、**c-overlay.css の標準分離形をそのまま踏襲**。

## 全 Component 揺れ点検結果（事前確認済）

17 Component のうち公開 API を持つのは 8 個。変更が必要なのは c-prose のみ。

| Component | 公開 API 数 | 現状記法 | 修正要否 |
|---|---|---|---|
| c-button | 4 | 標準形 | 不要 |
| c-card | 5 | 標準形 | 不要 |
| c-form | 3 | 標準形 | 不要 |
| c-icon-button | 4 | 標準形 | 不要 |
| c-media-split | 1 | 標準形 | 不要 |
| c-overlay | 1 | 分離形（ground truth） | 不要 |
| **c-prose** | 1 | **異形（混在）** | **修正済み** |
| c-text-block | 1 | 標準形 | 不要 |

公開 API なし 9 Component（c-accordion / c-back-to-top / c-badge / c-blockquote / c-hamburger / c-section-heading / c-skip-link / c-stat / c-table）はヘッダ追加不要。

検出方法: 各 Component の prefix（例: `c-button` → `--button-`）で始まり `var(--xxx-yyy, ...)` 形式で参照される Custom Property を grep。`--_xxx`（local）は除外。

## AR レポート

### C1（発見フェーズ）

| 観点 | レビュアー | 結果 |
|---|---|---|
| spec 準拠 + コード品質 | Reviewer 1 | **Critical 1 件**: `spec §5.5 /` は §5.5 に子孫セレクタ規則が存在しないため誤情報 |
| 修正副作用 + 運用方針整合 | Reviewer 2 | 問題なし（副作用なし、pure 形式・c-overlay 整合） |

Critical 対応: `spec §5.5 / ` 削除 → `agent-reference S2-4（子孫セレクタ許容例外）参照。` のみに

### C2（検証フェーズ）

- **Critical 0 / Major 0 / Minor 0**
- 懸念点0判定: **Yes**（採用0件 + 保留0件）
- C1 修正の副作用なし確認済み

### AR 最終判定

**AR 合格 — マージ可**

## 確認事項

- [x] c-prose.css 分離形修正 + AGENT_GUIDE URL 削除完了
- [x] `pnpm build` 成功（built in 71ms）
- [x] `pnpm lint:css` pass（Stylelint エラーなし）
- [x] AR C1 Critical 修正対応 + C2 確認（懸念点0）

Closes #182