### PR TITLE
fix: 実案件で本番検証済みのバグ 3 件を反映（viewport / c-button / formSelector）

### DIFF
--- a/public/scripts/viewport.js
+++ b/public/scripts/viewport.js
@@ -23,7 +23,9 @@ const meta = document.querySelector('meta[name="viewport"]');
 
 function updateViewport() {
   const value = window.outerWidth > VIEWPORT_MIN ? 'device-width' : String(VIEWPORT_MIN);
-  const content = `width=${value},initial-scale=1`;
+  // 固定幅時は initial-scale=1 を省略する。
+  // initial-scale=1 を付与すると 390px 端末等で約 10px の横スクロールが発生する。
+  const content = value === 'device-width' ? `width=${value},initial-scale=1` : `width=${value}`;
   if (meta.content !== content) {
     meta.content = content;
   }

--- a/src/assets/css/component/c-button.css
+++ b/src/assets/css/component/c-button.css
@@ -38,6 +38,7 @@
   }
 
   &:active {
+    opacity: 0.8;
     translate: 0 0;
   }
 

--- a/src/assets/scripts/main.js
+++ b/src/assets/scripts/main.js
@@ -202,10 +202,10 @@ function initBackToTop(options = {}) {
  * フォームバリデーション a11y を初期化する（HTML5 制約検証 + role="alert" 動的表示）。
  * フォームに novalidate が必要（ブラウザネイティブ tooltip を抑制して JS で制御）。
  * @param {Object} [options] - カスタマイズオプション
- * @param {string} [options.formSelector='.c-form'] - 対象フォームのセレクタ
+ * @param {string} [options.formSelector='[data-validate]'] - 対象フォームのセレクタ。JS フックは data-* 属性で指定する（スタイルクラスとの分離）
  */
 function initFormValidation(options = {}) {
-  const { formSelector = '.c-form' } = options;
+  const { formSelector = '[data-validate]' } = options;
   const forms = document.querySelectorAll(formSelector);
   if (forms.length === 0) return;
 
@@ -294,4 +294,5 @@ initFormValidation();
 // initStagger({ delayStep: 0.15 });
 // initScrollAnimation({ threshold: 0.3, rootMargin: '0px 0px -100px 0px' });
 // initBackToTop({ threshold: 500 });
-// initFormValidation({ formSelector: '#my-form' });
+// initFormValidation({ formSelector: '[data-validate]' });
+// initFormValidation({ formSelector: '.c-form' }); // クラスセレクタ（旧方式）も引き続き使用可

--- a/src/index.html
+++ b/src/index.html
@@ -620,7 +620,7 @@
           <p class="p-contact__lead">下記フォームからお気軽にどうぞ。24時間以内に折り返しご連絡いたします。</p>
 
           <!-- CUSTOMIZE: 本番バックエンド URL に差し替え。starter はフォーム送信処理を提供しません -->
-          <form class="c-form p-contact__form" action="/api/contact" method="post" novalidate>
+          <form class="c-form p-contact__form" action="/api/contact" method="post" novalidate data-validate>
             <p class="c-form__note"><span aria-hidden="true">*</span> のついた項目は必須です</p>
             <div class="c-form__field">
               <label class="c-form__label" for="name">お名前</label>


### PR DESCRIPTION
## 背景

mFLOCSS starter 派生 WordPress テーマの実案件における ConoHa 本番環境 + iPhone 16e 実機検証で発見・実証済みの構造的バグを starter に反映する。

---

## 変更一覧（5 件中 3 件反映・2 件 skip）

### ✅ #1 viewport.js — 固定幅時の `initial-scale=1` 除去

**問題**: 固定幅モードで `width=400,initial-scale=1` を設定すると、390px 端末（iPhone 16e 等）で約 10px の横スクロールが発生する。

**修正**: 固定幅時（`value !== 'device-width'`）は `initial-scale=1` を省略する。

```js
// Before
const content = `width=${value},initial-scale=1`;

// After
const content = value === 'device-width' ? `width=${value},initial-scale=1` : `width=${value}`;
```

---

### ✅ #4 c-button.css — タッチ端末の押下フィードバック追加

**問題**: `:hover` は `@media (any-hover: hover)` でタッチ端末無効、かつ reset の `-webkit-tap-highlight-color: transparent` でデフォルト青ハイライトも消えているため、タッチ時に視覚変化が一切ない。

**修正**: `:active` に `opacity: 0.8` を追加（Component 層責任境界を守った最小限の変更）。

---

### ✅ #5 initFormValidation — CSS クラスから `data-*` フック規約へ移行

**問題**: `formSelector = '.c-form'`（スタイルクラス）は starter の `data-*` JS フック規約（`[data-drawer]`, `[data-animate]`, `[data-back-to-top]` 等）と不整合。iOS の `<select required>` ネイティブ検証が無反応に見える原因でもある。

**修正**:
- `formSelector` デフォルトを `'[data-validate]'` に変更
- `src/index.html` の `<form>` に `data-validate` 属性を追加
- CUSTOMIZE コメントに旧方式（`.c-form`）の後方互換ガイドを追記

---

### ⏭ #2 eslint.config.mjs — skip

starter の `files` は既に `'public/**/*.js'` で `public/scripts/` をカバー済み（派生テーマ側は `src/assets/scripts/**/*.js` のみだったため追加が必要だった）。

### ⏭ #3 main.js no-useless-assignment — skip

starter の `main.js` にはタブ keydown ハンドラが存在せず `let targetIndex = null;` 自体が不在（派生テーマ側は独自機能を追加していた）。

---

## 検証

- `pnpm run lint:js` — エラーなし
- `npx eslint "public/scripts/**/*.js"` — エラーなし
- `pnpm run lint:css` — エラーなし

## テスト計画

- [ ] viewport.js: 390px 幅でのシミュレーションで横スクロールなしを確認
- [ ] c-button: タッチシミュレーション（devtools）で `:active` 時 opacity 変化を確認
- [ ] formValidation: フォームにカーソルを当て `[data-validate]` セレクタで validation が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)