### PR TITLE
refactor: l-inner p-XXX__inner 併記構造に統一（U2 原則 + 原則 11 整合 + p-404 grid 分離）

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -35,30 +35,32 @@
 
     <!-- Header -->
     <header class="l-header p-header">
-      <div class="l-inner p-header__bar">
-        <a class="p-header__logo" data-drawer-inert href="/" translate="no">iluha</a>
+      <div class="l-inner p-header__inner">
+        <div class="p-header__bar">
+          <a class="p-header__logo" data-drawer-inert href="/" translate="no">iluha</a>
 
-        <nav class="p-header__nav" data-drawer-inert aria-label="メインナビゲーション">
-          <ul class="p-header__nav-list">
-            <li><a class="p-header__nav-link" href="/#features">特徴</a></li>
-            <li><a class="p-header__nav-link" href="/#voice">お客様の声</a></li>
-            <li><a class="p-header__nav-link" href="/#faq">よくある質問</a></li>
-            <li><a class="p-header__nav-link" href="/#contact">ご予約</a></li>
-          </ul>
-          <a class="c-button p-header__cta" href="/#contact">初回体験を予約する</a>
-        </nav>
+          <nav class="p-header__nav" data-drawer-inert aria-label="メインナビゲーション">
+            <ul class="p-header__nav-list">
+              <li><a class="p-header__nav-link" href="/#features">特徴</a></li>
+              <li><a class="p-header__nav-link" href="/#voice">お客様の声</a></li>
+              <li><a class="p-header__nav-link" href="/#faq">よくある質問</a></li>
+              <li><a class="p-header__nav-link" href="/#contact">ご予約</a></li>
+            </ul>
+            <a class="c-button p-header__cta" href="/#contact">初回体験を予約する</a>
+          </nav>
 
-        <!-- Hamburger: drawer 開閉中も機能するため data-drawer-inert 対象外 -->
-        <button
-          class="c-hamburger p-header__hamburger"
-          data-hamburger
-          type="button"
-          aria-expanded="false"
-          aria-controls="drawer"
-          aria-label="メニュー"
-        >
-          <span class="c-hamburger__line" aria-hidden="true"></span>
-        </button>
+          <!-- Hamburger: drawer 開閉中も機能するため data-drawer-inert 対象外 -->
+          <button
+            class="c-hamburger p-header__hamburger"
+            data-hamburger
+            type="button"
+            aria-expanded="false"
+            aria-controls="drawer"
+            aria-label="メニュー"
+          >
+            <span class="c-hamburger__line" aria-hidden="true"></span>
+          </button>
+        </div>
       </div>
     </header>
 
@@ -90,16 +92,18 @@
     <main id="main" tabindex="-1" data-drawer-inert>
       <section class="l-section p-404" aria-labelledby="not-found-heading">
         <div class="l-inner p-404__inner">
-          <hgroup class="c-section-heading p-404__heading">
-            <p class="c-section-heading__eyebrow">404</p>
-            <h1 class="c-section-heading__title" id="not-found-heading">ページが見つかりません</h1>
-          </hgroup>
-          <p class="p-404__lead">
-            お探しのページは移動または削除された可能性があります。<br />
-            お手数ですが、トップページから目的のページをお探しください。
-          </p>
-          <div class="p-404__actions">
-            <a class="c-button -large p-404__cta" href="/">トップページへ戻る</a>
+          <div class="p-404__stack">
+            <hgroup class="c-section-heading p-404__heading">
+              <p class="c-section-heading__eyebrow">404</p>
+              <h1 class="c-section-heading__title" id="not-found-heading">ページが見つかりません</h1>
+            </hgroup>
+            <p class="p-404__lead">
+              お探しのページは移動または削除された可能性があります。<br />
+              お手数ですが、トップページから目的のページをお探しください。
+            </p>
+            <div class="p-404__actions">
+              <a class="c-button -large p-404__cta" href="/">トップページへ戻る</a>
+            </div>
           </div>
         </div>
       </section>
@@ -107,28 +111,30 @@
 
     <!-- Footer -->
     <footer class="l-footer p-footer" data-drawer-inert>
-      <div class="l-inner p-footer__stack">
-        <nav class="p-footer__nav" aria-label="フッターナビゲーション">
-          <ul class="p-footer__nav-list">
-            <li><a class="p-footer__nav-link" href="/#features">特徴</a></li>
-            <li><a class="p-footer__nav-link" href="/#voice">お客様の声</a></li>
-            <li><a class="p-footer__nav-link" href="/#faq">よくある質問</a></li>
-            <li><a class="p-footer__nav-link" href="/#contact">ご予約</a></li>
-            <li>
-              <a class="p-footer__nav-link" href="/privacy/">プライバシーポリシー</a>
-            </li>
-          </ul>
-        </nav>
-        <!-- CUSTOMIZE: 住所・電話番号・営業時間を差し替え -->
-        <address class="p-footer__address">
-          〒xxx-xxxx 東京都渋谷区○○ x-x-x ○○ビル 3F<br />
-          <a class="p-footer__tel" href="tel:03-xxxx-xxxx" translate="no">TEL: 03-xxxx-xxxx</a><br />
-          営業時間: 10:00〜20:00（最終受付 19:00）<br />
-          定休日: 毎週水曜日
-        </address>
-        <p class="p-footer__copyright">
-          <small><span translate="no">© 2026 iluha</span></small>
-        </p>
+      <div class="l-inner p-footer__inner">
+        <div class="p-footer__stack">
+          <nav class="p-footer__nav" aria-label="フッターナビゲーション">
+            <ul class="p-footer__nav-list">
+              <li><a class="p-footer__nav-link" href="/#features">特徴</a></li>
+              <li><a class="p-footer__nav-link" href="/#voice">お客様の声</a></li>
+              <li><a class="p-footer__nav-link" href="/#faq">よくある質問</a></li>
+              <li><a class="p-footer__nav-link" href="/#contact">ご予約</a></li>
+              <li>
+                <a class="p-footer__nav-link" href="/privacy/">プライバシーポリシー</a>
+              </li>
+            </ul>
+          </nav>
+          <!-- CUSTOMIZE: 住所・電話番号・営業時間を差し替え -->
+          <address class="p-footer__address">
+            〒xxx-xxxx 東京都渋谷区○○ x-x-x ○○ビル 3F<br />
+            <a class="p-footer__tel" href="tel:03-xxxx-xxxx" translate="no">TEL: 03-xxxx-xxxx</a><br />
+            営業時間: 10:00〜20:00（最終受付 19:00）<br />
+            定休日: 毎週水曜日
+          </address>
+          <p class="p-footer__copyright">
+            <small><span translate="no">© 2026 iluha</span></small>
+          </p>
+        </div>
       </div>
     </footer>
 

--- a/src/assets/css/project/p-404.css
+++ b/src/assets/css/project/p-404.css
@@ -3,10 +3,13 @@
 }
 
 .p-404__inner {
+  max-inline-size: 40rem;
+}
+
+.p-404__stack {
   display: grid;
   gap: var(--space-xl);
   justify-items: center;
-  max-inline-size: 40rem;
 }
 
 .p-404__lead {

--- a/src/assets/css/project/p-footer.css
+++ b/src/assets/css/project/p-footer.css
@@ -4,6 +4,10 @@
   border-block-start: var(--border-width) solid var(--color-border);
 }
 
+.p-footer__inner {
+  /* スタイルなし（HTML クラスとの対応を維持） */
+}
+
 .p-footer__stack {
   display: flex;
   flex-direction: column;

--- a/src/assets/css/project/p-header.css
+++ b/src/assets/css/project/p-header.css
@@ -12,6 +12,10 @@
   }
 }
 
+.p-header__inner {
+  /* スタイルなし（HTML クラスとの対応を維持） */
+}
+
 .p-header__bar {
   display: flex;
   align-items: center;

--- a/src/assets/css/project/p-hero.css
+++ b/src/assets/css/project/p-hero.css
@@ -7,6 +7,10 @@
   background: radial-gradient(ellipse at 50% 0%, oklch(from var(--color-main) l c h / 6%) 0%, transparent 70%);
 }
 
+.p-hero__inner {
+  /* スタイルなし（HTML クラスとの対応を維持） */
+}
+
 .p-hero__stack {
   position: relative;
   z-index: 1;

--- a/src/index.html
+++ b/src/index.html
@@ -147,31 +147,33 @@
 
     <!-- Header -->
     <header class="l-header p-header">
-      <div class="l-inner p-header__bar">
-        <!-- CUSTOMIZE: サービス名を差し替え -->
-        <a class="p-header__logo" data-drawer-inert href="/" translate="no">iluha</a>
+      <div class="l-inner p-header__inner">
+        <div class="p-header__bar">
+          <!-- CUSTOMIZE: サービス名を差し替え -->
+          <a class="p-header__logo" data-drawer-inert href="/" translate="no">iluha</a>
 
-        <nav class="p-header__nav" data-drawer-inert aria-label="メインナビゲーション">
-          <ul class="p-header__nav-list">
-            <li><a class="p-header__nav-link" href="#features">特徴</a></li>
-            <li><a class="p-header__nav-link" href="#voice">お客様の声</a></li>
-            <li><a class="p-header__nav-link" href="#faq">よくある質問</a></li>
-            <li><a class="p-header__nav-link" href="#contact">ご予約</a></li>
-          </ul>
-          <a class="c-button p-header__cta" href="#contact">初回体験を予約する</a>
-        </nav>
+          <nav class="p-header__nav" data-drawer-inert aria-label="メインナビゲーション">
+            <ul class="p-header__nav-list">
+              <li><a class="p-header__nav-link" href="#features">特徴</a></li>
+              <li><a class="p-header__nav-link" href="#voice">お客様の声</a></li>
+              <li><a class="p-header__nav-link" href="#faq">よくある質問</a></li>
+              <li><a class="p-header__nav-link" href="#contact">ご予約</a></li>
+            </ul>
+            <a class="c-button p-header__cta" href="#contact">初回体験を予約する</a>
+          </nav>
 
-        <!-- Hamburger: drawer 開閉中も機能するため data-drawer-inert 対象外 -->
-        <button
-          class="c-hamburger p-header__hamburger"
-          data-hamburger
-          type="button"
-          aria-expanded="false"
-          aria-controls="drawer"
-          aria-label="メニュー"
-        >
-          <span class="c-hamburger__line" aria-hidden="true"></span>
-        </button>
+          <!-- Hamburger: drawer 開閉中も機能するため data-drawer-inert 対象外 -->
+          <button
+            class="c-hamburger p-header__hamburger"
+            data-hamburger
+            type="button"
+            aria-expanded="false"
+            aria-controls="drawer"
+            aria-label="メニュー"
+          >
+            <span class="c-hamburger__line" aria-hidden="true"></span>
+          </button>
+        </div>
       </div>
     </header>
 
@@ -203,22 +205,24 @@
     <main id="main" tabindex="-1" data-drawer-inert>
       <!-- Hero -->
       <section class="l-section p-hero" aria-labelledby="hero-heading">
-        <div class="l-inner p-hero__stack">
-          <!-- CUSTOMIZE: サービス名・キャッチコピーを差し替え -->
-          <div class="p-hero__content" data-immediate="scale-in">
-            <h1 class="p-hero__title" id="hero-heading">からだの声を、<br class="u-hidden-pc" />聴く時間。</h1>
-            <p class="p-hero__lead">
-              忙しい毎日の中で後回しにしてきた自分のケア。<br class="u-hidden-sp" />iluha
-              は、内側から整うボディケアサロンです。
-            </p>
-            <div class="p-hero__actions">
-              <a class="c-icon-button -large p-hero__cta" href="#contact">
-                初回体験を予約する
-                <svg class="c-icon-button__icon" width="20" height="20" aria-hidden="true">
-                  <use href="/assets/images/icons/arrow-right.svg#icon" />
-                </svg>
-              </a>
-              <a class="c-button -ghost -large p-hero__sub-cta" href="#features">選ばれる理由を見る</a>
+        <div class="l-inner p-hero__inner">
+          <div class="p-hero__stack">
+            <!-- CUSTOMIZE: サービス名・キャッチコピーを差し替え -->
+            <div class="p-hero__content" data-immediate="scale-in">
+              <h1 class="p-hero__title" id="hero-heading">からだの声を、<br class="u-hidden-pc" />聴く時間。</h1>
+              <p class="p-hero__lead">
+                忙しい毎日の中で後回しにしてきた自分のケア。<br class="u-hidden-sp" />iluha
+                は、内側から整うボディケアサロンです。
+              </p>
+              <div class="p-hero__actions">
+                <a class="c-icon-button -large p-hero__cta" href="#contact">
+                  初回体験を予約する
+                  <svg class="c-icon-button__icon" width="20" height="20" aria-hidden="true">
+                    <use href="/assets/images/icons/arrow-right.svg#icon" />
+                  </svg>
+                </a>
+                <a class="c-button -ghost -large p-hero__sub-cta" href="#features">選ばれる理由を見る</a>
+              </div>
             </div>
           </div>
         </div>
@@ -686,28 +690,30 @@
 
     <!-- Footer -->
     <footer class="l-footer p-footer" data-drawer-inert>
-      <div class="l-inner p-footer__stack">
-        <nav class="p-footer__nav" aria-label="フッターナビゲーション">
-          <ul class="p-footer__nav-list">
-            <li><a class="p-footer__nav-link" href="#features">特徴</a></li>
-            <li><a class="p-footer__nav-link" href="#voice">お客様の声</a></li>
-            <li><a class="p-footer__nav-link" href="#faq">よくある質問</a></li>
-            <li><a class="p-footer__nav-link" href="#contact">ご予約</a></li>
-            <li>
-              <a class="p-footer__nav-link" href="/privacy/">プライバシーポリシー</a>
-            </li>
-          </ul>
-        </nav>
-        <!-- CUSTOMIZE: 住所・電話番号・営業時間を差し替え -->
-        <address class="p-footer__address">
-          〒xxx-xxxx 東京都渋谷区○○ x-x-x ○○ビル 3F<br />
-          <a class="p-footer__tel" href="tel:03-xxxx-xxxx" translate="no">TEL: 03-xxxx-xxxx</a><br />
-          営業時間: 10:00〜20:00（最終受付 19:00）<br />
-          定休日: 毎週水曜日
-        </address>
-        <p class="p-footer__copyright">
-          <small><span translate="no">© 2026 iluha</span></small>
-        </p>
+      <div class="l-inner p-footer__inner">
+        <div class="p-footer__stack">
+          <nav class="p-footer__nav" aria-label="フッターナビゲーション">
+            <ul class="p-footer__nav-list">
+              <li><a class="p-footer__nav-link" href="#features">特徴</a></li>
+              <li><a class="p-footer__nav-link" href="#voice">お客様の声</a></li>
+              <li><a class="p-footer__nav-link" href="#faq">よくある質問</a></li>
+              <li><a class="p-footer__nav-link" href="#contact">ご予約</a></li>
+              <li>
+                <a class="p-footer__nav-link" href="/privacy/">プライバシーポリシー</a>
+              </li>
+            </ul>
+          </nav>
+          <!-- CUSTOMIZE: 住所・電話番号・営業時間を差し替え -->
+          <address class="p-footer__address">
+            〒xxx-xxxx 東京都渋谷区○○ x-x-x ○○ビル 3F<br />
+            <a class="p-footer__tel" href="tel:03-xxxx-xxxx" translate="no">TEL: 03-xxxx-xxxx</a><br />
+            営業時間: 10:00〜20:00（最終受付 19:00）<br />
+            定休日: 毎週水曜日
+          </address>
+          <p class="p-footer__copyright">
+            <small><span translate="no">© 2026 iluha</span></small>
+          </p>
+        </div>
       </div>
     </footer>
 

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -75,30 +75,32 @@
 
     <!-- Header -->
     <header class="l-header p-header">
-      <div class="l-inner p-header__bar">
-        <a class="p-header__logo" data-drawer-inert href="/" translate="no">iluha</a>
+      <div class="l-inner p-header__inner">
+        <div class="p-header__bar">
+          <a class="p-header__logo" data-drawer-inert href="/" translate="no">iluha</a>
 
-        <nav class="p-header__nav" data-drawer-inert aria-label="メインナビゲーション">
-          <ul class="p-header__nav-list">
-            <li><a class="p-header__nav-link" href="/#features">特徴</a></li>
-            <li><a class="p-header__nav-link" href="/#voice">お客様の声</a></li>
-            <li><a class="p-header__nav-link" href="/#faq">よくある質問</a></li>
-            <li><a class="p-header__nav-link" href="/#contact">ご予約</a></li>
-          </ul>
-          <a class="c-button p-header__cta" href="/#contact">初回体験を予約する</a>
-        </nav>
+          <nav class="p-header__nav" data-drawer-inert aria-label="メインナビゲーション">
+            <ul class="p-header__nav-list">
+              <li><a class="p-header__nav-link" href="/#features">特徴</a></li>
+              <li><a class="p-header__nav-link" href="/#voice">お客様の声</a></li>
+              <li><a class="p-header__nav-link" href="/#faq">よくある質問</a></li>
+              <li><a class="p-header__nav-link" href="/#contact">ご予約</a></li>
+            </ul>
+            <a class="c-button p-header__cta" href="/#contact">初回体験を予約する</a>
+          </nav>
 
-        <!-- Hamburger: drawer 開閉中も機能するため data-drawer-inert 対象外 -->
-        <button
-          class="c-hamburger p-header__hamburger"
-          data-hamburger
-          type="button"
-          aria-expanded="false"
-          aria-controls="drawer"
-          aria-label="メニュー"
-        >
-          <span class="c-hamburger__line" aria-hidden="true"></span>
-        </button>
+          <!-- Hamburger: drawer 開閉中も機能するため data-drawer-inert 対象外 -->
+          <button
+            class="c-hamburger p-header__hamburger"
+            data-hamburger
+            type="button"
+            aria-expanded="false"
+            aria-controls="drawer"
+            aria-label="メニュー"
+          >
+            <span class="c-hamburger__line" aria-hidden="true"></span>
+          </button>
+        </div>
       </div>
     </header>
 
@@ -168,28 +170,30 @@
 
     <!-- Footer -->
     <footer class="l-footer p-footer" data-drawer-inert>
-      <div class="l-inner p-footer__stack">
-        <nav class="p-footer__nav" aria-label="フッターナビゲーション">
-          <ul class="p-footer__nav-list">
-            <li><a class="p-footer__nav-link" href="/#features">特徴</a></li>
-            <li><a class="p-footer__nav-link" href="/#voice">お客様の声</a></li>
-            <li><a class="p-footer__nav-link" href="/#faq">よくある質問</a></li>
-            <li><a class="p-footer__nav-link" href="/#contact">ご予約</a></li>
-            <li>
-              <a class="p-footer__nav-link" href="/privacy/" aria-current="page">プライバシーポリシー</a>
-            </li>
-          </ul>
-        </nav>
-        <!-- CUSTOMIZE: 住所・電話番号・営業時間を差し替え -->
-        <address class="p-footer__address">
-          〒xxx-xxxx 東京都渋谷区○○ x-x-x ○○ビル 3F<br />
-          <a class="p-footer__tel" href="tel:03-xxxx-xxxx" translate="no">TEL: 03-xxxx-xxxx</a><br />
-          営業時間: 10:00〜20:00（最終受付 19:00）<br />
-          定休日: 毎週水曜日
-        </address>
-        <p class="p-footer__copyright">
-          <small><span translate="no">© 2026 iluha</span></small>
-        </p>
+      <div class="l-inner p-footer__inner">
+        <div class="p-footer__stack">
+          <nav class="p-footer__nav" aria-label="フッターナビゲーション">
+            <ul class="p-footer__nav-list">
+              <li><a class="p-footer__nav-link" href="/#features">特徴</a></li>
+              <li><a class="p-footer__nav-link" href="/#voice">お客様の声</a></li>
+              <li><a class="p-footer__nav-link" href="/#faq">よくある質問</a></li>
+              <li><a class="p-footer__nav-link" href="/#contact">ご予約</a></li>
+              <li>
+                <a class="p-footer__nav-link" href="/privacy/" aria-current="page">プライバシーポリシー</a>
+              </li>
+            </ul>
+          </nav>
+          <!-- CUSTOMIZE: 住所・電話番号・営業時間を差し替え -->
+          <address class="p-footer__address">
+            〒xxx-xxxx 東京都渋谷区○○ x-x-x ○○ビル 3F<br />
+            <a class="p-footer__tel" href="tel:03-xxxx-xxxx" translate="no">TEL: 03-xxxx-xxxx</a><br />
+            営業時間: 10:00〜20:00（最終受付 19:00）<br />
+            定休日: 毎週水曜日
+          </address>
+          <p class="p-footer__copyright">
+            <small><span translate="no">© 2026 iluha</span></small>
+          </p>
+        </div>
       </div>
     </footer>
 


### PR DESCRIPTION
## PR #187 が誤判断だった理由

PR #187「l-inner 一段ネスト化」は、各 section に `<div class="l-inner">` → `<div class="p-XXX__bar / __stack">` という 2 段構造を導入した。

これは U2 原則（原則 8）と原則 11（Block + Element 併記推奨）に反していた:
- **U2 原則**: マークアップにあるクラスは documentation placeholder。`l-inner` だけでは HTML と CSS の対応が曖昧になる
- **原則 11**: `l-* → p-*` 順の同要素 Block + Element 併記が spec §5.6 推奨パターン（class 記載順ルール準拠）
- **U2 結果**: PR #187 で dead Element として外した `p-header__inner` 等は、HTML に存在するクラスである以上、CSS にも documentation placeholder ルールが適用されるべきだった

## 最終構造の設計理由

しゅんえいルール:
> `l-inner p-XXX__inner` とすることで、名前も一致、上書き可能性時の役割も一致。  
> `p-header__bar` の内容が inner の役割に沿っていないなら、一段ネスト か。

| 要素 | 役割 | 構造 |
|---|---|---|
| `l-inner p-header__inner` | max-inline-size + padding + 中央配置（inner 役割一致） | 外側 wrapper |
| `p-header__bar` | flex container（height + space-between） | 内側 wrapper（役割逸脱） |
| `l-inner p-hero__inner` | inner 役割 | 外側 wrapper |
| `p-hero__stack` | grid-area stack（z-index + grid placement） | 内側 wrapper（役割逸脱） |
| `l-inner p-cta__inner` | max-inline-size + margin-inline: auto + text-align | 外側 wrapper（inner 役割完結、内側 wrapper 不要） |
| `l-inner p-footer__inner` | inner 役割 | 外側 wrapper |
| `p-footer__stack` | flex column + gap + align-items | 内側 wrapper（役割逸脱） |
| `l-inner p-404__inner` | max-inline-size（inner 役割の上書き） | 外側 wrapper |
| `p-404__stack` | display: grid + gap + justify-items | 内側 wrapper（grid 機能を分離） |

### しゅんえい流評価軸への整合

- **整合性が取れている**: 名前一致（inner = inner）+ 役割一致（centering / max-width）
- **意図がある**: 外側が制約、内側が機能という責任分離が明確
- **自然 / 無理がない**: `l-inner p-XXX__inner` は既存の `p-problem__inner` 等と完全に同じパターン

## 修正前後の HTML 構造比較

### A. p-header__inner（Before = v1.2 の誤パターン）
```html
<!-- Before (v1.2): 同一要素に l-inner と p-header__bar → 役割混在 -->
<div class="l-inner p-header__bar">
  ...bar content...
</div>

<!-- After (最終): inner 役割 + bar 機能を分離 -->
<div class="l-inner p-header__inner">
  <div class="p-header__bar">
    ...bar content...
  </div>
</div>
```

### D. p-cta__inner（inner 役割完結、内側 wrapper 不要）
```html
<!-- After (最終 = v1.2 からの変更なし): inner 完結 -->
<div class="l-inner p-cta__inner">
  <div class="p-cta__stack">...</div>
</div>
```

### E. p-404__inner（grid 機能分離）
```html
<!-- Before (v1.2): __inner に grid + centering + max-inline-size が混在 -->
<div class="l-inner p-404__inner">
  ...content...
</div>

<!-- After (最終): inner は max-inline-size のみ、stack が grid 担当 -->
<div class="l-inner p-404__inner">
  <div class="p-404__stack">
    ...content...
  </div>
</div>
```

## p-404 CSS リファクタ詳細

```css
/* Before */
.p-404__inner {
  display: grid;
  gap: var(--space-xl);
  justify-items: center;
  max-inline-size: 40rem;  /* inner 役割 + grid 機能が混在 */
}

/* After */
.p-404__inner {
  max-inline-size: 40rem;  /* inner 役割のみ（l-inner の max-inline-size 上書き） */
}

.p-404__stack {
  display: grid;           /* grid 機能を責任分離 */
  gap: var(--space-xl);
  justify-items: center;
}
```

## 変更ファイル

- `src/index.html`: A（header）/ B（hero）/ C（footer）各 1 箇所 ← D（CTA）は変更なし
- `src/404.html`: A（header）/ E（p-404）/ C（footer）各 1 箇所
- `src/privacy/index.html`: A（header）/ C（footer）各 1 箇所
- `src/assets/css/project/p-header.css`: `.p-header__inner` 空ルール追加
- `src/assets/css/project/p-hero.css`: `.p-hero__inner` 空ルール追加
- `src/assets/css/project/p-footer.css`: `.p-footer__inner` 空ルール追加
- `src/assets/css/project/p-404.css`: `.p-404__inner` 責任分離 + `.p-404__stack` 新設

## 簡易 AR レポート

**Critical (0件)**: なし  
**Major (0件)**: なし  
**Minor (0件)**: なし

検証:
- `grep -rn "l-inner p-header__inner\|..."` で 9 箇所すべて確認 ✅
- dead Element 9 件（p-problem__inner 等）変更なし ✅
- `pnpm run check` (markuplint / stylelint / eslint) 通過 ✅
- `pnpm run build` 成功 ✅

## 関連 PR

- #187 本 PR の書き換え元（誤判断の一段ネスト化）
- #186 c-media-split `-stacked` 追加