### PR TITLE
refactor: JS フック data-* 統一 + dist/assets 構成整理（vite.config 出力命名設定）

### DIFF
--- a/CODING_GUIDE.md
+++ b/CODING_GUIDE.md
@@ -143,14 +143,11 @@ Drawer と Hamburger トリガー**以外**の、フォーカス可能（= Tab �
 
 ## JS フックの分離
 
-JS で DOM 要素を取得する際は **`data-*` 属性** または **ID 等の直接セレクタ** を使います。スタイルクラス（`c-` / `p-` / `l-` / `u-` プレフィックス）を JS フックに使ってはいけません。
+JS で DOM 要素を取得する際は **`data-*` 属性** を使います。スタイルクラス（`c-` / `p-` / `l-` / `u-` プレフィックス）を JS フックに使ってはいけません。
 
 ```js
-// ✅ data-* 属性（推奨）
+// ✅ data-* 属性で JS フック
 document.querySelectorAll('[data-validate]');
-
-// ✅ ID 直接指定
-document.querySelector('#contact-form');
 
 // ❌ スタイルクラスを JS フックに使用（禁止）
 document.querySelectorAll('.c-form');

--- a/src/assets/scripts/main.js
+++ b/src/assets/scripts/main.js
@@ -294,5 +294,4 @@ initFormValidation();
 // initStagger({ delayStep: 0.15 });
 // initScrollAnimation({ threshold: 0.3, rootMargin: '0px 0px -100px 0px' });
 // initBackToTop({ threshold: 500 });
-// initFormValidation({ formSelector: '[data-validate]' }); // data 属性で指定（推奨）
-// initFormValidation({ formSelector: '#contact-form' }); // ID で直接指定
+// initFormValidation({ formSelector: '[data-validate]' });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,9 +17,19 @@ export default defineConfig({
     rolldownOptions: {
       // CUSTOMIZE: ページの追加・削除時にエントリを更新
       input: {
-        main: resolve(__dirname, 'src/index.html'),
+        index: resolve(__dirname, 'src/index.html'),
         privacy: resolve(__dirname, 'src/privacy/index.html'),
         notFound: resolve(__dirname, 'src/404.html'),
+      },
+      output: {
+        assetFileNames: (assetInfo) => {
+          if (assetInfo.names?.some((n) => n.endsWith('.css'))) {
+            return 'assets/css/[name][extname]';
+          }
+          return 'assets/[name][extname]';
+        },
+        entryFileNames: 'assets/scripts/[name].js',
+        chunkFileNames: 'assets/scripts/[name].js',
       },
     },
     outDir: resolve(__dirname, 'dist'),


### PR DESCRIPTION
## 背景

- JS フックの規約を `data-*` 属性に統一（ID/直接セレクタ例を除去）
- dist/assets の JS が `main.js`/`viewport.js` でフォルダ分裂していた問題を解消（wp-starter に合わせる）

## 変更内容

### 1. `src/assets/scripts/main.js` — CUSTOMIZE 例を data-* 単一に

`initFormValidation` の CUSTOMIZE 例から ID 直接指定行を削除し、`[data-validate]` の1例のみに統一。

### 2. `CODING_GUIDE.md` — 「JS フックの分離」節を data-* 単一規約に

- `✅ ID 直接指定` の例（`#contact-form`）を削除
- 冒頭の説明文から「または ID 等の直接セレクタ」を除去
- `✅ data-*` と `❌ スタイルクラス` の2例構成に整理

### 3. `vite.config.ts` — rolldownOptions.output を設定

wp-starter の vite.config.ts を canonical として合わせた:

```
output: {
  assetFileNames: CSS → assets/css/[name][extname] / その他 → assets/[name][extname]
  entryFileNames: assets/scripts/[name].js
  chunkFileNames: assets/scripts/[name].js
}
```

また input key `main`（HTML）と JS chunk 名の衝突（`main2.js` 出力）を避けるため `main` → `index` に変更。

## 完遂検証

```
dist/assets/scripts/main.js     ← バンドル JS（vite.config 設定前は main2.js だった）
dist/assets/scripts/viewport.js ← public/ 経由（既存）
dist/assets/css/main.css        ← CSS
```

- `dist/index.html` の JS 参照: `assets/scripts/main.js`（Vite 自動 rewrite 確認）
- スタイルクラス参照: `git grep -nE` でゼロ確認
- CUSTOMIZE: `[data-validate]` 1例のみ

## AR

4 ゲート通過。必須修正なし。レポートは repo にコミットしない方針。

🤖 Generated with [Claude Code](https://claude.com/claude-code)