### PR TITLE
refactor: l-inner p-XXX__inner 併記構造に統一（U2 原則 + 原則 11 整合 + p-404 grid 分離）

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -35,7 +35,7 @@
 
     <!-- Header -->
     <header class="l-header p-header">
-      <div class="l-inner">
+      <div class="l-inner p-header__inner">
         <div class="p-header__bar">
           <a class="p-header__logo" data-drawer-inert href="/" translate="no">iluha</a>
 
@@ -91,8 +91,8 @@
 
     <main id="main" tabindex="-1" data-drawer-inert>
       <section class="l-section p-404" aria-labelledby="not-found-heading">
-        <div class="l-inner">
-          <div class="p-404__inner">
+        <div class="l-inner p-404__inner">
+          <div class="p-404__stack">
             <hgroup class="c-section-heading p-404__heading">
               <p class="c-section-heading__eyebrow">404</p>
               <h1 class="c-section-heading__title" id="not-found-heading">ページが見つかりません</h1>
@@ -111,7 +111,7 @@
 
     <!-- Footer -->
     <footer class="l-footer p-footer" data-drawer-inert>
-      <div class="l-inner">
+      <div class="l-inner p-footer__inner">
         <div class="p-footer__stack">
           <nav class="p-footer__nav" aria-label="フッターナビゲーション">
             <ul class="p-footer__nav-list">

--- a/src/assets/css/project/p-404.css
+++ b/src/assets/css/project/p-404.css
@@ -3,10 +3,13 @@
 }
 
 .p-404__inner {
+  max-inline-size: 40rem;
+}
+
+.p-404__stack {
   display: grid;
   gap: var(--space-xl);
   justify-items: center;
-  max-inline-size: 40rem;
 }
 
 .p-404__lead {

--- a/src/assets/css/project/p-footer.css
+++ b/src/assets/css/project/p-footer.css
@@ -4,6 +4,10 @@
   border-block-start: var(--border-width) solid var(--color-border);
 }
 
+.p-footer__inner {
+  /* スタイルなし（HTML クラスとの対応を維持） */
+}
+
 .p-footer__stack {
   display: flex;
   flex-direction: column;

--- a/src/assets/css/project/p-header.css
+++ b/src/assets/css/project/p-header.css
@@ -12,6 +12,10 @@
   }
 }
 
+.p-header__inner {
+  /* スタイルなし（HTML クラスとの対応を維持） */
+}
+
 .p-header__bar {
   display: flex;
   align-items: center;

--- a/src/assets/css/project/p-hero.css
+++ b/src/assets/css/project/p-hero.css
@@ -7,6 +7,10 @@
   background: radial-gradient(ellipse at 50% 0%, oklch(from var(--color-main) l c h / 6%) 0%, transparent 70%);
 }
 
+.p-hero__inner {
+  /* スタイルなし（HTML クラスとの対応を維持） */
+}
+
 .p-hero__stack {
   position: relative;
   z-index: 1;

--- a/src/index.html
+++ b/src/index.html
@@ -147,7 +147,7 @@
 
     <!-- Header -->
     <header class="l-header p-header">
-      <div class="l-inner">
+      <div class="l-inner p-header__inner">
         <div class="p-header__bar">
           <!-- CUSTOMIZE: サービス名を差し替え -->
           <a class="p-header__logo" data-drawer-inert href="/" translate="no">iluha</a>
@@ -205,7 +205,7 @@
     <main id="main" tabindex="-1" data-drawer-inert>
       <!-- Hero -->
       <section class="l-section p-hero" aria-labelledby="hero-heading">
-        <div class="l-inner">
+        <div class="l-inner p-hero__inner">
           <div class="p-hero__stack">
             <!-- CUSTOMIZE: サービス名・キャッチコピーを差し替え -->
             <div class="p-hero__content" data-immediate="scale-in">
@@ -534,17 +534,13 @@
 
       <!-- CTA -->
       <section class="l-section p-cta" id="cta" aria-labelledby="cta-heading">
-        <div class="l-inner">
-          <div class="p-cta__inner">
-            <div class="p-cta__stack" data-stagger="fade-in-slide-up">
-              <div class="c-text-block p-cta__message">
-                <h2 class="c-text-block__title" id="cta-heading">まずは一度、からだの声を聴いてみませんか？</h2>
-                <p class="c-text-block__text">
-                  初回体験は 60分 4,400円。カウンセリング込み。無理な勧誘はいたしません。
-                </p>
-              </div>
-              <a class="c-button -large p-cta__button" href="#contact">初回体験を予約する</a>
+        <div class="l-inner p-cta__inner">
+          <div class="p-cta__stack" data-stagger="fade-in-slide-up">
+            <div class="c-text-block p-cta__message">
+              <h2 class="c-text-block__title" id="cta-heading">まずは一度、からだの声を聴いてみませんか？</h2>
+              <p class="c-text-block__text">初回体験は 60分 4,400円。カウンセリング込み。無理な勧誘はいたしません。</p>
             </div>
+            <a class="c-button -large p-cta__button" href="#contact">初回体験を予約する</a>
           </div>
         </div>
       </section>
@@ -694,7 +690,7 @@
 
     <!-- Footer -->
     <footer class="l-footer p-footer" data-drawer-inert>
-      <div class="l-inner">
+      <div class="l-inner p-footer__inner">
         <div class="p-footer__stack">
           <nav class="p-footer__nav" aria-label="フッターナビゲーション">
             <ul class="p-footer__nav-list">

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -75,7 +75,7 @@
 
     <!-- Header -->
     <header class="l-header p-header">
-      <div class="l-inner">
+      <div class="l-inner p-header__inner">
         <div class="p-header__bar">
           <a class="p-header__logo" data-drawer-inert href="/" translate="no">iluha</a>
 
@@ -170,7 +170,7 @@
 
     <!-- Footer -->
     <footer class="l-footer p-footer" data-drawer-inert>
-      <div class="l-inner">
+      <div class="l-inner p-footer__inner">
         <div class="p-footer__stack">
           <nav class="p-footer__nav" aria-label="フッターナビゲーション">
             <ul class="p-footer__nav-list">


### PR DESCRIPTION
## 概要

PR #187（l-inner 一段ネスト化）を受けた最終構造への整合。
外側 wrapper に `l-inner` と `p-XXX__inner` を**併記**することで、名前一致・役割上書き可能性・Block 単独運用の三条件を同時達成する。

## PR #187 が誤判断だった理由

PR #187 は「Component が Layout クラスを持つのは純度違反」という内部判断メモを適用したが、これは**過剰適用**だった。

- spec §5.6 および Component 使用統一原則（原則 11）は、Block 間の**責任直交**を前提に、`l-inner` と `p-XXX__inner` を同一要素で**併記することを推奨**している
- しゅんえいルール: 「`l-inner p-XXX__inner` とすることで、名前も一致、上書き可能性時の役割も一致」
- 過剰適用警戒の補足を内部メモに追加済

## 最終構造の設計理由（5 評価軸整合）

| 評価軸 | 根拠 |
|---|---|
| **spec 準拠** | §5.6 Block + Element 併記推奨・U2 原則（独立運用） |
| **名前一致** | `l-inner` wrapper と `p-XXX__inner` Element が同一要素 → 役割説明自然体 |
| **責任分離** | `l-inner`（幅制御）/ `p-XXX__inner`（Block 固有上書き点）/ `p-XXX__bar/stack`（内部レイアウト）で 3 層分離 |
| **最小差分** | PR #187 の 2 段→1 段ネスト化から、外側 class 追加のみに変換（D / E を除き structural 変更最小） |
| **上書き可能性** | Project 層から `p-XXX__inner` 経由で `l-inner` の max-inline-size / padding 等を overrideable |

## 修正前後の構造比較

### A. p-header（3 ファイル）

```html
<!-- Before (v1.2 HEAD = PR #187 後) -->
<div class="l-inner">
  <div class="p-header__bar">...</div>
</div>

<!-- After -->
<div class="l-inner p-header__inner">
  <div class="p-header__bar">...</div>
</div>
```

### B. p-hero（index.html）

```html
<!-- Before -->
<div class="l-inner">
  <div class="p-hero__stack">...</div>
</div>

<!-- After -->
<div class="l-inner p-hero__inner">
  <div class="p-hero__stack">...</div>
</div>
```

### C. p-footer（3 ファイル）

```html
<!-- Before -->
<div class="l-inner">
  <div class="p-footer__stack">...</div>
</div>

<!-- After -->
<div class="l-inner p-footer__inner">
  <div class="p-footer__stack">...</div>
</div>
```

### D. p-cta（index.html）— 内側 wrapper 削除

```html
<!-- Before (PR #187 が追加した内側 wrapper) -->
<div class="l-inner">
  <div class="p-cta__inner">
    <div class="p-cta__stack">...</div>
  </div>
</div>

<!-- After (p-cta__inner は inner 役割完結、内側 wrapper 不要) -->
<div class="l-inner p-cta__inner">
  <div class="p-cta__stack">...</div>
</div>
```

### E. p-404（404.html）— grid 機能を __stack に分離

```html
<!-- Before -->
<div class="l-inner">
  <div class="p-404__inner">...content...</div>
</div>

<!-- After -->
<div class="l-inner p-404__inner">
  <div class="p-404__stack">...content...</div>
</div>
```

## p-404 CSS リファクタ詳細

`p-404__inner` に grid 機能と max-inline-size が混在していたため、`l-inner` との併記に合わせて責任を分離した。

```css
/* Before */
.p-404__inner {
  display: grid;
  gap: var(--space-xl);
  justify-items: center;
  max-inline-size: 40rem;
}

/* After: __inner は幅制約のみ（l-inner の override 点） */
.p-404__inner {
  max-inline-size: 40rem;
}

/* After: __stack がグリッドレイアウトを担う */
.p-404__stack {
  display: grid;
  gap: var(--space-xl);
  justify-items: center;
}
```

**理由**: `l-inner` が `margin-inline: auto` + `max-inline-size` を持つため、`p-404__inner` はその上書き点（40rem 制約）のみを担い、grid 機能は内部 `p-404__stack` に委譲するのが責任分離原則に合致する。

## 変更対象

| ファイル | 変更種別 |
|---|---|
| `src/index.html` | A（header）/ B（hero）/ D（cta inner 削除）/ C（footer） |
| `src/404.html` | A（header）/ E（p-404 stack 分離）/ C（footer） |
| `src/privacy/index.html` | A（header）/ C（footer） |
| `src/assets/css/project/p-header.css` | `__inner` 空ルール追加 |
| `src/assets/css/project/p-hero.css` | `__inner` 空ルール追加 |
| `src/assets/css/project/p-footer.css` | `__inner` 空ルール追加 |
| `src/assets/css/project/p-404.css` | `__inner` max-inline-size 分離 + `__stack` 新設 |

**変更なし**: dead Element 9 件（`p-problem__inner` / `p-features__inner` / `p-flow__inner` / `p-pricing__inner` / `p-numbers__inner` / `p-voice__inner` / `p-faq__inner` / `p-contact__inner` / `p-privacy__inner`）

## 簡易 AR レポート

### Critical（仕様違反・機能破損）: 0 件

### Major（品質低下）: 0 件

### Minor（改善候補）: 0 件

- spec §5 単一責任原則・§5.6 Block 併記推奨に完全準拠
- 命名規則（spec §6）準拠：`p-404__stack` は既存 `p-hero__stack` / `p-footer__stack` と一貫したパターン
- `pnpm run check`（markuplint / stylelint / eslint）全通過
- `pnpm run build` 成功（built in 70ms）
- grep 復活確認: 9 箇所全出力確認済

## 参照

- spec §5.4 単一責任原則 / §5.6 Block + Element 併記推奨
- 関連 PR: #187（β 一段ネスト化、誤判断）

🤖 Generated with [Claude Code](https://claude.com/claude-code)