### PR TITLE
feat(v1.2): 新規 .l-page Layout クラスで sticky footer 実装

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -29,7 +29,7 @@
     <script type="module" src="/assets/scripts/main.js"></script>
     <script src="/scripts/viewport.js"></script>
   </head>
-  <body id="top">
+  <body id="top" class="l-page">
     <!-- Skip Link -->
     <a class="c-skip-link" data-drawer-inert href="#main">本文へスキップ</a>
 

--- a/src/assets/css/layout/l-page.css
+++ b/src/assets/css/layout/l-page.css
@@ -1,0 +1,11 @@
+/* ページ全体の骨格（spec §5.4 Layout 層責任）。
+   sticky footer 動作: 短いコンテンツでも footer をウィンドウ下部に配置 */
+.l-page {
+  display: flex;
+  flex-direction: column;
+  min-block-size: 100dvb;
+}
+
+.l-page > main {
+  flex: 1;
+}

--- a/src/assets/css/reset/reset.css
+++ b/src/assets/css/reset/reset.css
@@ -19,7 +19,6 @@
 }
 
 :where(body) {
-  min-block-size: 100dvb;
   margin: unset;
 }
 

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -19,6 +19,7 @@
 @import './foundation/form.css' layer(foundation);
 
 /* Layout: ページの大枠を構成するブロック（l- プレフィックス） */
+@import './layout/l-page.css' layer(layout);
 @import './layout/l-header.css' layer(layout);
 @import './layout/l-footer.css' layer(layout);
 @import './layout/l-section.css' layer(layout);

--- a/src/index.html
+++ b/src/index.html
@@ -141,7 +141,7 @@
       }
     </script>
   </head>
-  <body id="top">
+  <body id="top" class="l-page">
     <!-- Skip Link -->
     <a class="c-skip-link" data-drawer-inert href="#main">本文へスキップ</a>
 

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -69,7 +69,7 @@
       }
     </script>
   </head>
-  <body id="top">
+  <body id="top" class="l-page">
     <!-- Skip Link -->
     <a class="c-skip-link" data-drawer-inert href="#main">本文へスキップ</a>
 


### PR DESCRIPTION
## 概要

しゅんえい指摘（2026-05-01 セッション 33）: 404 等の短いコンテンツページでも footer をウィンドウ下部に配置。

mFLOCSS spec §5.4 Layout 層責任に整合する設計で、**新規 `.l-page` Layout クラス**として実装。

## 変更内容

### 新規ファイル
- `src/assets/css/layout/l-page.css`: ページ全体の骨格（`display: flex; flex-direction: column; min-block-size: 100dvb;`）+ `.l-page > main { flex: 1; }`

### 修正ファイル
- `src/assets/css/style.css`: `@import './layout/l-page.css' layer(layout);` を layout セクション先頭に追加
- `src/assets/css/reset/reset.css`: `:where(body)` から `min-block-size: 100dvb` 削除（Layout 層 `.l-page` に責任統一）
- `src/index.html` / `src/404.html` / `src/privacy/index.html`: `<body id="top">` → `<body id="top" class="l-page">`

## 設計根拠

- **Layout 層責任**: mFLOCSS spec §5.4「ページの大枠を構成するブロック」= Layout 層の責任
- **Foundation 責任分散解消**: reset.css の `min-block-size: 100dvb` は「ページ骨格の制御」であり Reset 層の責任域外。Layout 層に集約することで責任統一
- **sticky footer パターン**: `display: flex; flex-direction: column; min-block-size: 100dvb;` + `main { flex: 1; }` は CSS 標準の sticky footer 実装

## 動作確認

- ✅ 全 3 ページ（index / 404 / privacy）: `<body class="l-page">` 付与確認
- ✅ ビルド CSS: `@layer layout` に `.l-page` / `.l-page > main` ルール存在確認
- ✅ ビルド CSS: `@layer reset` の `:where(body)` は `margin: unset` のみ（`min-block-size` 削除確認）
- ✅ lint（CSS / JS / HTML）全 PASS
- ✅ `pnpm build` 成功

## テストチェックリスト

- [ ] 404 ページ: コンテンツが少なくても footer がウィンドウ下部に配置
- [ ] index ページ: 既存レイアウト崩れなし / sticky header 維持
- [ ] privacy ページ: コンテンツ少なくても footer がウィンドウ下部
- [ ] PC + SP viewport で各ページ目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)