### PR TITLE
fix(p-hero): __inner に grid-area: stack を設定（hero stack レイアウト復元）

### DIFF
--- a/src/assets/css/project/p-hero.css
+++ b/src/assets/css/project/p-hero.css
@@ -8,7 +8,12 @@
 }
 
 .p-hero__inner {
-  /* スタイルなし（HTML クラスとの対応を維持） */
+  /*
+   * Hero stack レイアウトの grid セル配置（原則 9 の明示理由付き例外）
+   * .p-hero の grid-template-areas: 'stack' に対して、.p-hero__media と同セルに配置する
+   * （l-inner p-hero__inner 併記により .p-hero の grid 直接子になったため）
+   */
+  grid-area: stack;
 }
 
 .p-hero__stack {


### PR DESCRIPTION
## バグ症状

Hero セクションで画像（`.p-hero__media`）とテキスト（`.p-hero__inner` 内）が重ならず、縦に分離して表示される。

## 根本原因

PR #189（`l-inner p-hero__inner` 併記構造化）の副作用。

`.p-hero` は `display: grid; grid-template-areas: 'stack'` で stack レイアウトを定義している。PR #189 以前は `.p-hero__inner` が `.p-hero` の直接子ではなかったが、`l-inner` との併記構造化後に直接子になった。

- `.p-hero__media`: `grid-area: stack`（明示）→ `'stack'` エリアに配置 ✅
- `.p-hero__inner`: `grid-area` なし → `auto`（暗黙 placement）→ **別 row に配置** ❌

結果として `.p-hero__media`（画像）と `.p-hero__inner`（テキスト）が異なる grid row に配置され、重なりが発生しないバグが生じた。

## 修正方針

`.p-hero__inner` に `grid-area: stack` を追加。

Component 使用統一原則 9（`__inner` は幅制御のみ）の **明示理由付き例外** として処理。`l-inner p-hero__inner` 併記により `.p-hero` の grid 直接子になったため、配置責任（`grid-area`）を保持することが必要かつ正当。

## 変更ファイル

- `src/assets/css/project/p-hero.css`: `.p-hero__inner` に `grid-area: stack` を追加（1 ルールのみ）

## 関連

- 起点 PR: #189（`l-inner p-hero__inner` 併記構造化、本バグの起点）
- **wp-starter にも同 CSS sync 必要**（並行 PR で対応予定）

## 検証

- [x] `pnpm run check`（Stylelint / ESLint / markuplint）全通過
- [x] `pnpm run build` 成功（vite 80ms, エラーなし）