### PR TITLE
docs(style.css): @layer 順序コメントを全 8 層に説明統一

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -18,13 +18,13 @@
 @import './foundation/base.css' layer(foundation);
 @import './foundation/form.css' layer(foundation);
 
-/* Layout */
+/* Layout: ページの大枠を構成するブロック（l- プレフィックス） */
 @import './layout/l-header.css' layer(layout);
 @import './layout/l-footer.css' layer(layout);
 @import './layout/l-section.css' layer(layout);
 @import './layout/l-inner.css' layer(layout);
 
-/* Component */
+/* Component: 再利用可能な UI 部品（c- プレフィックス） */
 @import './component/c-button.css' layer(component);
 @import './component/c-form.css' layer(component);
 @import './component/c-icon-button.css' layer(component);
@@ -43,7 +43,7 @@
 @import './component/c-overlay.css' layer(component);
 @import './component/c-skip-link.css' layer(component);
 
-/* Project */
+/* Project: ページ / プロジェクト固有のブロック（p- プレフィックス） */
 @import './project/p-header.css' layer(project);
 @import './project/p-drawer.css' layer(project);
 @import './project/p-hero.css' layer(project);
@@ -60,9 +60,9 @@
 @import './project/p-privacy.css' layer(project);
 @import './project/p-404.css' layer(project);
 
-/* Animation */
+/* Animation: アニメーション・トランジション定義 */
 @import './animation/fade-in-slide-up.css' layer(animation);
 @import './animation/scale-in.css' layer(animation);
 
-/* Utility */
+/* Utility: 単一プロパティの汎用上書き（u- プレフィックス） */
 @import './utility/u-hidden.css' layer(utility);


### PR DESCRIPTION
## 変更概要

`src/assets/css/style.css` の @layer 順序コメントを全 8 層で統一。

### 変更前後

| 層 | 変更前 | 変更後 |
|---|---|---|
| Layout | `/* Layout */` | `/* Layout: ページの大枠を構成するブロック（l- プレフィックス） */` |
| Component | `/* Component */` | `/* Component: 再利用可能な UI 部品（c- プレフィックス） */` |
| Project | `/* Project */` | `/* Project: ページ / プロジェクト固有のブロック（p- プレフィックス） */` |
| Animation | `/* Animation */` | `/* Animation: アニメーション・トランジション定義 */` |
| Utility | `/* Utility */` | `/* Utility: 単一プロパティの汎用上書き（u- プレフィックス） */` |

Token / Reset / Foundation はすでに説明あり（変更なし）。

### 変更規模

- 変更ファイル: 1 件（`src/assets/css/style.css`）
- 変更行数: 5 行置換（追加・削除はなし）
- CSS 出力への影響: なし（コメントのみ）

## AR 対象範囲

**C 段階（全体）**: starter は v1.0 公開リリース対象リポ。ただし変更はコメント追加のみ（スコープ極小）のため軽量実施。

- `pnpm build` → ✅ 成功（built in 88ms）
- `pnpm lint:css` → ✅ エラーなし

## 判断根拠

既存 3 層（Token / Reset / Foundation）の表現スタイル（コロン区切り・簡潔 1 行）を踏襲。プレフィックス情報（l- / c- / p- / u-）を追加して navigation コメントとしての教材性を向上。しゅんえい承認フォーマット厳守。

🤖 Generated with [Claude Code](https://claude.com/claude-code)