### PR TITLE
fix(v1.2): フォーム a11y 完全実装（PR #124 方針反転、Issue #195）

### DIFF
--- a/src/assets/css/component/c-form.css
+++ b/src/assets/css/component/c-form.css
@@ -94,6 +94,13 @@ textarea.c-form__input {
   margin-block-start: var(--space-xs);
 }
 
+/* Element: バリデーションエラーメッセージ（JS が hidden 解除 + textContent 投入で表示）。
+   表示制御は HTML の hidden 属性で行うため、CSS の display 制御は不要 */
+.c-form__error {
+  font-size: var(--font-size-caption);
+  color: var(--color-error);
+}
+
 /* Element: 送信ボタン配置ラッパー（中央寄せ default、Project 側で上書き可） */
 .c-form__actions {
   display: flex;

--- a/src/assets/scripts/main.js
+++ b/src/assets/scripts/main.js
@@ -6,6 +6,7 @@
  * - スクロールアニメーション（IntersectionObserver + data-animate）
  * - スタッガーアニメーション（data-stagger）
  * - Back to Top ボタン表示制御
+ * - フォームバリデーション a11y（HTML5 制約検証 + role="alert" 動的表示）
  *
  * data-immediate: CSS 完結のアニメーション（JS 待ちなし）。ファーストビュー要素のアニメーション遅延防止に使用。
  * data-animate:   JS 待ちアニメーション。IntersectionObserver が data-visible を付与して再生開始。
@@ -197,14 +198,100 @@ function initBackToTop(options = {}) {
   toggleVisibility();
 }
 
+/**
+ * フォームバリデーション a11y を初期化する（HTML5 制約検証 + role="alert" 動的表示）。
+ * フォームに novalidate が必要（ブラウザネイティブ tooltip を抑制して JS で制御）。
+ * @param {Object} [options] - カスタマイズオプション
+ * @param {string} [options.formSelector='.c-form'] - 対象フォームのセレクタ
+ */
+function initFormValidation(options = {}) {
+  const { formSelector = '.c-form' } = options;
+  const forms = document.querySelectorAll(formSelector);
+  if (forms.length === 0) return;
+
+  forms.forEach((form) => {
+    const fields = form.querySelectorAll('[aria-describedby]');
+
+    /**
+     * fieldset は制約検証対象外（barred from constraint validation）のため、
+     * 内部の最初の required 入力要素を代わりに検査する。
+     */
+    function getRepresentativeInput(field) {
+      if (field.tagName === 'FIELDSET') {
+        return field.querySelector('[required]') ?? null;
+      }
+      return field;
+    }
+
+    // 送信時バリデーション
+    form.addEventListener('submit', (event) => {
+      let firstInvalid = null;
+
+      fields.forEach((field) => {
+        const errorId = field.getAttribute('aria-describedby');
+        const errorEl = document.getElementById(errorId);
+        if (!errorEl) return;
+
+        const input = getRepresentativeInput(field);
+        if (!input) return;
+
+        if (!input.checkValidity()) {
+          // エラー表示
+          errorEl.textContent = input.validationMessage;
+          errorEl.hidden = false;
+          field.setAttribute('aria-invalid', 'true');
+          if (!firstInvalid) firstInvalid = input;
+        } else {
+          // エラー解除
+          errorEl.textContent = '';
+          errorEl.hidden = true;
+          field.removeAttribute('aria-invalid');
+        }
+      });
+
+      // 最初のエラーフィールドに focus
+      if (firstInvalid) {
+        event.preventDefault();
+        firstInvalid.focus({ preventScroll: false });
+        firstInvalid.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    });
+
+    // input / change イベントで有効化時にエラー解除
+    fields.forEach((field) => {
+      const errorId = field.getAttribute('aria-describedby');
+      const errorEl = document.getElementById(errorId);
+      if (!errorEl) return;
+
+      const input = getRepresentativeInput(field);
+      if (!input) return;
+
+      const handler = () => {
+        if (input.checkValidity()) {
+          errorEl.textContent = '';
+          errorEl.hidden = true;
+          field.removeAttribute('aria-invalid');
+        }
+      };
+
+      // input は textarea / input[type=text|email|tel] 等
+      // change は select / radio / checkbox
+      field.addEventListener('input', handler);
+      field.addEventListener('change', handler);
+    });
+  });
+}
+
 // 初期化（デフォルト値で動作）
 initDrawer();
 initStagger();
 initScrollAnimation();
 initBackToTop();
+initFormValidation();
 
 // CUSTOMIZE 例:
 // initDrawer({ breakpoint: 1024 });
 // initStagger({ delayStep: 0.15 });
 // initScrollAnimation({ threshold: 0.3, rootMargin: '0px 0px -100px 0px' });
 // initBackToTop({ threshold: 500 });
+// initFormValidation({ formSelector: '#my-form' });

--- a/src/index.html
+++ b/src/index.html
@@ -623,34 +623,38 @@
           <p class="p-contact__lead">下記フォームからお気軽にどうぞ。24時間以内に折り返しご連絡いたします。</p>
 
           <!-- CUSTOMIZE: 本番バックエンド URL に差し替え。starter はフォーム送信処理を提供しません -->
-          <form class="c-form p-contact__form" action="/api/contact" method="post">
+          <form class="c-form p-contact__form" action="/api/contact" method="post" novalidate>
             <p class="c-form__note"><span aria-hidden="true">*</span> のついた項目は必須です</p>
             <div class="c-form__field">
               <label class="c-form__label" for="name">お名前</label>
-              <input class="c-form__input" id="name" name="name" type="text" autocomplete="name" required />
+              <input class="c-form__input" id="name" name="name" type="text" autocomplete="name" required aria-describedby="name-error" />
+              <p class="c-form__error" id="name-error" role="alert" hidden></p>
             </div>
 
             <div class="c-form__field">
               <label class="c-form__label" for="email">メールアドレス</label>
-              <input class="c-form__input" id="email" name="email" type="email" autocomplete="email" required />
+              <input class="c-form__input" id="email" name="email" type="email" autocomplete="email" required aria-describedby="email-error" />
+              <p class="c-form__error" id="email-error" role="alert" hidden></p>
             </div>
 
             <div class="c-form__field">
               <label class="c-form__label" for="tel">電話番号</label>
-              <input class="c-form__input" id="tel" name="tel" type="tel" autocomplete="tel" />
+              <input class="c-form__input" id="tel" name="tel" type="tel" autocomplete="tel" aria-describedby="tel-error" />
+              <p class="c-form__error" id="tel-error" role="alert" hidden></p>
             </div>
 
             <div class="c-form__field">
               <label class="c-form__label" for="category">お問い合わせ種別</label>
-              <select class="c-form__input" id="category" name="category" required>
+              <select class="c-form__input" id="category" name="category" required aria-describedby="category-error">
                 <option value="">選択してください</option>
                 <option value="reservation">初回体験の予約</option>
                 <option value="inquiry">施術に関するお問い合わせ</option>
                 <option value="other">その他</option>
               </select>
+              <p class="c-form__error" id="category-error" role="alert" hidden></p>
             </div>
 
-            <fieldset class="c-form__field">
+            <fieldset class="c-form__field" aria-describedby="plan-error">
               <legend class="c-form__legend">ご希望のプラン</legend>
               <div class="c-form__choice-group">
                 <label class="c-form__choice-label">
@@ -666,18 +670,21 @@
                   リラクゼーション（90分）
                 </label>
               </div>
+              <p class="c-form__error" id="plan-error" role="alert" hidden></p>
             </fieldset>
 
             <div class="c-form__field">
               <label class="c-form__label" for="message">メッセージ</label>
-              <textarea class="c-form__input" id="message" name="message" rows="6" required></textarea>
+              <textarea class="c-form__input" id="message" name="message" rows="6" required aria-describedby="message-error"></textarea>
+              <p class="c-form__error" id="message-error" role="alert" hidden></p>
             </div>
 
             <div class="c-form__field">
               <label class="c-form__choice-label" for="agree">
-                <input id="agree" name="agree" type="checkbox" required />
+                <input id="agree" name="agree" type="checkbox" required aria-describedby="agree-error" />
                 <a href="/privacy/">プライバシーポリシー</a>に同意する
               </label>
+              <p class="c-form__error" id="agree-error" role="alert" hidden></p>
             </div>
 
             <div class="c-form__actions">


### PR DESCRIPTION
## 概要

**PR #124（df28c56、2026-04-23）の方針反転**: しゅんえい再判断（2026-05-01 セッション 33）により、フォーム a11y を完全実装する。

> 何度も指摘してきてくれるのは、リファレンス実装に必要だからだろう。

### 変更ファイル

- `src/index.html` — 全 7 フィールドに `aria-describedby` + `role="alert"` エラー要素、`form` に `novalidate`
- `src/assets/css/component/c-form.css` — `.c-form__error` スタイル復活
- `src/assets/scripts/main.js` — `initFormValidation()` 関数追加 + 初期化呼び出し

## 実装詳細

### HTML（src/index.html）

- `<form>` に `novalidate` 追加（JS 完全制御のため、ブラウザ native tooltip を抑制）
- 全 7 フィールド（name / email / tel / category / plan / message / agree）に対応:
  - `input` / `select` / `textarea`: `aria-describedby="<field>-error"` 追加
  - `fieldset`（plan）: `fieldset` 自体に `aria-describedby="plan-error"` 追加
  - 各フィールド直後に `<p class="c-form__error" id="<field>-error" role="alert" hidden></p>` 配置

### CSS（c-form.css）

```css
.c-form__error {
  font-size: var(--font-size-caption);
  color: var(--color-error);
}
```

表示制御は HTML `hidden` 属性で行うため CSS の `display` 制御は不要。

### JS（main.js）

`initFormValidation(options = {})` 関数を追加:

- **fieldset 対応**: `fieldset` は HTML5 制約検証対象外（barred from constraint validation）のため、内部の `required` 入力要素を代替検査する `getRepresentativeInput()` ヘルパーを内部定義
- **submit 時**: 全フィールドを `checkValidity()` で検査し:
  - 無効: `validationMessage`（ブラウザロケール準拠）を `textContent` に投入 + `hidden` 解除 + `aria-invalid="true"`
  - 最初の無効フィールドへ `focus()` + `scrollIntoView()` + `event.preventDefault()`
- **input/change 時**: 有効化された瞬間にエラー要素を非表示 + `aria-invalid` 削除

## WCAG 準拠

- **SC 3.3.1（A）** Error Identification — エラーフィールドの特定と文言提示 ✅
- **SC 3.3.3（AA）** Error Suggestion — `validationMessage` によるブラウザロケール準拠の修正提案 ✅

## 検証

- `pnpm build` ✅
- `pnpm run lint:js` ✅
- `pnpm run lint:css` ✅
- `pnpm run lint:html` ✅

## 関連

- Closes #195
- 過去 PR #124（差し戻し commit df28c56、2026-04-23 シンプル志向方針）の反転

🤖 Generated with [Claude Code](https://claude.com/claude-code)