### PR TITLE
refactor(project): p-not-found を p-404 に改名（WP テンプレート階層整合 + 直感性向上）

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -88,18 +88,18 @@
     </dialog>
 
     <main id="main" tabindex="-1" data-drawer-inert>
-      <section class="l-section p-not-found" aria-labelledby="not-found-heading">
-        <div class="l-inner p-not-found__inner">
-          <hgroup class="c-section-heading p-not-found__heading">
+      <section class="l-section p-404" aria-labelledby="not-found-heading">
+        <div class="l-inner p-404__inner">
+          <hgroup class="c-section-heading p-404__heading">
             <p class="c-section-heading__eyebrow">404</p>
             <h1 class="c-section-heading__title" id="not-found-heading">ページが見つかりません</h1>
           </hgroup>
-          <p class="p-not-found__lead">
+          <p class="p-404__lead">
             お探しのページは移動または削除された可能性があります。<br />
             お手数ですが、トップページから目的のページをお探しください。
           </p>
-          <div class="p-not-found__actions">
-            <a class="c-button -large p-not-found__cta" href="/">トップページへ戻る</a>
+          <div class="p-404__actions">
+            <a class="c-button -large p-404__cta" href="/">トップページへ戻る</a>
           </div>
         </div>
       </section>

--- a/src/assets/css/project/p-404.css
+++ b/src/assets/css/project/p-404.css
@@ -1,26 +1,26 @@
-.p-not-found {
+.p-404 {
   text-align: center;
 }
 
-.p-not-found__inner {
+.p-404__inner {
   display: grid;
   gap: var(--space-xl);
   justify-items: center;
   max-inline-size: 40rem;
 }
 
-.p-not-found__lead {
+.p-404__lead {
   line-height: var(--line-height-text);
   color: var(--color-text-light);
 }
 
-.p-not-found__actions {
+.p-404__actions {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-md);
   justify-content: center;
 }
 
-.p-not-found__cta {
+.p-404__cta {
   /* スタイルなし（HTML クラスとの対応を維持） */
 }

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -58,7 +58,7 @@
 @import './project/p-contact.css' layer(project);
 @import './project/p-footer.css' layer(project);
 @import './project/p-privacy.css' layer(project);
-@import './project/p-not-found.css' layer(project);
+@import './project/p-404.css' layer(project);
 
 /* Animation */
 @import './animation/fade-in-slide-up.css' layer(animation);


### PR DESCRIPTION
## 改名内容

- `src/assets/css/project/p-not-found.css` → `p-404.css`（`git mv` で履歴保持）
- 内部クラス: `.p-not-found` / `.p-not-found__{inner,lead,actions,cta}` → `.p-404` / `.p-404__{...}`
- `src/assets/css/style.css` の `@import` パス更新
- `src/404.html` の `class` 属性 6 箇所更新

## 改名理由（しゅんえい承認 2026-04-30 セッション 32）

- WP テンプレート階層 `404.php` との対応で直感的
- HTTP ステータスコード 404 ベースの命名で実装者にとって分かりやすい
- `mflocss/wordpress-starter` の `p-404.css` と命名統一（リファレンス実装の一貫性向上）

## 影響範囲（grep ベース、Before / After: 12 → 0）

| ファイル | 変更箇所 |
|---|---|
| `src/assets/css/project/p-404.css`（旧 p-not-found.css） | クラス定義 5 件（Block + Element 4） |
| `src/assets/css/style.css` | `@import` 1 件 |
| `src/404.html` | `class` 属性 6 箇所 |

`src/` 内合計 **12 箇所** を完全置換。`grep -rn 'p-not-found' src/` の結果 0 件確認。

## 破壊的変更通知

クラス名は **HTML 側で外部消費される公開 API**。本変更は **v1.0 公開リリース後の同種変更で SemVer major bump 相当**。

ただし **本 PR 時点では v1.0 未リリース**（`CHANGELOG.md` Unreleased 状態）のため、現時点で外部影響なし。

### 移行ガイド（v1.0 リリース後にこの PR と同種の変更を実施する場合の参考）

ユーザープロジェクトで `class="p-not-found"` を使っている場合、以下で一括置換:

```bash
# HTML / templates の class 名置換
find . -type f \( -name "*.html" -o -name "*.php" -o -name "*.tsx" -o -name "*.vue" \) \
  -exec sed -i '' 's/p-not-found/p-404/g' {} +

# CSS で `.p-not-found` を上書き / 拡張している場合
find . -type f -name "*.css" -exec sed -i '' 's/p-not-found/p-404/g' {} +
```

## 検証結果

- `pnpm lint:css`（stylelint）pass
- `pnpm lint:html`（markuplint）3 ファイル全 pass
- `pnpm build`（vite）成功、`dist/404.html` + `dist/assets/main-*.css` に `p-404` が正しく出力
- `dist/` 内の `p-not-found` 残存 **0 件**

## AR レポート（C 段階 / 全体対象、リリース前 7 条件 #7「公開 API 改名」該当）

### 対象範囲

- **段階**: C（全体）
- **観点段階**: 🔴 Critical（純度原則 / ブランド整合）+ 🟠 Guardian（変更完全性）+ 🟢 Essential（教育設計）
- **リリース前条件**: #7 該当（公開 API 改名 = 公開クラス名変更）
- **判定根拠**: `mflocss/starter` は v1.0 公開リリース対象 5 リポの 1 つ + クラス名は外部消費される公開 API

### 8 軸チェック結果

| # | 軸 | 対象範囲 | 結果 |
|---|---|---|---|
| 1 | 直接修正ファイル | `p-404.css`（旧 p-not-found.css）| ✅ rename + 内部 5 クラス参照置換、ロジック変更ゼロ |
| 2 | import / 参照ファイル | `src/assets/css/style.css`（1 箇所）| ✅ `@import './project/p-404.css'` 更新、build pass |
| 3 | 同 Layer 他ファイル | `project/` 全 15 ファイル | ✅ `p-not-found` 参照ゼロ確認、他 Block の命名と整合 |
| 4 | 横展開対象 | `src/` 全体 + `dist/` ビルド成果物 | ✅ `p-not-found` 0 件、`p-404` 正しく出力（dist 7 hits） |
| 5 | spec 対応条項 | `mflocss-spec` リポ全体 | ✅ `p-not-found` 言及ゼロ、spec §6 `p-{block-name}` 命名規則準拠（数字含む Block 名は spec で禁止記載なし）|
| 6 | テスト / Example HTML | `src/404.html`、`src/index.html`、`src/privacy/index.html` | ✅ `404.html` 6 箇所更新、他 2 ファイルに該当なし、markuplint 全 pass |
| 7 | ドキュメント整合性 | `README.md` / `CHANGELOG.md` / `CODING_GUIDE.md` / `CONTRIBUTING.md` / `SECURITY.md` / `CODE_OF_CONDUCT.md` / `docs/` | ✅ `p-not-found` 言及ゼロ、整合性問題なし |
| 8 | 公開 API 互換性 | `.p-not-found` クラス名（HTML 側で消費）| ✅ v1.0 未リリース（Unreleased）のため現時点で外部影響なし。v1.0 リリース後の同種変更は SemVer major + 移行ガイド義務 |

### Critical 5 観点

- **目的把握**: ✅ WP テンプレート階層整合 + 直感性向上 + wp-starter 命名統一（しゅんえい承認 2026-04-30）
- **既存資産調査**: ✅ 影響範囲 grep（事前 12 件、事後 0 件）+ 他リポ確認（spec / agent-reference / book / mflocss.dev で言及ゼロ）
- **純度原則**: ✅ spec / agent-reference / 書籍での `p-not-found` 言及なし、純度問題なし
- **ブランド整合**: ✅ wp-starter（既に `p-404`）と命名統一、リファレンス実装の一貫性向上
- **事実妥当性**: ✅ `.p-404` は CSS 仕様で有効（数字始まり Block 名は p- プレフィックス付きで合法）

### 判定

- Critical: **0 件**
- Major: **0 件**
- Minor: **0 件**
- AR pass

## escalation 報告（影響範囲外、報告のみ）

他リポでの `p-not-found` 言及確認結果（grep ベース）:

| リポ | 結果 | アクション |
|---|---|---|
| `mflocss/spec` | 言及ゼロ | 不要 |
| `mflocss/agent-reference` | 言及ゼロ | 不要 |
| 書籍 | 言及ゼロ | 不要 |
| `mflocss/mflocss.dev` | 言及ゼロ | 不要 |
| `mflocss/wordpress-starter` | 既に `p-404.css` | ✅ 命名統一達成 |

**escalation 不要**（spec / agent-reference / book / mflocss.dev での影響なし）。

## 完了条件 checklist

- [x] `project/p-not-found.css` → `project/p-404.css` 改名（git mv で履歴保持）
- [x] 内部クラス参照（`.p-not-found` → `.p-404`）置換完了
- [x] HTML / 他 CSS / docs 全件参照置換完了（grep ゼロ確認）
- [x] `style.css` `@import` 更新
- [x] Vite ビルド + Stylelint + markuplint 全 pass
- [x] 全体対象 AR レポート Critical 0 / Major 0 / Minor 0
- [x] PR 作成（base: v1.2、タイトルバージョン記載なし）
- [x] PR body に AR レポート + 8 軸結果 + 移行ガイド + escalation

🤖 Generated with [Claude Code](https://claude.com/claude-code)