### PR TITLE
refactor: JS フックのスタイルクラス参照を排除（data-* / 直接セレクタに統一）

### DIFF
--- a/CODING_GUIDE.md
+++ b/CODING_GUIDE.md
@@ -141,6 +141,23 @@ Drawer と Hamburger トリガー**以外**の、フォーカス可能（= Tab �
 
 `querySelectorAll('[data-drawer-inert]')` で全対象要素を取得 → `openDrawer` で `inert` 属性付与、`closeDrawer` で削除するだけ。新規対象を追加しても JS 側の変更は不要です。
 
+## JS フックの分離
+
+JS で DOM 要素を取得する際は **`data-*` 属性** または **ID 等の直接セレクタ** を使います。スタイルクラス（`c-` / `p-` / `l-` / `u-` プレフィックス）を JS フックに使ってはいけません。
+
+```js
+// ✅ data-* 属性（推奨）
+document.querySelectorAll('[data-validate]');
+
+// ✅ ID 直接指定
+document.querySelector('#contact-form');
+
+// ❌ スタイルクラスを JS フックに使用（禁止）
+document.querySelectorAll('.c-form');
+```
+
+**理由**: スタイルクラスは CSS 設計の都合で変更・削除されることがあります。JS フックにスタイルクラスを使うと、デザイン変更が JS バグに直結します（スタイルと挙動の結合）。`data-*` 属性はスタイルとは独立しており、HTML の意味を壊さずに JS の選択対象を明示できます。
+
 ## コミットメッセージ
 
 prefix で変更の種類を明示し、タイトルで変更の影響を日本語で伝えます。git log を一覧したときに「何が変わったか」が即座に分かり、差し戻しや cherry-pick の判断コストを削減できます。

--- a/src/assets/scripts/main.js
+++ b/src/assets/scripts/main.js
@@ -294,5 +294,5 @@ initFormValidation();
 // initStagger({ delayStep: 0.15 });
 // initScrollAnimation({ threshold: 0.3, rootMargin: '0px 0px -100px 0px' });
 // initBackToTop({ threshold: 500 });
-// initFormValidation({ formSelector: '[data-validate]' });
-// initFormValidation({ formSelector: '.c-form' }); // クラスセレクタ（旧方式）も引き続き使用可
+// initFormValidation({ formSelector: '[data-validate]' }); // data 属性で指定（推奨）
+// initFormValidation({ formSelector: '#contact-form' }); // ID で直接指定


### PR DESCRIPTION
## Summary

- `main.js` の CUSTOMIZE 例から `.c-form`（スタイルクラス）を JS フックに使う例と「旧方式も引き続き使用可」という容認コメントを削除
- `[data-validate]`（data 属性）と `#contact-form`（ID 直接指定）の 2 方式の例に差し替え
- `CODING_GUIDE.md` に「JS フックの分離」節を追加（スタイルクラスをフックに使わない理由 + ✅/❌ コード例）

## 背景

スタイルクラス（`c-` / `p-` 等）を JS セレクタに使うと、デザイン変更が JS バグに直結するアンチパターン。旧方式の例が CUSTOMIZE コメントに残っており、アンチパターンを容認する記述になっていた。

実コード（`initDrawer` / `initScrollAnimation` / `initFormValidation` 等）はすでに `[data-*]` ベースで問題なし。今回は **コメント例とドキュメントのみの修正**。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/assets/scripts/main.js` | CUSTOMIZE 例コメント 2 行を差し替え（スタイルクラス例 → data 属性 / ID 例）|
| `CODING_GUIDE.md` | 「JS フックの分離」節を追加（17 行）|

## Test plan

- [x] `git grep -nE "['\"\`]\.(c-|p-|l-|u-)" -- 'src/**/*.js'` → 0 件（スタイルクラス参照なし）
- [x] AR 評価（B 段階）: 目的達成 / コメント最小限 / CODING_GUIDE 既存様式整合

> base: `v1.2` ← `refactor/js-hook-separation`（`main` ではない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)