### PR TITLE
fix(starter): theme-color 削除 + lightningcss transformer/minifier 切替 + 手動 prefix 削除 + stylelint 簡素化

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -17,9 +17,6 @@
     <!-- CUSTOMIZE: ダークモード不要なら content="light" に -->
     <meta name="color-scheme" content="light dark" />
     <meta name="robots" content="noindex,follow" />
-    <!-- CUSTOMIZE: token/color.css のメインカラーに合わせて変更（ライト / ダークそれぞれ指定） -->
-    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#5b7a5e" />
-    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#1a2e1f" />
     <!-- Styles -->
     <link rel="stylesheet" href="/assets/css/style.css" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />

--- a/src/assets/css/reset/reset.css
+++ b/src/assets/css/reset/reset.css
@@ -11,7 +11,6 @@
   line-break: strict;
   overflow-wrap: anywhere;
   text-autospace: normal;
-  -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
   -webkit-tap-highlight-color: transparent;
 

--- a/src/index.html
+++ b/src/index.html
@@ -12,9 +12,6 @@
     <meta name="format-detection" content="telephone=no,address=no,email=no" />
     <!-- CUSTOMIZE: ダークモード不要なら content="light" に -->
     <meta name="color-scheme" content="light dark" />
-    <!-- CUSTOMIZE: token/color.css のメインカラーに合わせて変更（ライト / ダークそれぞれ指定） -->
-    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#5b7a5e" />
-    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#1a2e1f" />
     <!-- OGP -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="iluha — からだの声を、聴く時間。" />

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -12,9 +12,6 @@
     <meta name="format-detection" content="telephone=no,address=no,email=no" />
     <!-- CUSTOMIZE: ダークモード不要なら content="light" に -->
     <meta name="color-scheme" content="light dark" />
-    <!-- CUSTOMIZE: token/color.css のメインカラーに合わせて変更（ライト / ダークそれぞれ指定） -->
-    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#5b7a5e" />
-    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#1a2e1f" />
     <!-- OGP -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="プライバシーポリシー — iluha" />

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -6,11 +6,5 @@ export default {
     'custom-property-pattern': '^([a-z][a-z0-9]*(-[a-z0-9]+)*|_[a-z0-9]+(-[a-z0-9]+)*)$',
     'at-rule-no-unknown': [true, { ignoreAtRules: ['layer'] }],
     'import-notation': 'string',
-    'property-no-vendor-prefix': [
-      true,
-      {
-        ignoreProperties: ['text-size-adjust', '-webkit-text-size-adjust', '-webkit-tap-highlight-color'],
-      },
-    ],
   },
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,12 @@ export default defineConfig({
   // CUSTOMIZE: サブディレクトリにデプロイする場合はパスを変更（例: '/my-site/'）
   base: '/',
 
+  css: {
+    transformer: 'lightningcss',
+  },
+
   build: {
+    cssMinify: 'lightningcss',
     rolldownOptions: {
       // CUSTOMIZE: ページの追加・削除時にエントリを更新
       input: {
@@ -46,10 +51,7 @@ export default defineConfig({
             // 既存ファイル / ディレクトリが存在する場合は Vite に処理を委譲する
             // 候補 1: dist/{url}（静的ファイル直接 or ディレクトリ）
             // 候補 2: dist/{url}/index.html（ディレクトリ配下の index.html）
-            const candidates = [
-              resolve(distDir, url.slice(1)),
-              resolve(distDir, url.slice(1), 'index.html'),
-            ];
+            const candidates = [resolve(distDir, url.slice(1)), resolve(distDir, url.slice(1), 'index.html')];
 
             for (const candidate of candidates) {
               if (fs.existsSync(candidate)) {


### PR DESCRIPTION
## Summary

3 件の整合的な変更を統合した atomic PR:

1. **theme-color media attribute 削除** (Baseline 未達 + fallback 不能、書籍 v1.0 scope 純化と連動)
2. **lightningcss transformer/minifier 切替** (autoprefixer 内蔵 → 手動 prefix 不要 + build 高速化)
3. **手動 prefix 削除 + stylelint 簡素化** (lightningcss 連動の cascade 整合)

## 変更詳細

### theme-color 削除 (6 行 × 3 ページ = 9 行)
- \`src/index.html\` L15-17: CUSTOMIZE コメント 1 行 + theme-color meta 2 行 削除
- \`src/privacy/index.html\` L15-17: 同 3 行
- \`src/404.html\` L20-22: 同 3 行

### lightningcss 切替 (\`vite.config.ts\`)
- \`css.transformer: 'lightningcss'\` 追加 (CSS transformation 担当 = autoprefixer 内蔵)
- \`build.cssMinify: 'lightningcss'\` 追加 (CSS minification 統合)

### 手動 prefix 削除 (\`src/assets/css/reset/reset.css\`)
- \`-webkit-text-size-adjust: 100%;\` 削除 (lightningcss autoprefixer が自動生成)

### stylelint 簡素化 (\`stylelint.config.mjs\`)
- \`property-no-vendor-prefix\` rule + \`ignoreProperties\` 配列 削除 (lightningcss が prefix 管理 = 手動除外不要)

## theme-color 削除理由

1. **Baseline 未達**: Firefox 未対応 / Chrome は PWA インストール時のみ動作
2. **fallback 不能**: field-sizing / text-spacing-trim と異なり @supports 等の進化的採用が無理
3. **動作確認不能**: Safari macOS/iOS のみ確認可能 → 教材として価値低い
4. **mFLOCSS thesis 外**: HTML meta、CSS 設計判断「どこに書くか」軸ではない
5. **連動**: 書籍 v1.0 scope 純化（2026-05-19 確定）と整合

## lightningcss 切替理由

- **modern target 方針整合**: modern CSS fallback 不要方針を確立済
- **autoprefixer 内蔵**: 手動 prefix 不要 → stylelint 設定簡素化 cascade
- **Rust 製で build 高速化**: CSS transform + minify 統合 = 1 step
- **Vite 5+/6+ 公式サポート**: production-ready

## Test plan

- [x] grep -rn \"theme-color\" src/ で残存なし確認
- [x] pnpm build 成功確認 (built in 70ms)
- [x] grep -rn \"theme-color\" dist/ で残存なし確認 (build artifact 反映)
- [ ] codex review clean
- [ ] v1.2 マージ → main は一斉マージ (PR #83) で処理

## 関連

- 書籍 v1.0 scope 純化（2026-05-19 確定）と連動
- v1.2 dev branch incremental fix (一斉マージ計画 PR #83 とは別タイミング、本 PR は v1.2 内で先に統合)

🤖 Generated with [Claude Code](https://claude.com/claude-code)