### PR TITLE
refactor: l-inner 併記責任分離 — 一段ネスト化（5 種類、純度違反解消）

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -35,30 +35,32 @@
 
     <!-- Header -->
     <header class="l-header p-header">
-      <div class="l-inner p-header__bar">
-        <a class="p-header__logo" data-drawer-inert href="/" translate="no">iluha</a>
+      <div class="l-inner">
+        <div class="p-header__bar">
+          <a class="p-header__logo" data-drawer-inert href="/" translate="no">iluha</a>
 
-        <nav class="p-header__nav" data-drawer-inert aria-label="メインナビゲーション">
-          <ul class="p-header__nav-list">
-            <li><a class="p-header__nav-link" href="/#features">特徴</a></li>
-            <li><a class="p-header__nav-link" href="/#voice">お客様の声</a></li>
-            <li><a class="p-header__nav-link" href="/#faq">よくある質問</a></li>
-            <li><a class="p-header__nav-link" href="/#contact">ご予約</a></li>
-          </ul>
-          <a class="c-button p-header__cta" href="/#contact">初回体験を予約する</a>
-        </nav>
+          <nav class="p-header__nav" data-drawer-inert aria-label="メインナビゲーション">
+            <ul class="p-header__nav-list">
+              <li><a class="p-header__nav-link" href="/#features">特徴</a></li>
+              <li><a class="p-header__nav-link" href="/#voice">お客様の声</a></li>
+              <li><a class="p-header__nav-link" href="/#faq">よくある質問</a></li>
+              <li><a class="p-header__nav-link" href="/#contact">ご予約</a></li>
+            </ul>
+            <a class="c-button p-header__cta" href="/#contact">初回体験を予約する</a>
+          </nav>
 
-        <!-- Hamburger: drawer 開閉中も機能するため data-drawer-inert 対象外 -->
-        <button
-          class="c-hamburger p-header__hamburger"
-          data-hamburger
-          type="button"
-          aria-expanded="false"
-          aria-controls="drawer"
-          aria-label="メニュー"
-        >
-          <span class="c-hamburger__line" aria-hidden="true"></span>
-        </button>
+          <!-- Hamburger: drawer 開閉中も機能するため data-drawer-inert 対象外 -->
+          <button
+            class="c-hamburger p-header__hamburger"
+            data-hamburger
+            type="button"
+            aria-expanded="false"
+            aria-controls="drawer"
+            aria-label="メニュー"
+          >
+            <span class="c-hamburger__line" aria-hidden="true"></span>
+          </button>
+        </div>
       </div>
     </header>
 
@@ -89,17 +91,19 @@
 
     <main id="main" tabindex="-1" data-drawer-inert>
       <section class="l-section p-404" aria-labelledby="not-found-heading">
-        <div class="l-inner p-404__inner">
-          <hgroup class="c-section-heading p-404__heading">
-            <p class="c-section-heading__eyebrow">404</p>
-            <h1 class="c-section-heading__title" id="not-found-heading">ページが見つかりません</h1>
-          </hgroup>
-          <p class="p-404__lead">
-            お探しのページは移動または削除された可能性があります。<br />
-            お手数ですが、トップページから目的のページをお探しください。
-          </p>
-          <div class="p-404__actions">
-            <a class="c-button -large p-404__cta" href="/">トップページへ戻る</a>
+        <div class="l-inner">
+          <div class="p-404__inner">
+            <hgroup class="c-section-heading p-404__heading">
+              <p class="c-section-heading__eyebrow">404</p>
+              <h1 class="c-section-heading__title" id="not-found-heading">ページが見つかりません</h1>
+            </hgroup>
+            <p class="p-404__lead">
+              お探しのページは移動または削除された可能性があります。<br />
+              お手数ですが、トップページから目的のページをお探しください。
+            </p>
+            <div class="p-404__actions">
+              <a class="c-button -large p-404__cta" href="/">トップページへ戻る</a>
+            </div>
           </div>
         </div>
       </section>
@@ -107,28 +111,30 @@
 
     <!-- Footer -->
     <footer class="l-footer p-footer" data-drawer-inert>
-      <div class="l-inner p-footer__stack">
-        <nav class="p-footer__nav" aria-label="フッターナビゲーション">
-          <ul class="p-footer__nav-list">
-            <li><a class="p-footer__nav-link" href="/#features">特徴</a></li>
-            <li><a class="p-footer__nav-link" href="/#voice">お客様の声</a></li>
-            <li><a class="p-footer__nav-link" href="/#faq">よくある質問</a></li>
-            <li><a class="p-footer__nav-link" href="/#contact">ご予約</a></li>
-            <li>
-              <a class="p-footer__nav-link" href="/privacy/">プライバシーポリシー</a>
-            </li>
-          </ul>
-        </nav>
-        <!-- CUSTOMIZE: 住所・電話番号・営業時間を差し替え -->
-        <address class="p-footer__address">
-          〒xxx-xxxx 東京都渋谷区○○ x-x-x ○○ビル 3F<br />
-          <a class="p-footer__tel" href="tel:03-xxxx-xxxx" translate="no">TEL: 03-xxxx-xxxx</a><br />
-          営業時間: 10:00〜20:00（最終受付 19:00）<br />
-          定休日: 毎週水曜日
-        </address>
-        <p class="p-footer__copyright">
-          <small><span translate="no">© 2026 iluha</span></small>
-        </p>
+      <div class="l-inner">
+        <div class="p-footer__stack">
+          <nav class="p-footer__nav" aria-label="フッターナビゲーション">
+            <ul class="p-footer__nav-list">
+              <li><a class="p-footer__nav-link" href="/#features">特徴</a></li>
+              <li><a class="p-footer__nav-link" href="/#voice">お客様の声</a></li>
+              <li><a class="p-footer__nav-link" href="/#faq">よくある質問</a></li>
+              <li><a class="p-footer__nav-link" href="/#contact">ご予約</a></li>
+              <li>
+                <a class="p-footer__nav-link" href="/privacy/">プライバシーポリシー</a>
+              </li>
+            </ul>
+          </nav>
+          <!-- CUSTOMIZE: 住所・電話番号・営業時間を差し替え -->
+          <address class="p-footer__address">
+            〒xxx-xxxx 東京都渋谷区○○ x-x-x ○○ビル 3F<br />
+            <a class="p-footer__tel" href="tel:03-xxxx-xxxx" translate="no">TEL: 03-xxxx-xxxx</a><br />
+            営業時間: 10:00〜20:00（最終受付 19:00）<br />
+            定休日: 毎週水曜日
+          </address>
+          <p class="p-footer__copyright">
+            <small><span translate="no">© 2026 iluha</span></small>
+          </p>
+        </div>
       </div>
     </footer>
 

--- a/src/index.html
+++ b/src/index.html
@@ -147,31 +147,33 @@
 
     <!-- Header -->
     <header class="l-header p-header">
-      <div class="l-inner p-header__bar">
-        <!-- CUSTOMIZE: サービス名を差し替え -->
-        <a class="p-header__logo" data-drawer-inert href="/" translate="no">iluha</a>
+      <div class="l-inner">
+        <div class="p-header__bar">
+          <!-- CUSTOMIZE: サービス名を差し替え -->
+          <a class="p-header__logo" data-drawer-inert href="/" translate="no">iluha</a>
 
-        <nav class="p-header__nav" data-drawer-inert aria-label="メインナビゲーション">
-          <ul class="p-header__nav-list">
-            <li><a class="p-header__nav-link" href="#features">特徴</a></li>
-            <li><a class="p-header__nav-link" href="#voice">お客様の声</a></li>
-            <li><a class="p-header__nav-link" href="#faq">よくある質問</a></li>
-            <li><a class="p-header__nav-link" href="#contact">ご予約</a></li>
-          </ul>
-          <a class="c-button p-header__cta" href="#contact">初回体験を予約する</a>
-        </nav>
+          <nav class="p-header__nav" data-drawer-inert aria-label="メインナビゲーション">
+            <ul class="p-header__nav-list">
+              <li><a class="p-header__nav-link" href="#features">特徴</a></li>
+              <li><a class="p-header__nav-link" href="#voice">お客様の声</a></li>
+              <li><a class="p-header__nav-link" href="#faq">よくある質問</a></li>
+              <li><a class="p-header__nav-link" href="#contact">ご予約</a></li>
+            </ul>
+            <a class="c-button p-header__cta" href="#contact">初回体験を予約する</a>
+          </nav>
 
-        <!-- Hamburger: drawer 開閉中も機能するため data-drawer-inert 対象外 -->
-        <button
-          class="c-hamburger p-header__hamburger"
-          data-hamburger
-          type="button"
-          aria-expanded="false"
-          aria-controls="drawer"
-          aria-label="メニュー"
-        >
-          <span class="c-hamburger__line" aria-hidden="true"></span>
-        </button>
+          <!-- Hamburger: drawer 開閉中も機能するため data-drawer-inert 対象外 -->
+          <button
+            class="c-hamburger p-header__hamburger"
+            data-hamburger
+            type="button"
+            aria-expanded="false"
+            aria-controls="drawer"
+            aria-label="メニュー"
+          >
+            <span class="c-hamburger__line" aria-hidden="true"></span>
+          </button>
+        </div>
       </div>
     </header>
 
@@ -203,22 +205,24 @@
     <main id="main" tabindex="-1" data-drawer-inert>
       <!-- Hero -->
       <section class="l-section p-hero" aria-labelledby="hero-heading">
-        <div class="l-inner p-hero__stack">
-          <!-- CUSTOMIZE: サービス名・キャッチコピーを差し替え -->
-          <div class="p-hero__content" data-immediate="scale-in">
-            <h1 class="p-hero__title" id="hero-heading">からだの声を、<br class="u-hidden-pc" />聴く時間。</h1>
-            <p class="p-hero__lead">
-              忙しい毎日の中で後回しにしてきた自分のケア。<br class="u-hidden-sp" />iluha
-              は、内側から整うボディケアサロンです。
-            </p>
-            <div class="p-hero__actions">
-              <a class="c-icon-button -large p-hero__cta" href="#contact">
-                初回体験を予約する
-                <svg class="c-icon-button__icon" width="20" height="20" aria-hidden="true">
-                  <use href="/assets/images/icons/arrow-right.svg#icon" />
-                </svg>
-              </a>
-              <a class="c-button -ghost -large p-hero__sub-cta" href="#features">選ばれる理由を見る</a>
+        <div class="l-inner">
+          <div class="p-hero__stack">
+            <!-- CUSTOMIZE: サービス名・キャッチコピーを差し替え -->
+            <div class="p-hero__content" data-immediate="scale-in">
+              <h1 class="p-hero__title" id="hero-heading">からだの声を、<br class="u-hidden-pc" />聴く時間。</h1>
+              <p class="p-hero__lead">
+                忙しい毎日の中で後回しにしてきた自分のケア。<br class="u-hidden-sp" />iluha
+                は、内側から整うボディケアサロンです。
+              </p>
+              <div class="p-hero__actions">
+                <a class="c-icon-button -large p-hero__cta" href="#contact">
+                  初回体験を予約する
+                  <svg class="c-icon-button__icon" width="20" height="20" aria-hidden="true">
+                    <use href="/assets/images/icons/arrow-right.svg#icon" />
+                  </svg>
+                </a>
+                <a class="c-button -ghost -large p-hero__sub-cta" href="#features">選ばれる理由を見る</a>
+              </div>
             </div>
           </div>
         </div>
@@ -530,13 +534,17 @@
 
       <!-- CTA -->
       <section class="l-section p-cta" id="cta" aria-labelledby="cta-heading">
-        <div class="l-inner p-cta__inner">
-          <div class="p-cta__stack" data-stagger="fade-in-slide-up">
-            <div class="c-text-block p-cta__message">
-              <h2 class="c-text-block__title" id="cta-heading">まずは一度、からだの声を聴いてみませんか？</h2>
-              <p class="c-text-block__text">初回体験は 60分 4,400円。カウンセリング込み。無理な勧誘はいたしません。</p>
+        <div class="l-inner">
+          <div class="p-cta__inner">
+            <div class="p-cta__stack" data-stagger="fade-in-slide-up">
+              <div class="c-text-block p-cta__message">
+                <h2 class="c-text-block__title" id="cta-heading">まずは一度、からだの声を聴いてみませんか？</h2>
+                <p class="c-text-block__text">
+                  初回体験は 60分 4,400円。カウンセリング込み。無理な勧誘はいたしません。
+                </p>
+              </div>
+              <a class="c-button -large p-cta__button" href="#contact">初回体験を予約する</a>
             </div>
-            <a class="c-button -large p-cta__button" href="#contact">初回体験を予約する</a>
           </div>
         </div>
       </section>
@@ -686,28 +694,30 @@
 
     <!-- Footer -->
     <footer class="l-footer p-footer" data-drawer-inert>
-      <div class="l-inner p-footer__stack">
-        <nav class="p-footer__nav" aria-label="フッターナビゲーション">
-          <ul class="p-footer__nav-list">
-            <li><a class="p-footer__nav-link" href="#features">特徴</a></li>
-            <li><a class="p-footer__nav-link" href="#voice">お客様の声</a></li>
-            <li><a class="p-footer__nav-link" href="#faq">よくある質問</a></li>
-            <li><a class="p-footer__nav-link" href="#contact">ご予約</a></li>
-            <li>
-              <a class="p-footer__nav-link" href="/privacy/">プライバシーポリシー</a>
-            </li>
-          </ul>
-        </nav>
-        <!-- CUSTOMIZE: 住所・電話番号・営業時間を差し替え -->
-        <address class="p-footer__address">
-          〒xxx-xxxx 東京都渋谷区○○ x-x-x ○○ビル 3F<br />
-          <a class="p-footer__tel" href="tel:03-xxxx-xxxx" translate="no">TEL: 03-xxxx-xxxx</a><br />
-          営業時間: 10:00〜20:00（最終受付 19:00）<br />
-          定休日: 毎週水曜日
-        </address>
-        <p class="p-footer__copyright">
-          <small><span translate="no">© 2026 iluha</span></small>
-        </p>
+      <div class="l-inner">
+        <div class="p-footer__stack">
+          <nav class="p-footer__nav" aria-label="フッターナビゲーション">
+            <ul class="p-footer__nav-list">
+              <li><a class="p-footer__nav-link" href="#features">特徴</a></li>
+              <li><a class="p-footer__nav-link" href="#voice">お客様の声</a></li>
+              <li><a class="p-footer__nav-link" href="#faq">よくある質問</a></li>
+              <li><a class="p-footer__nav-link" href="#contact">ご予約</a></li>
+              <li>
+                <a class="p-footer__nav-link" href="/privacy/">プライバシーポリシー</a>
+              </li>
+            </ul>
+          </nav>
+          <!-- CUSTOMIZE: 住所・電話番号・営業時間を差し替え -->
+          <address class="p-footer__address">
+            〒xxx-xxxx 東京都渋谷区○○ x-x-x ○○ビル 3F<br />
+            <a class="p-footer__tel" href="tel:03-xxxx-xxxx" translate="no">TEL: 03-xxxx-xxxx</a><br />
+            営業時間: 10:00〜20:00（最終受付 19:00）<br />
+            定休日: 毎週水曜日
+          </address>
+          <p class="p-footer__copyright">
+            <small><span translate="no">© 2026 iluha</span></small>
+          </p>
+        </div>
       </div>
     </footer>
 

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -75,30 +75,32 @@
 
     <!-- Header -->
     <header class="l-header p-header">
-      <div class="l-inner p-header__bar">
-        <a class="p-header__logo" data-drawer-inert href="/" translate="no">iluha</a>
+      <div class="l-inner">
+        <div class="p-header__bar">
+          <a class="p-header__logo" data-drawer-inert href="/" translate="no">iluha</a>
 
-        <nav class="p-header__nav" data-drawer-inert aria-label="メインナビゲーション">
-          <ul class="p-header__nav-list">
-            <li><a class="p-header__nav-link" href="/#features">特徴</a></li>
-            <li><a class="p-header__nav-link" href="/#voice">お客様の声</a></li>
-            <li><a class="p-header__nav-link" href="/#faq">よくある質問</a></li>
-            <li><a class="p-header__nav-link" href="/#contact">ご予約</a></li>
-          </ul>
-          <a class="c-button p-header__cta" href="/#contact">初回体験を予約する</a>
-        </nav>
+          <nav class="p-header__nav" data-drawer-inert aria-label="メインナビゲーション">
+            <ul class="p-header__nav-list">
+              <li><a class="p-header__nav-link" href="/#features">特徴</a></li>
+              <li><a class="p-header__nav-link" href="/#voice">お客様の声</a></li>
+              <li><a class="p-header__nav-link" href="/#faq">よくある質問</a></li>
+              <li><a class="p-header__nav-link" href="/#contact">ご予約</a></li>
+            </ul>
+            <a class="c-button p-header__cta" href="/#contact">初回体験を予約する</a>
+          </nav>
 
-        <!-- Hamburger: drawer 開閉中も機能するため data-drawer-inert 対象外 -->
-        <button
-          class="c-hamburger p-header__hamburger"
-          data-hamburger
-          type="button"
-          aria-expanded="false"
-          aria-controls="drawer"
-          aria-label="メニュー"
-        >
-          <span class="c-hamburger__line" aria-hidden="true"></span>
-        </button>
+          <!-- Hamburger: drawer 開閉中も機能するため data-drawer-inert 対象外 -->
+          <button
+            class="c-hamburger p-header__hamburger"
+            data-hamburger
+            type="button"
+            aria-expanded="false"
+            aria-controls="drawer"
+            aria-label="メニュー"
+          >
+            <span class="c-hamburger__line" aria-hidden="true"></span>
+          </button>
+        </div>
       </div>
     </header>
 
@@ -168,28 +170,30 @@
 
     <!-- Footer -->
     <footer class="l-footer p-footer" data-drawer-inert>
-      <div class="l-inner p-footer__stack">
-        <nav class="p-footer__nav" aria-label="フッターナビゲーション">
-          <ul class="p-footer__nav-list">
-            <li><a class="p-footer__nav-link" href="/#features">特徴</a></li>
-            <li><a class="p-footer__nav-link" href="/#voice">お客様の声</a></li>
-            <li><a class="p-footer__nav-link" href="/#faq">よくある質問</a></li>
-            <li><a class="p-footer__nav-link" href="/#contact">ご予約</a></li>
-            <li>
-              <a class="p-footer__nav-link" href="/privacy/" aria-current="page">プライバシーポリシー</a>
-            </li>
-          </ul>
-        </nav>
-        <!-- CUSTOMIZE: 住所・電話番号・営業時間を差し替え -->
-        <address class="p-footer__address">
-          〒xxx-xxxx 東京都渋谷区○○ x-x-x ○○ビル 3F<br />
-          <a class="p-footer__tel" href="tel:03-xxxx-xxxx" translate="no">TEL: 03-xxxx-xxxx</a><br />
-          営業時間: 10:00〜20:00（最終受付 19:00）<br />
-          定休日: 毎週水曜日
-        </address>
-        <p class="p-footer__copyright">
-          <small><span translate="no">© 2026 iluha</span></small>
-        </p>
+      <div class="l-inner">
+        <div class="p-footer__stack">
+          <nav class="p-footer__nav" aria-label="フッターナビゲーション">
+            <ul class="p-footer__nav-list">
+              <li><a class="p-footer__nav-link" href="/#features">特徴</a></li>
+              <li><a class="p-footer__nav-link" href="/#voice">お客様の声</a></li>
+              <li><a class="p-footer__nav-link" href="/#faq">よくある質問</a></li>
+              <li><a class="p-footer__nav-link" href="/#contact">ご予約</a></li>
+              <li>
+                <a class="p-footer__nav-link" href="/privacy/" aria-current="page">プライバシーポリシー</a>
+              </li>
+            </ul>
+          </nav>
+          <!-- CUSTOMIZE: 住所・電話番号・営業時間を差し替え -->
+          <address class="p-footer__address">
+            〒xxx-xxxx 東京都渋谷区○○ x-x-x ○○ビル 3F<br />
+            <a class="p-footer__tel" href="tel:03-xxxx-xxxx" translate="no">TEL: 03-xxxx-xxxx</a><br />
+            営業時間: 10:00〜20:00（最終受付 19:00）<br />
+            定休日: 毎週水曜日
+          </address>
+          <p class="p-footer__copyright">
+            <small><span translate="no">© 2026 iluha</span></small>
+          </p>
+        </div>
       </div>
     </footer>
 


### PR DESCRIPTION
## 概要

`l-inner`（Layout 層）と Project 各 Element が **1 要素に併記** されていた単一責任原則違反（spec §5.4）を、一段ネストによる責任分離で解消する。

## 修正前後の HTML 構造比較

### Before（純度違反）
```html
<!-- l-inner（max-inline-size + padding + 中央配置）と
     p-header__bar（flex container + align/justify）が1要素に二重責任 -->
<div class="l-inner p-header__bar">
  <a class="p-header__logo" ...>...</a>
  <nav class="p-header__nav" ...>...</nav>
  <button class="c-hamburger p-header__hamburger" ...>...</button>
</div>
```

### After（責任分離）
```html
<!-- l-inner: max-inline-size + padding + 中央配置のみ -->
<div class="l-inner">
  <!-- p-header__bar: flex container + alignment のみ -->
  <div class="p-header__bar">
    <a class="p-header__logo" ...>...</a>
    <nav class="p-header__nav" ...>...</nav>
    <button class="c-hamburger p-header__hamburger" ...>...</button>
  </div>
</div>
```

## 修正対象（5 種類 × 9 出現箇所）

| Element | ファイル | 別責任（分離対象） |
|---|---|---|
| `p-header__bar` | index.html / 404.html / privacy/index.html | `display: flex; align-items; justify-content; block-size` |
| `p-hero__stack` | index.html | `position: relative; z-index; grid-area: stack` |
| `p-cta__inner` | index.html | `max-inline-size: var(--content-width-narrow); margin-inline: auto; text-align: center` |
| `p-footer__stack` | index.html / 404.html / privacy/index.html | `display: flex; flex-direction: column; gap; align-items; text-align` |
| `p-404__inner` | 404.html | `display: grid; gap; justify-items: center; max-inline-size: 40rem` |

## CSS 変更なし

クラス名・CSS 定義は一切変更していない。HTML 構造（一段ネスト追加）のみの変更。

## 影響なし根拠

- `l-inner` は `box-sizing: content-box; max-inline-size; padding-inline; margin-inline: auto;` = ブロックレベル要素として子の幅と padding を制御
- 内側の新規 div（`p-header__bar` 等）は `l-inner` の content-box 幅内で flex/grid container として従来通り動作
- CSS カスケードへの影響なし（クラス名・詳細度・セレクタ構造すべて同一）

## 検証

```
# grep 残存ゼロ確認
$ grep -rn "l-inner p-header__bar\|l-inner p-hero__stack\|l-inner p-footer__stack\|l-inner p-cta__inner\|l-inner p-404__inner" src/
（出力なし）

# pnpm run check（markuplint / stylelint / eslint）
markuplint: passed index.html / 404.html / privacy/index.html ✅
stylelint: エラーなし ✅
eslint: エラーなし ✅

# pnpm run build
✓ built in 77ms ✅
```

## スコープ外

dead Element 9 件（`p-problem__inner` / `p-features__inner` 等、CSS 定義が空のプレースホルダ）は今回対象外。後続 Issue として別判断予定。

## 根拠

- spec §5.4 単一責任原則
- しゅんえい指示「`__inner` の役割に沿っていないなら、一段ネスト」