### PR TITLE
refactor(footer): p-footer__tel から「TEL: 」プレフィックス削除（モダン UX 整合）

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -127,7 +127,7 @@
           <!-- CUSTOMIZE: 住所・電話番号・営業時間を差し替え -->
           <address class="p-footer__address">
             〒xxx-xxxx 東京都渋谷区○○ x-x-x ○○ビル 3F<br />
-            <a class="p-footer__tel" href="tel:03-xxxx-xxxx" translate="no">TEL: 03-xxxx-xxxx</a><br />
+            <a class="p-footer__tel" href="tel:03-xxxx-xxxx" translate="no">03-xxxx-xxxx</a><br />
             営業時間: 10:00〜20:00（最終受付 19:00）<br />
             定休日: 毎週水曜日
           </address>

--- a/src/index.html
+++ b/src/index.html
@@ -713,7 +713,7 @@
           <!-- CUSTOMIZE: 住所・電話番号・営業時間を差し替え -->
           <address class="p-footer__address">
             〒xxx-xxxx 東京都渋谷区○○ x-x-x ○○ビル 3F<br />
-            <a class="p-footer__tel" href="tel:03-xxxx-xxxx" translate="no">TEL: 03-xxxx-xxxx</a><br />
+            <a class="p-footer__tel" href="tel:03-xxxx-xxxx" translate="no">03-xxxx-xxxx</a><br />
             営業時間: 10:00〜20:00（最終受付 19:00）<br />
             定休日: 毎週水曜日
           </address>

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -186,7 +186,7 @@
           <!-- CUSTOMIZE: 住所・電話番号・営業時間を差し替え -->
           <address class="p-footer__address">
             〒xxx-xxxx 東京都渋谷区○○ x-x-x ○○ビル 3F<br />
-            <a class="p-footer__tel" href="tel:03-xxxx-xxxx" translate="no">TEL: 03-xxxx-xxxx</a><br />
+            <a class="p-footer__tel" href="tel:03-xxxx-xxxx" translate="no">03-xxxx-xxxx</a><br />
             営業時間: 10:00〜20:00（最終受付 19:00）<br />
             定休日: 毎週水曜日
           </address>


### PR DESCRIPTION
## 概要

`<a class="p-footer__tel">` の表示テキストから「TEL: 」プレフィックスを削除する。モダン UX のベストプラクティス（リンクテキスト最小化、`<a href="tel:...">` で電話リンクと推測可能）に整合。

## 変更内容

- `src/index.html` / `src/404.html` / `src/privacy/index.html` の `p-footer__tel` 表示から「TEL: 」削除
- href（`tel:03-xxxx-xxxx`）は変更なし
- a11y: `<a href="tel:...">` でスクリーンリーダーは「電話する」と認識、WCAG 2.4.4 はコンテキストで OK

## 関連

- wp-starter 整合化 PR（並行）: footer.php に prepend なし + 営業時間 / 定休日 対応
- セッション 34: starter / wp-starter 整合化（モダン UX ベストプラクティス採用）