### PR TITLE
chore(deps): override uuid to fix moderate vuln (GHSA-w5hq-g745-h8pq)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,16 @@
     "eslint": "^10.1.0",
     "eslint-config-prettier": "^10.1.8",
     "globals": "^17.4.0",
-    "markuplint": "^4.14.1",
+    "markuplint": "^4.18.1",
     "prettier": "^3.0.0",
     "stylelint": "^17.6.0",
     "stylelint-config-recess-order": "^7.7.0",
     "stylelint-config-standard": "^40.0.0",
     "vite": "^8.0.5"
+  },
+  "pnpm": {
+    "overrides": {
+      "uuid": ">=14.0.0"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  uuid: '>=14.0.0'
+
 importers:
 
   .:
@@ -24,8 +27,8 @@ importers:
         specifier: ^17.4.0
         version: 17.5.0
       markuplint:
-        specifier: ^4.14.1
-        version: 4.18.0
+        specifier: ^4.18.1
+        version: 4.18.1
       prettier:
         specifier: ^3.0.0
         version: 3.8.3
@@ -185,8 +188,8 @@ packages:
   '@markuplint/config-presets@4.18.0':
     resolution: {integrity: sha512-ZJjb0+7w0c4grYkfOdN+6R6UayIsLgBVs/FLYW2haHdDn8+7IUZkJBr3i6oZPmVsNoARoWrgqEmMAHDtv+na4w==}
 
-  '@markuplint/file-resolver@4.18.0':
-    resolution: {integrity: sha512-vBCQ4vBgEPBc0/sLqpquSkPhpo1Wtz5KhNbQHLWt0/DOF32FGToKOcOppRU9phiv/tkwOmD8+OE/Yvq/WpJtYA==}
+  '@markuplint/file-resolver@4.18.1':
+    resolution: {integrity: sha512-7+FxNF5Ulix80c2W1667x3XHtdL8EWzZST719kmo64y9ot2CcSKsXUs2RPulTE1V3WLYDPImXPTMZv3WndEFSg==}
 
   '@markuplint/html-parser@4.18.0':
     resolution: {integrity: sha512-6egvxypegPnNmVwnDXiuIelEQZCJnjynuIKVt+PwvUYUeGpW+03NIm6o+jt0olmfDPfPbMxr4frZa04tEofMdg==}
@@ -200,11 +203,11 @@ packages:
   '@markuplint/ml-ast@4.18.0':
     resolution: {integrity: sha512-K8V1hcTFGVEWkdGZF2EZNix3RiV+iMTekEvXm0BxwBwJ09XBs207v/rb2Aehd+VHGy78+/a+kU/BTNrqApzZmA==}
 
-  '@markuplint/ml-config@4.18.0':
-    resolution: {integrity: sha512-Dhx2CbdxVYdWX77NL7YPiT/KmqFSZY8sb2qUUvoDuZaTjA3//Tp6IrT0SeLoOd863FdCwjTLyJOPEReOkWknbw==}
+  '@markuplint/ml-config@4.18.1':
+    resolution: {integrity: sha512-2ZzXxJC+3OVX9dHRbVRikIFyKXLIlWQeoxCqe5vBEpTfvZh9sH8MyvaaM+Or1mrTGQpchbTsH/xujpPAtJ0sDA==}
 
-  '@markuplint/ml-core@4.18.0':
-    resolution: {integrity: sha512-GDRUlpP2N5BjsdbJtKvekLY3tSvg1j0L/LFN6GxcF60JTyo19QQD8VG89JXNik/bpggZIWJUwQuqaYYleENV8g==}
+  '@markuplint/ml-core@4.18.1':
+    resolution: {integrity: sha512-4nRbSsD1Xa1OyFKEmzr0Olgr+2gQPu44eCA9gwZ4MteyLOqervE+Yv5DFOKcZ/1Y5biyGh5LmTVCSSUMcMsrlA==}
 
   '@markuplint/ml-spec@4.18.0':
     resolution: {integrity: sha512-rVz9RsYeBGgCggYYxU0H4EUrodm2wBTw3vmrtaFps3/SNnKcvSZNlFnYd2VaV2oNGrEvvCE+tXDXUH353sG6SQ==}
@@ -212,11 +215,11 @@ packages:
   '@markuplint/parser-utils@4.18.0':
     resolution: {integrity: sha512-wp0PocLzZdLUhWbGKVK528WxknT/FCk1/PEqQnBjUlqOR2SD1rXHShoxz+gbYJVe6hMXUfKfqSA3KBUXLOelqg==}
 
-  '@markuplint/rules@4.18.0':
-    resolution: {integrity: sha512-nUtY7htaQxLbJB1SZT1uJOI0KWtmD0GeHqHq71sG+1sMHeaDg1YN2jTBf3XWhS0Qv9AVHJw6R5VZPpEDz/+WGA==}
+  '@markuplint/rules@4.18.1':
+    resolution: {integrity: sha512-dAIv1nrU5Upra3dVLJbtMVt6Nb5b2HCmzcdAtoJsD1686rMHUUd1tpPxYOs7mN0TdzlntYoITx3Dme83nEGTwg==}
 
-  '@markuplint/selector@4.18.0':
-    resolution: {integrity: sha512-znc75zS4z/HcsS2QK+ELXXqgf/p8MaLo1CIhJ/DfhfYTh7AvPso3BfZRe/kOpFuZLdXXDX287+ujJTk900lxwA==}
+  '@markuplint/selector@4.18.1':
+    resolution: {integrity: sha512-0pgJ9Ded2rmkJm0K1eHY/+DegHslaOV4GTCt0avQK2JdRH4qWEZDkmXIWCUx4zk0T9kFuPaoa9yBKNUfQG4d3Q==}
 
   '@markuplint/shared@4.18.0':
     resolution: {integrity: sha512-srF15il/HObuqx43hEXehutktOk62X0oHLIVtCuqwSXl8B0L6eu9kQ7ltxvhtN5wIEZu1IySBRBgFXavR7mojg==}
@@ -948,8 +951,8 @@ packages:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
 
-  markuplint@4.18.0:
-    resolution: {integrity: sha512-l2l1JH6db+FsLX5fX+axtUCYuzW8PNJt7jQFerV+cZQ076+LASwJBhTwrRwOMJXsCEKKEKrwSRuKFj4WMGF4bQ==}
+  markuplint@4.18.1:
+    resolution: {integrity: sha512-w3TX+4jpI9O1wjr/2l/tgk+b5PSYl39PXfR7O4iTza15fdOFNt0RB1J+6xqVZcHXsrSbkZT+Yunm29S9mpYKjg==}
     hasBin: true
 
   mathml-tag-names@4.0.0:
@@ -1086,6 +1089,10 @@ packages:
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -1267,8 +1274,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@13.0.0:
-    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   vite@8.0.10:
@@ -1474,15 +1481,15 @@ snapshots:
 
   '@markuplint/config-presets@4.18.0': {}
 
-  '@markuplint/file-resolver@4.18.0':
+  '@markuplint/file-resolver@4.18.1':
     dependencies:
       '@markuplint/html-parser': 4.18.0
       '@markuplint/ml-ast': 4.18.0
-      '@markuplint/ml-config': 4.18.0
-      '@markuplint/ml-core': 4.18.0
+      '@markuplint/ml-config': 4.18.1
+      '@markuplint/ml-core': 4.18.1
       '@markuplint/ml-spec': 4.18.0
       '@markuplint/parser-utils': 4.18.0
-      '@markuplint/selector': 4.18.0
+      '@markuplint/selector': 4.18.1
       '@markuplint/shared': 4.18.0
       cosmiconfig: 9.0.1
       debug: 4.4.3
@@ -1514,11 +1521,11 @@ snapshots:
 
   '@markuplint/ml-ast@4.18.0': {}
 
-  '@markuplint/ml-config@4.18.0':
+  '@markuplint/ml-config@4.18.1':
     dependencies:
       '@markuplint/ml-ast': 4.18.0
       '@markuplint/ml-spec': 4.18.0
-      '@markuplint/selector': 4.18.0
+      '@markuplint/selector': 4.18.1
       '@markuplint/shared': 4.18.0
       '@types/mustache': 4.2.6
       deepmerge: 4.3.1
@@ -1528,17 +1535,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@markuplint/ml-core@4.18.0':
+  '@markuplint/ml-core@4.18.1':
     dependencies:
       '@markuplint/config-presets': 4.18.0
       '@markuplint/html-parser': 4.18.0
       '@markuplint/html-spec': 4.18.0
       '@markuplint/i18n': 4.18.0
       '@markuplint/ml-ast': 4.18.0
-      '@markuplint/ml-config': 4.18.0
+      '@markuplint/ml-config': 4.18.1
       '@markuplint/ml-spec': 4.18.0
       '@markuplint/parser-utils': 4.18.0
-      '@markuplint/selector': 4.18.0
+      '@markuplint/selector': 4.18.1
       '@markuplint/shared': 4.18.0
       '@types/debug': 4.1.13
       debug: 4.4.3
@@ -1566,16 +1573,16 @@ snapshots:
       debug: 4.4.3
       espree: 11.2.0
       type-fest: 5.6.0
-      uuid: 13.0.0
+      uuid: 14.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@markuplint/rules@4.18.0':
+  '@markuplint/rules@4.18.1':
     dependencies:
       '@markuplint/html-spec': 4.18.0
-      '@markuplint/ml-core': 4.18.0
+      '@markuplint/ml-core': 4.18.1
       '@markuplint/ml-spec': 4.18.0
-      '@markuplint/selector': 4.18.0
+      '@markuplint/selector': 4.18.1
       '@markuplint/shared': 4.18.0
       '@markuplint/types': 4.18.0
       '@types/debug': 4.1.13
@@ -1587,7 +1594,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@markuplint/selector@4.18.0':
+  '@markuplint/selector@4.18.1':
     dependencies:
       '@markuplint/ml-spec': 4.18.0
       '@types/debug': 4.1.13
@@ -1717,7 +1724,7 @@ snapshots:
 
   '@types/uuid@11.0.0':
     dependencies:
-      uuid: 13.0.0
+      uuid: 14.0.0
 
   '@types/whatwg-mimetype@5.0.0': {}
 
@@ -2223,18 +2230,18 @@ snapshots:
 
   lru-cache@11.3.5: {}
 
-  markuplint@4.18.0:
+  markuplint@4.18.1:
     dependencies:
       '@markuplint/cli-utils': 4.18.0
-      '@markuplint/file-resolver': 4.18.0
+      '@markuplint/file-resolver': 4.18.1
       '@markuplint/html-parser': 4.18.0
       '@markuplint/html-spec': 4.18.0
       '@markuplint/i18n': 4.18.0
       '@markuplint/ml-ast': 4.18.0
-      '@markuplint/ml-config': 4.18.0
-      '@markuplint/ml-core': 4.18.0
+      '@markuplint/ml-config': 4.18.1
+      '@markuplint/ml-core': 4.18.1
       '@markuplint/ml-spec': 4.18.0
-      '@markuplint/rules': 4.18.0
+      '@markuplint/rules': 4.18.1
       '@markuplint/shared': 4.18.0
       '@types/debug': 4.1.13
       chokidar: 5.0.0
@@ -2352,13 +2359,19 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-sorting@10.0.0(postcss@8.5.10):
+  postcss-sorting@10.0.0(postcss@8.5.12):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.12
 
   postcss-value-parser@4.2.0: {}
 
   postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -2473,8 +2486,8 @@ snapshots:
 
   stylelint-order@8.1.1(stylelint@17.9.0):
     dependencies:
-      postcss: 8.5.10
-      postcss-sorting: 10.0.0(postcss@8.5.10)
+      postcss: 8.5.12
+      postcss-sorting: 10.0.0(postcss@8.5.12)
       stylelint: 17.9.0
 
   stylelint@17.9.0:
@@ -2568,7 +2581,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@13.0.0: {}
+  uuid@14.0.0: {}
 
   vite@8.0.10(@types/node@25.6.0):
     dependencies:


### PR DESCRIPTION
## 概要

月次セキュリティレビューでの対応。`pnpm audit` で検出された `markuplint > @markuplint/file-resolver > @markuplint/parser-utils > uuid (<14.0.0)` の moderate 脆弱性を `pnpm.overrides` で解消する。

## 変更内容

- `markuplint` を `^4.14.1 → ^4.18.1` に更新（minor）
- `package.json` に `pnpm.overrides.uuid >=14.0.0` を追加（transitive deps の uuid を v14 系に強制）

## 検証

- `pnpm install` で overrides 反映確認 ✅
- `pnpm audit` で 0 vulnerabilities 確認 ✅
- `pnpm lint:html` 動作確認 PASS ✅（全 3 HTML ファイル passed）
- vite モジュール loadable 確認 OK ✅
- lockfile に uuid@14.0.0 のみ参照（13.x 排除済） ✅

## AR

PASS（必須修正なし、変更スコープ: package.json + pnpm-lock.yaml のみ）

## 関連

- Advisory: https://github.com/advisories/GHSA-w5hq-g745-h8pq