### PR TITLE
refactor: フォント CUSTOMIZE コメントを opinionated default 形式に統一

### DIFF
--- a/src/assets/css/token/typography.css
+++ b/src/assets/css/token/typography.css
@@ -1,23 +1,8 @@
 :root {
-  /* CUSTOMIZE: Font selection
-   *
-   * Noto Sans JP を使う場合、以下いずれかで読み込み:
-   *
-   * A) Google Fonts CDN（手軽）: <link> を index.html <head> に追加
-   *    <link rel="preconnect" href="https://fonts.googleapis.com">
-   *    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-   *    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet">
-   *
-   * B) セルフホスト（推奨、パフォーマンス高）: WOFF2 を配信 + @font-face 宣言
-   *    @font-face {
-   *      font-family: 'Noto Sans JP';
-   *      src: url('/assets/fonts/noto-sans-jp.woff2') format('woff2');
-   *      font-display: swap;
-   *      font-weight: 100 900;
-   *    }
-   *
-   * 読み込みなしの場合: システムフォント（system-ui）にフォールバック
-   */
+  /* CUSTOMIZE: フォント
+   * 既定は system-ui（先頭の Noto Sans JP は <head> で読み込めば自動適用）。
+   * カスタム Web フォントの読み込みは <head> 側で設定:
+   *   starter = index.html / WordPress = inc/enqueue.php のフォント CUSTOMIZE コメント参照。 */
   --font-family:
     'Noto Sans JP', system-ui, -apple-system, blinkmacsystemfont, 'Hiragino Kaku Gothic ProN', 'Yu Gothic', meiryo,
     sans-serif;

--- a/src/index.html
+++ b/src/index.html
@@ -35,13 +35,10 @@
     <!-- CUSTOMIZE: og:* と同値でほとんどの場合 OK。Twitter 専用の差別化が必要な場合のみ変更 -->
     <!-- CUSTOMIZE: 本番 URL に差し替え -->
     <link rel="canonical" href="https://example.com/" />
-    <!-- CUSTOMIZE: フォント読み込み
-       Google Fonts を使う場合、ここに以下を追加:
+    <!-- CUSTOMIZE: Web フォントを使う場合のみ <head> で読み込み（例: Google Fonts）
        <link rel="preconnect" href="https://fonts.googleapis.com">
        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-       <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet">
-       詳細: src/assets/css/token/typography.css の CUSTOMIZE コメント参照
-    -->
+       <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet"> -->
     <!-- CUSTOMIZE: LCP 画像を差し替える場合は href + type を更新、image/jpeg image/png image/avif に対応可 -->
     <link rel="preload" as="image" type="image/webp" href="/assets/images/hero-main.webp" fetchpriority="high" />
     <!-- Styles -->


### PR DESCRIPTION
## 概要

typography.css のフォントコメントを「選択肢メニュー」から「最小ポインタ（opinionated default）」形式に整理。ダークモードの `color-scheme` コメント（既定 ON + opt-out 案内）と同じ設計思想に揃える。

## 背景・理由

| 問題 | 詳細 |
|---|---|
| 不正確な記述 |「セルフホスト = 推奨・パフォーマンス高」は条件付き（web.dev: CDN+HTTP/2 前提）であり無条件の推奨は不正確 |
| 重複コンテンツ | CDN スニペットが typography.css と index.html に重複 |
| 循環参照 | index.html に「詳細: typography.css 参照」→ typography.css 側にも HTML スニペット |
| 教示過剰 | self-host チュートリアルは必要なユーザーが自分で導入するレベルの内容 |

## 変更内容

### `src/assets/css/token/typography.css`

A/B メニュー・self-host @font-face 例・CDN `<link>` 3 行を削除し、4 行最小コメントに置換:

```css
/* CUSTOMIZE: フォント
 * 既定は system-ui（先頭の Noto Sans JP は <head> で読み込めば自動適用）。
 * カスタム Web フォントの読み込みは <head> 側で設定:
 *   starter = index.html / WordPress = inc/enqueue.php のフォント CUSTOMIZE コメント参照。 */
```

- `--font-family` の値（スタック）は変更なし
- mflocss-wordpress-starter と横断統一（両リポ共通コメントとして機能）

### `src/index.html`

「詳細: typography.css 参照」の循環参照を削除し、コメントアウト済み Google Fonts スニペットを単一ソースとして残す:

```html
<!-- CUSTOMIZE: Web フォントを使う場合のみ <head> で読み込み（例: Google Fonts）
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400; 700 & display=swap" rel="stylesheet"> -->
```

## 検証結果

- [x] `grep` で「A)」「B)」「セルフホスト」「手軽」「パフォーマンス高」が typography.css に**残っていない**ことを確認
- [x] `pnpm run build` 通過（CSS コメント変更のみ、ビルド 69ms 成功）
- [x] AR: 軽微なコメント整理（AR 不要区分）

## AR 区分

**AR 不要**（コメント変更のみ、コード動作に影響なし、誤字脱字・フォーマット修正相当）

🤖 Generated with [Claude Code](https://claude.com/claude-code)