### PR TITLE
chore: formSelector JSDoc から原則説明句を削除（CODING_GUIDE に既述）

### DIFF
--- a/src/assets/scripts/main.js
+++ b/src/assets/scripts/main.js
@@ -202,7 +202,7 @@ function initBackToTop(options = {}) {
  * フォームバリデーション a11y を初期化する（HTML5 制約検証 + role="alert" 動的表示）。
  * フォームに novalidate が必要（ブラウザネイティブ tooltip を抑制して JS で制御）。
  * @param {Object} [options] - カスタマイズオプション
- * @param {string} [options.formSelector='[data-validate]'] - 対象フォームのセレクタ。JS フックは data-* 属性で指定する（スタイルクラスとの分離）
+ * @param {string} [options.formSelector='[data-validate]'] - 対象フォームのセレクタ
  */
 function initFormValidation(options = {}) {
   const { formSelector = '[data-validate]' } = options;


### PR DESCRIPTION
## 概要

`src/assets/scripts/main.js` の `initFormValidation` — `@param formSelector` JSDoc に付いていた原則説明句を削除する。

### 変更前
```js
 * @param {string} [options.formSelector='[data-validate]'] - 対象フォームのセレクタ。JS フックは data-* 属性で指定する（スタイルクラスとの分離）
```

### 変更後
```js
 * @param {string} [options.formSelector='[data-validate]'] - 対象フォームのセレクタ
```

## 理由

- **一貫性**: drawer / animate / stagger / back-to-top など他の `data-*` フックには同様コメントが存在しない。`formSelector` だけ one-off で記述されており一貫性がない。
- **冗長性**: 同原則は `CODING_GUIDE.md` §「JS フックの分離」（L144）に明文化済み。インラインへの重複記述は不要。

## スコープ

- コード挙動・デフォルト値に変更なし（JSDoc コメントのみ）
- `CODING_GUIDE.md` は変更しない（原則の正典はそちら）

## AR 観点

- 変更内容: コメント 1 行の trim のみ
- コード不変: `formSelector = '[data-validate]'` デフォルト値・ロジック変更なし
- 対象範囲: `completeness-criteria` 観点で B 段階（コメント整合）、必須修正なし
- リリース前 7 条件: 非該当（コード挙動変更なし、コメントのみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)