### PR TITLE
feat(starter): c-media-split に -stacked Modifier 追加（縦並び固定バリエーション）

### DIFF
--- a/src/assets/css/component/c-media-split.css
+++ b/src/assets/css/component/c-media-split.css
@@ -16,6 +16,15 @@
   }
 }
 
+/* Modifier: -stacked（投稿カード等の縦並び固定バリエーション） */
+.c-media-split.-stacked {
+  grid-template-columns: 1fr;
+  gap: var(--space-md);
+  align-items: start;
+
+  /* @container クエリなしで常に縦並び（投稿カード一覧の小さなカード内で適合） */
+}
+
 .c-media-split__content {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 目的

wp-starter#26（Component 純度回復）の前提として、`c-media-split` Component に `-stacked` Modifier を追加する。

wp-starter の `card.php` で `c-card.c-media-split.-stacked` の Block 併記合成を可能にし、Component 純度違反（c-card に `__media`/`__image`/`__body`/`__title`/`__text`/`__link` Element 追加）を解消する基盤を整える。

## 修正内容

`src/assets/css/component/c-media-split.css` に `.c-media-split.-stacked` Modifier を追加。

```css
/* Modifier: -stacked（投稿カード等の縦並び固定バリエーション） */
.c-media-split.-stacked {
  grid-template-columns: 1fr;
  gap: var(--space-md);
  align-items: start;

  /* @container クエリなしで常に縦並び（投稿カード一覧の小さなカード内で適合） */
}
```

**配置**: Block ルール（`.c-media-split { ... }`）終了直後・Element 群の前（CSS 定義順ルール準拠）。

## 既存挙動への影響なし根拠

- 既存の Features セクション（`src/index.html` L282〜）の `c-media-split` はすべて `-stacked` 未指定
- `-stacked` Modifier は HTML で明示指定した場合のみ作用するため、既存マークアップへの影響はゼロ
- `@container` クエリ（50rem 以上で 2 列）の動作は変更なし

## 関連

- wp-starter#26: https://github.com/mflocss/wordpress-starter/issues/26（本 PR が前提となる）
- spec §6 Modifier 命名規則（`.-{modifier}` 形式）準拠
- mFLOCSS CSS 定義順ルール準拠（Block 直後、Element 群の前）