### PR TITLE
hotfix(v1.2): preview-404-fallback plugin の / と /privacy/ 404 副作用修正

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,14 +40,33 @@ export default defineConfig({
         // 本番（Cloudflare Pages / Netlify / Vercel 等）は 404.html を root に置くだけで自動配信される
         return () => {
           server.middlewares.use((req, res, next) => {
-            const notFoundPath = resolve(__dirname, 'dist', '404.html');
+            const url = (req.url || '/').split('?')[0];
+            const distDir = resolve(__dirname, 'dist');
+
+            // 既存ファイル / ディレクトリが存在する場合は Vite に処理を委譲する
+            // 候補 1: dist/{url}（静的ファイル直接 or ディレクトリ）
+            // 候補 2: dist/{url}/index.html（ディレクトリ配下の index.html）
+            const candidates = [
+              resolve(distDir, url.slice(1)),
+              resolve(distDir, url.slice(1), 'index.html'),
+            ];
+
+            for (const candidate of candidates) {
+              if (fs.existsSync(candidate)) {
+                return next();
+              }
+            }
+
+            // どちらも存在しない → 404.html を 404 ステータスで返す
+            const notFoundPath = resolve(distDir, '404.html');
             if (fs.existsSync(notFoundPath)) {
               res.statusCode = 404;
               res.setHeader('Content-Type', 'text/html; charset=utf-8');
               fs.createReadStream(notFoundPath).pipe(res);
-            } else {
-              next();
+              return;
             }
+
+            next();
           });
         };
       },


### PR DESCRIPTION
## 概要

PR #199 で実装した `preview-404-fallback` plugin に副作用が発覚。QC リトライで検出。

## 問題

| URL | 期待 | PR #199 実際 |
|---|---|---|
| `/` | 200 | **404** ❌ |
| `/privacy/` | 200 | **404** ❌ |
| `/nonexistent` | 404 | 404 ✅ |

## 根本原因

Vite の middleware 実行順:
```
viteAssetMiddleware → htmlFallbackMiddleware(MPA) → postHooks(カスタム) → indexHtmlMiddleware → notFoundMiddleware
```

PR #199 の実装は「post-hook は Vite 処理後の未処理のみ届く」前提だったが誤り。  
カスタム middleware は **indexHtmlMiddleware より前**に動くため、存在チェックなしで全リクエストを飲み込んでいた。

## 修正内容

既存ファイル / ディレクトリ存在チェックを追加:

```ts
const candidates = [
  resolve(distDir, url.slice(1)),              // dist/{url}（ファイル / ディレクトリ）
  resolve(distDir, url.slice(1), 'index.html'), // dist/{url}/index.html
];

for (const candidate of candidates) {
  if (fs.existsSync(candidate)) {
    return next(); // 存在する → Vite に委譲
  }
}
// 存在しない → 404.html 返却
```

## 動作確認（全 11 URL）

| URL | 期待 | 結果 |
|---|---|---|
| `/` | 200 | ✅ 200 |
| `/index.html` | 200 | ✅ 200 |
| `/privacy/` | 200 | ✅ 200 |
| `/privacy/index.html` | 200 | ✅ 200 |
| `/404.html` | 200 | ✅ 200 |
| `/assets/main-BYe0Lm16.css` | 200 | ✅ 200 |
| `/assets/main-1c-sa6K-.js` | 200 | ✅ 200 |
| `/scripts/viewport.js` | 200 | ✅ 200 |
| `/nonexistent` | 404 | ✅ 404 |
| `/nonexistent/deep` | 404 | ✅ 404 |
| `/nonexistent` タイトル | ページが見つかりません — iluha | ✅ 一致 |

## lint / build

- `pnpm run lint:js`: PASS
- `pnpm run lint:css`: PASS
- `pnpm run lint:html`: PASS
- `pnpm build`: PASS

## 関連

- 元 PR: #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>