### PR TITLE
chore(p-hero): __inner の経緯コメント削除（コミット履歴で追える）

### DIFF
--- a/src/assets/css/project/p-hero.css
+++ b/src/assets/css/project/p-hero.css
@@ -8,11 +8,6 @@
 }
 
 .p-hero__inner {
-  /*
-   * Hero stack レイアウトの grid セル配置（原則 9 の明示理由付き例外）
-   * .p-hero の grid-template-areas: 'stack' に対して、.p-hero__media と同セルに配置する
-   * （l-inner p-hero__inner 併記により .p-hero の grid 直接子になったため）
-   */
   grid-area: stack;
 }
 


### PR DESCRIPTION
## 変更内容

`.p-hero__inner` の経緯ベースコメントを完全削除。

`grid-area: stack` は CSS で意図が自明（`grid-template-areas: 'stack'` に呼応）であり、「なぜ l-inner と併記したか」という経緯は `git log` / PR #191 で追える。コードに残す必要がない。

## 根拠

- comment-audit ルール 8: 実装判断記録 ≠ 経緯説明
- Component 使用統一原則 §コメント方針

## diff

```diff
 .p-hero__inner {
-  /*
-   * Hero stack レイアウトの grid セル配置（原則 9 の明示理由付き例外）
-   * .p-hero の grid-template-areas: 'stack' に対して、.p-hero__media と同セルに配置する
-   * （l-inner p-hero__inner 併記により .p-hero の grid 直接子になったため）
-   */
   grid-area: stack;
 }
```

## 検証

- `pnpm run check` ✅
- `pnpm run build` ✅ (built in 68ms)

関連: #191 (コメント追加) / #192 (短縮)