### PR TITLE
docs(v1.2): README/CONTRIBUTING に 404 ページの動作確認セクション追加（Issue #198 補完）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,5 +20,6 @@ mFLOCSS starter の変更履歴。[Keep a Changelog](https://keepachangelog.com/
 - Community health files（CHANGELOG / CONTRIBUTING / SECURITY / CODE_OF_CONDUCT）
 - GitHub Actions CI（starter 本体のみ発動、Fork / Clone 時は自動 skip）
 - Issue テンプレート（bug report / feature request）
+- ローカル `npm run preview` での 404 fallback 動作（`vite.config.ts` の `preview-404-fallback` plugin により本番ホスティング動作を完全再現、教材性向上）
 
 [Unreleased]: https://github.com/mflocss/starter/compare/v1.0.0...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,8 @@ Node.js LTS 以降を推奨。
 2. ブランチ名: `feat/` `fix/` `refactor/` `chore/` `docs/` のいずれか + 短い要約
 3. commit message: `type(scope): subject`（日本語 OK、例: `fix(c-form): focus-visible でリング温存`）
 4. PR 作成前に `pnpm run check` + `pnpm run build` 通過確認
-5. PR body に変更理由・spec 参照節・動作確認項目を記載
+5. PR 作成前に `pnpm run preview` で動作確認（404 ページの fallback 含む。詳細は [README.md「404 ページの動作確認」](./README.md#404-ページの動作確認) 参照）
+6. PR body に変更理由・spec 参照節・動作確認項目を記載
 
 ## コード規約
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,26 @@ base: '/my-site/',
 
 納品前にプロジェクト全体で `CUSTOMIZE` を検索し、差し替え忘れがないことを確認してください。
 
+### 404 ページの動作確認
+
+`src/404.html` は本番ホスティングで存在しないパスにアクセスされた際の Not Found ページです。動作確認方法は以下の 3 通り:
+
+| 確認方法 | URL | 期待動作 |
+|---------|-----|---------|
+| 本番ホスティング | `https://example.com/nonexistent` | ホスティング側が `404.html` を **HTTP 404** で自動配信 |
+| ローカル preview | `http://localhost:4173/nonexistent` | `vite.config.ts` の preview-404-fallback plugin が `404.html` を **HTTP 404** で配信 |
+| 直接アクセス（内容確認） | `http://localhost:4173/404.html` | `404.html` が **HTTP 200** で配信（デザイン確認用） |
+
+ローカル動作確認の手順:
+
+```bash
+npm run build
+npm run preview
+# 別タブで http://localhost:4173/nonexistent にアクセス
+```
+
+本番側は **Cloudflare Pages / Netlify / Vercel / GitHub Pages のいずれも `dist/404.html` を root に配置するだけで自動配信**します（追加設定ファイル不要）。ローカル `npm run preview` でも同じ動作を再現するため `vite.config.ts` に `preview-404-fallback` plugin を含めています。
+
 ## リファレンス
 
 ### コマンド一覧


### PR DESCRIPTION
## 概要

Issue #198「preview server 404 fallback 追加 + 404 動作の README 明記」の **README/CONTRIBUTING ドキュメント補完** PR。

`vite.config.ts` の `preview-404-fallback` plugin 実装は **PR #199（feat）+ PR #200（hotfix）で v1.2 にマージ済**。一方で Issue #198 の完了条件のうち **「README または CONTRIBUTING に 404 動作明記」が未完遂** だった（PR #199 body には記載があったが実 commit には含まれていない partial misreport パターン）ため、本 PR で補完する。

## 検出経緯

- PR #199 changed files = `vite.config.ts` のみ（`gh pr view 199 --json files` で確認）
- README.md / CONTRIBUTING.md grep で 404 動作確認に関する記述ゼロを確認
- Issue #198 が `state: OPEN` のまま残っており、ドキュメント補完が必要と判定

## 変更内容

### `README.md`

「ビルドと納品」セクション末尾に **「404 ページの動作確認」サブセクション** を追加:

- 本番ホスティング（Cloudflare Pages / Netlify / Vercel / GitHub Pages いずれも root の `404.html` を自動配信）
- ローカル preview（`vite.config.ts` の `preview-404-fallback` plugin が再現）
- 直接アクセス（`/404.html` でデザイン確認）

### `CONTRIBUTING.md`

「基本フロー」に `pnpm run preview` での動作確認手順を追加し、README の「404 ページの動作確認」セクションへ相対リンク。

### `CHANGELOG.md`

`## [Unreleased]` の Added に preview-404-fallback plugin の動作を追記（PR #199 / #200 で更新漏れていた分の補完）。

## 動作確認

`npm run build && npm run preview` 後:

| URL | 期待 | 実測 |
|-----|------|------|
| `/` | 200 | ✅ 200 |
| `/privacy/` | 200 | ✅ 200 |
| `/nonexistent` | 404 | ✅ 404 |
| `/nonexistent/deep` | 404 | ✅ 404（既存 plugin 動作） |
| `/404.html`（直接） | 200 | ✅ 200 |
| `/assets/notfound.css` | 404 | ✅ 404 |

`pnpm run build` ✅ PASS

## AR レポート

### スコープ

- **B 段階（周辺 8 軸）**: 軽量 AR（README + CONTRIBUTING + CHANGELOG の数行追記のみ、新規ロジック無し）
- **completeness-criteria 観点段階**: 🟠 Guardian（変更完全性 / 情報公開範囲）+ 🟢 Essential（教材性 / ドキュメント整合）
- **リリース前 7 条件**: 該当（v1.0 P0 リリース判定の必須要件、Issue #198 完了に直結）

### チェック結果

| 観点 | 判定 | 根拠 |
|------|------|------|
| 🟠 変更完全性 | ✅ | Issue #198 完了条件のうち未完遂分（README/CONTRIBUTING 明記）を全て満たす |
| 🟠 情報公開範囲 | ✅ | パブリック情報のみ。秘密情報・内部 URL なし |
| 🟢 教材性 | ✅ | template 利用者（README）+ contributor（CONTRIBUTING）両者向けに 3 確認パターンを表形式で提示 |
| 🟢 事実の妥当性 | ✅ | Cloudflare Pages / Netlify / Vercel / GitHub Pages 4 社とも root の `404.html` 自動配信は公式仕様（一次ソース確認済） |
| 🟢 既存実装との整合 | ✅ | `vite.config.ts` の plugin 名 `preview-404-fallback` を文書側で正確に参照 |
| 🟢 npm/pnpm 表記の整合 | ✅ | README は npm 表記基本（既存方針）、CONTRIBUTING は pnpm 表記（contributor 開発環境） |
| 🟢 リンク整合 | ✅ | CONTRIBUTING → README#404-ページの動作確認 アンカー有効（GitHub flavored markdown 仕様、日本語アンカー対応） |
| ⚪ ブラウザ互換 | N/A | ドキュメントのみの変更 |

### 副次的 bug 検出

- なし

## 関連

Closes #198

- 既存実装: PR #199（feat） + PR #200（hotfix）
- 親方針: v1.0 一斉リリース P0 残課題
- 過去経緯: セッション 33 観察ログ「動作確認できない実装は教材性低い」（しゅんえい判断 2026-05-01）

🤖 Generated with [Claude Code](https://claude.com/claude-code)