### PR TITLE
refactor(assets): viewport.js を public/assets/scripts/ に移動し dist 出力階層を統一

### DIFF
--- a/CODING_GUIDE.md
+++ b/CODING_GUIDE.md
@@ -64,9 +64,21 @@ npm run preview
 
 本番側は **Cloudflare Pages / Netlify / Vercel / GitHub Pages のいずれも `dist/404.html` を root に配置するだけで自動配信**します（追加設定ファイル不要）。ローカル `npm run preview` でも同じ動作を再現するため `vite.config.ts` に `preview-404-fallback` plugin を含めています。
 
+## アセット配置規約
+
+mFLOCSS starter family（static starter / wordpress-starter）共通の配置基準です。
+
+| 対象 | 配置先 | 理由 |
+|------|--------|------|
+| favicon / OGP / robots.txt / sitemap.xml | `public/` 直下 | ルートパス固定が必要な静的ファイル |
+| viewport.js 等の非バンドル JS | `public/assets/scripts/` | `src/assets/scripts/` と階層を対称に揃えつつ非バンドル維持 |
+| WP テーマメタファイル（style.css メタ / screenshot.png）| theme root | wordpress-starter のみ該当（静的 starter では不要） |
+
+Vite は `publicDir`（= `public/`）配下のファイルをそのまま `dist/` へコピーします。`public/assets/scripts/` に置くことで `dist/assets/scripts/` に出力され、バンドル対象の `src/assets/scripts/` の出力先と階層が一致します。
+
 ## ブレークポイント値の CSS/JS 同期
 
-`public/scripts/viewport.js` の `VIEWPORT_MIN` は、`token/structure.css` の `--viewport-min` と同じ値に合わせてください。この値を変更する場合は両方を更新する必要があります。CSS と JS の基準値を一致させることで、400px 未満の端末でもレイアウト崩れを防ぎ、変更時の修正漏れを防止できます。
+`public/assets/scripts/viewport.js` の `VIEWPORT_MIN` は、`token/structure.css` の `--viewport-min` と同じ値に合わせてください。この値を変更する場合は両方を更新する必要があります。CSS と JS の基準値を一致させることで、400px 未満の端末でもレイアウト崩れを防ぎ、変更時の修正漏れを防止できます。
 
 ## ドロワー（p-drawer / c-overlay）
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ src/
 ├── privacy/index.html     # プライバシーポリシー
 └── 404.html               # 404 ページ（カスタマイズして使う）
 public/                    # ルートパス固定のファイル
-├── scripts/
-│   └── viewport.js        # ビューポート幅制御（--viewport-min 未満の端末向け）
+├── assets/
+│   └── scripts/
+│       └── viewport.js    # ビューポート幅制御（--viewport-min 未満の端末向け）
 ├── favicon.svg
 ├── favicon.ico
 ├── apple-touch-icon.png

--- a/public/assets/scripts/viewport.js
+++ b/public/assets/scripts/viewport.js
@@ -14,7 +14,7 @@
  * CUSTOMIZE:
  * - VIEWPORT_MIN の値は token/structure.css の `--viewport-min` と必ず一致させる
  * - 最小幅制限が不要なサイト（全幅でレスポンシブ対応済み）は
- *   <script src="/scripts/viewport.js"> および ResizeObserver ごと削除可
+ *   <script src="/assets/scripts/viewport.js"> および ResizeObserver ごと削除可
  */
 
 // CUSTOMIZE: must match --viewport-min in token/structure.css

--- a/src/404.html
+++ b/src/404.html
@@ -24,7 +24,7 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <!-- Scripts -->
     <script type="module" src="/assets/scripts/main.js"></script>
-    <script src="/scripts/viewport.js"></script>
+    <script src="/assets/scripts/viewport.js"></script>
   </head>
   <body id="top" class="l-page">
     <!-- Skip Link -->

--- a/src/index.html
+++ b/src/index.html
@@ -51,7 +51,7 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <!-- Scripts -->
     <script type="module" src="/assets/scripts/main.js"></script>
-    <script src="/scripts/viewport.js"></script>
+    <script src="/assets/scripts/viewport.js"></script>
 
     <!-- CUSTOMIZE: 構造化データの各値を本番情報に差し替え -->
     <script type="application/ld+json">

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -42,7 +42,7 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <!-- Scripts -->
     <script type="module" src="/assets/scripts/main.js"></script>
-    <script src="/scripts/viewport.js"></script>
+    <script src="/assets/scripts/viewport.js"></script>
 
     <!-- CUSTOMIZE: 構造化データの URL を本番 URL に差し替え -->
     <script type="application/ld+json">


### PR DESCRIPTION
## Summary

- `public/scripts/viewport.js` → `public/assets/scripts/viewport.js` へ移動し、ビルド出力を `dist/assets/scripts/viewport.js` に統一（`src/assets/scripts/main.js` の出力先と階層対称）
- HTML 3 件（`src/index.html` / `src/privacy/index.html` / `src/404.html`）の `script src` を `/assets/scripts/viewport.js` に更新（片落ちなし）
- `viewport.js` 内 CUSTOMIZE コメントのパス参照を更新
- `README.md` のファイル構成ツリーを更新
- `CODING_GUIDE.md` にアセット配置規約（mFLOCSS starter family 共通）を新設

## 背景

`public/scripts/viewport.js` → `dist/scripts/` vs `src/assets/scripts/main.js` → `dist/assets/scripts/` の非対称が問題（starter#212）。`public/assets/scripts/` に移すことで unbundled・安定 URL を維持したまま出力階層を統一。

## アセット配置規約（新設）

CODING_GUIDE.md に以下の規約を明文化（family 共通）:

| 対象 | 配置先 |
|------|--------|
| favicon / OGP / robots.txt / sitemap.xml | `public/` 直下 |
| viewport.js 等の非バンドル JS | `public/assets/scripts/` |
| WP テーマメタファイル（style.css メタ / screenshot.png） | theme root（wordpress-starter のみ） |

## 検証済み

- `pnpm run build` 実行 → `dist/assets/scripts/viewport.js` 生成確認 ✅
- 旧 `dist/scripts/viewport.js` 消滅確認 ✅
- 旧パス `/scripts/viewport.js` grep で残件なし ✅
- AR 実施済み（変更 6 ファイル全件確認、レポートファイルはリポに含まず）

## AR 結果

- 必須修正: なし
- 推奨修正: なし

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)