### PR TITLE
fix(viewport): コメント magic number 除去・抽象化（PR #209 follow-up）

### DIFF
--- a/public/scripts/viewport.js
+++ b/public/scripts/viewport.js
@@ -23,8 +23,7 @@ const meta = document.querySelector('meta[name="viewport"]');
 
 function updateViewport() {
   const value = window.outerWidth > VIEWPORT_MIN ? 'device-width' : String(VIEWPORT_MIN);
-  // 固定幅時は initial-scale=1 を省略する。
-  // initial-scale=1 を付与すると 390px 端末等で約 10px の横スクロールが発生する。
+  // 固定幅指定時は initial-scale を併記しない（一部端末で横スクロールを誘発するため）
   const content = value === 'device-width' ? `width=${value},initial-scale=1` : `width=${value}`;
   if (meta.content !== content) {
     meta.content = content;


### PR DESCRIPTION
## 概要

PR #209 で追加した viewport.js のコメントから付随的な magic number を除去し、本質のみに抽象化する。

## 変更内容

### Before
```javascript
// 固定幅時は initial-scale=1 を省略する。
// initial-scale=1 を付与すると 390px 端末等で約 10px の横スクロールが発生する。
```

### After
```javascript
// 固定幅指定時は initial-scale を併記しない（一部端末で横スクロールを誘発するため）
```

## 修正理由

- `390px` / `約10px` は付随的な測定値（比較対象不明 / 端末依存 / 将来矛盾の種）
- コメント責任境界原則: 本質（固定幅指定 + initial-scale 併記 = 横スクロール誘発）のみを記述
- 2 行を 1 行に統合することで冗長性も解消

## 検証

- コードロジック（ternary 本体）変更なし（`git diff` で確認済み）
- コメントのみ変更（1 insertion, 2 deletions）

## AR

本変更はコメント文字列のみの修正（コードロジック・公開 API・セマンティクス変更なし）。
completeness-criteria 観点: AR 不要（誤字脱字・フォーマット修正相当の軽微変更）。

## 関連

- 先行 PR: #209