### PR TITLE
chore(p-hero): __inner の経緯コメント完全削除（コミット履歴で追える）

### DIFF
--- a/src/assets/css/project/p-hero.css
+++ b/src/assets/css/project/p-hero.css
@@ -8,7 +8,6 @@
 }
 
 .p-hero__inner {
-  /* l-inner p-hero__inner 併記により .p-hero の grid 直接子になったため grid-area を宣言 */
   grid-area: stack;
 }
 


### PR DESCRIPTION
## 変更内容

`p-hero.css` の `.p-hero__inner` から経緯ベースのコメントを完全削除。

```diff
 .p-hero__inner {
-  /* l-inner p-hero__inner 併記により .p-hero の grid 直接子になったため grid-area を宣言 */
   grid-area: stack;
 }
```

## 背景

- PR #191 でコメント追加 → PR #192 で短縮 → しゅんえい指摘「経緯ベースのコメントはコードに残さない、コミット履歴で追える」
- PR #193（CONFLICTING）は close 済み。本 PR は v1.2 HEAD（PR #192 後）から作成

## 検証

- `pnpm run check` ✓（Stylelint / ESLint / markuplint 全通過）
- `pnpm run build` ✓（built in 70ms）

🤖 Generated with [Claude Code](https://claude.com/claude-code)