### PR TITLE
fix(token): typography.css の他リポ参照コメントを自リポ完結に修正

### DIFF
--- a/src/assets/css/token/typography.css
+++ b/src/assets/css/token/typography.css
@@ -1,8 +1,7 @@
 :root {
   /* CUSTOMIZE: フォント
    * 既定は system-ui（先頭の Noto Sans JP は <head> で読み込めば自動適用）。
-   * カスタム Web フォントの読み込みは <head> 側で設定:
-   *   starter = index.html / WordPress = inc/enqueue.php のフォント CUSTOMIZE コメント参照。 */
+   * カスタム Web フォントを使う場合は <head>（index.html）側で読み込む。 */
   --font-family:
     'Noto Sans JP', system-ui, -apple-system, blinkmacsystemfont, 'Hiragino Kaku Gothic ProN', 'Yu Gothic', meiryo,
     sans-serif;


### PR DESCRIPTION
## 概要

starter の独立原則に基づき、`typography.css` のフォント CUSTOMIZE コメントから他リポ（WordPress / inc/enqueue.php）への言及を削除。

## 変更内容

**ファイル**: `src/assets/css/token/typography.css`

```diff
- * カスタム Web フォントの読み込みは <head> 側で設定:
-  *   starter = index.html / WordPress = inc/enqueue.php のフォント CUSTOMIZE コメント参照。 */
+ * カスタム Web フォントを使う場合は <head>（index.html）側で読み込む。 */
```

## 原則

starter と wordpress-starter は互いに独立した存在。各リポは自分のことだけ記述し、相手リポを参照・言及しない（統一性は各々が独立に mFLOCSS に従う結果として生じる）。

## 検証

- [x] `git diff` で typography.css のみ変更を確認
- [x] `WordPress` / `enqueue.php` / `starter =` が残っていないことを grep 確認（0 件）
- [x] `pnpm run build` 成功（68ms）

## AR 判定

軽微（コメント文言修正のみ、構造・CSS 値変更なし） → AR 不要区分

🤖 Generated with [Claude Code](https://claude.com/claude-code)