### PR TITLE
chore: package.json から engines フィールドを削除（OSS 公開方針復元）

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "engines": {
-    "node": ">=24.0.0"
-  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## 概要

e19a7a8 で誤って追加された `engines` フィールドを削除し、OSS 公開方針を復元する。

## 復元の理由

CONTRIBUTING.md L36「Node.js LTS 以降を推奨」の記述通り、starter は OSS 公開リポとして広いユーザー層への対応を優先するため、`engines` フィールドを**意図的に未指定**としている。

e19a7a8 では `wp-starter`（案件用リポ・開発環境を固定する意図的判断）との整合を理由に `engines: { node: ">=24.0.0" }` を追加したが、starter に同ポリシーを適用するのは誤判断であった。

## 変更 diff

```diff
-  "engines": {
-    "node": ">=24.0.0"
-  },
```

## 維持する変更

- `devDependencies.vite: "^8.0.5"` — e19a7a8 のバージョン追従は有効なため維持

## 検証

- [x] `package.json` JSON 構文 valid
- [x] `engines` フィールド完全削除
- [x] `vite ^8.0.5` 維持確認
- [x] `pnpm run check` 通過
- [x] `pnpm run build` 成功（vite v8.0.10、74ms）

🤖 Generated with [Claude Code](https://claude.com/claude-code)