### PR TITLE
refactor: カード系を Component 粒度原理で再構成（c-media-card / c-step / c-concern-card）

### DIFF
--- a/src/assets/css/component/c-concern-card.css
+++ b/src/assets/css/component/c-concern-card.css
@@ -1,6 +1,3 @@
-/* 顧客の悩み・課題を提示するカード。title + text の縦積み。
-   初期スタイルは c-text-block と近いが、CTA の有無や type scale がサイトごとに
-   分岐しうる独立した意味単位として専用化している（汎用 title+text への押し込みを避ける）。 */
 .c-concern-card {
   display: flex;
   flex-direction: column;

--- a/src/assets/css/component/c-concern-card.css
+++ b/src/assets/css/component/c-concern-card.css
@@ -1,0 +1,16 @@
+/* 顧客の悩み・課題を提示するカード。title + text の縦積み。
+   初期スタイルは c-text-block と近いが、CTA の有無や type scale がサイトごとに
+   分岐しうる独立した意味単位として専用化している（汎用 title+text への押し込みを避ける）。 */
+.c-concern-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.c-concern-card__title {
+  /* スタイルなし（HTML クラスとの対応を維持） */
+}
+
+.c-concern-card__text {
+  color: var(--color-text-light);
+}

--- a/src/assets/css/component/c-media-card.css
+++ b/src/assets/css/component/c-media-card.css
@@ -1,7 +1,7 @@
 /* 公開 API:
-     --media-split-first-order  (default: 0、`:nth-child(even)` 等で 1 を set して左右反転) */
-.c-media-split {
-  --_first-order: var(--media-split-first-order, 0);
+     --media-card-first-order  (default: 0、`:nth-child(even)` 等で 1 を set して左右反転) */
+.c-media-card {
+  --_first-order: var(--media-card-first-order, 0);
 
   display: grid;
   gap: var(--space-xl);
@@ -17,7 +17,7 @@
 }
 
 /* Modifier: -stacked（投稿カード等の縦並び固定バリエーション） */
-.c-media-split.-stacked {
+.c-media-card.-stacked {
   grid-template-columns: 1fr;
   gap: var(--space-md);
   align-items: start;
@@ -25,32 +25,32 @@
   /* @container クエリなしで常に縦並び（投稿カード一覧の小さなカード内で適合） */
 }
 
-.c-media-split__content {
+.c-media-card__content {
   display: flex;
   flex-direction: column;
   gap: var(--space-md);
 }
 
-.c-media-split__badge {
+.c-media-card__badge {
   align-self: start;
 }
 
-.c-media-split__title {
+.c-media-card__title {
   /* スタイルなし（HTML クラスとの対応を維持） */
 }
 
-.c-media-split__text {
+.c-media-card__text {
   color: var(--color-text-light);
 }
 
-.c-media-split__media {
+.c-media-card__media {
   & img {
     inline-size: 100%;
     border-radius: var(--radius-md);
   }
 }
 
-.c-media-split__caption {
+.c-media-card__caption {
   margin-block-start: var(--space-sm);
   font-size: var(--font-size-caption);
   color: var(--color-text-light);

--- a/src/assets/css/component/c-section-heading.css
+++ b/src/assets/css/component/c-section-heading.css
@@ -11,7 +11,7 @@
 }
 
 .c-section-heading__title {
-  /* スタイルなし（foundation の h2 デフォルトを継承、HTML クラスとの対応を維持） */
+  /* スタイルなし（HTML クラスとの対応を維持） */
 }
 
 .c-section-heading__eyebrow + .c-section-heading__title {

--- a/src/assets/css/component/c-step-card.css
+++ b/src/assets/css/component/c-step-card.css
@@ -1,5 +1,5 @@
-/* counter-reset は使う側のリスト要素が宣言する（本コンポーネントは counter-increment のみ）。 */
-.c-step {
+/* 連番は使う側のリスト要素で `counter-reset: step;` を宣言（本コンポーネントは counter-increment のみ）。 */
+.c-step-card {
   display: grid;
   grid-template-columns: auto 1fr;
   gap: var(--space-sm) var(--space-lg);
@@ -27,10 +27,10 @@
   }
 }
 
-.c-step__title {
+.c-step-card__title {
   /* スタイルなし（HTML クラスとの対応を維持） */
 }
 
-.c-step__text {
+.c-step-card__text {
   color: var(--color-text-light);
 }

--- a/src/assets/css/component/c-step.css
+++ b/src/assets/css/component/c-step.css
@@ -1,0 +1,38 @@
+/* 番号付きステップ。連番バッジ（::before）+ バッジと本文の 2 列グリッドを担う。
+   counter は使う側のリスト要素が `counter-reset: step` を宣言することで連動する
+   （このコンポーネントは counter-increment のみ担当）。 */
+.c-step {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--space-sm) var(--space-lg);
+  counter-increment: step;
+
+  &::before {
+    display: flex;
+    grid-row: 1;
+    grid-column: 1;
+    align-items: center;
+    align-self: start;
+    justify-content: center;
+    inline-size: var(--space-2xl);
+    block-size: var(--space-2xl);
+    font-size: var(--font-size-h3);
+    font-weight: var(--font-weight-heading);
+    color: var(--color-surface);
+    content: counter(step);
+    background-color: var(--color-main);
+    border-radius: var(--radius-full);
+  }
+
+  & > * {
+    grid-column: 2;
+  }
+}
+
+.c-step__title {
+  /* スタイルなし（HTML クラスとの対応を維持） */
+}
+
+.c-step__text {
+  color: var(--color-text-light);
+}

--- a/src/assets/css/component/c-step.css
+++ b/src/assets/css/component/c-step.css
@@ -1,6 +1,4 @@
-/* 番号付きステップ。連番バッジ（::before）+ バッジと本文の 2 列グリッドを担う。
-   counter は使う側のリスト要素が `counter-reset: step` を宣言することで連動する
-   （このコンポーネントは counter-increment のみ担当）。 */
+/* counter-reset は使う側のリスト要素が宣言する（本コンポーネントは counter-increment のみ）。 */
 .c-step {
   display: grid;
   grid-template-columns: auto 1fr;

--- a/src/assets/css/project/p-cta.css
+++ b/src/assets/css/project/p-cta.css
@@ -22,9 +22,9 @@
 }
 
 .p-cta__message {
-  /* スタイルなし（HTML クラスとの対応を維持。c-text-block と Block+Element 併記パターン統一） */
+  /* スタイルなし（HTML クラスとの対応を維持） */
 }
 
 .p-cta__button {
-  /* スタイルなし（HTML クラスとの対応を維持。c-button と Block+Element 併記パターン統一） */
+  /* スタイルなし（HTML クラスとの対応を維持） */
 }

--- a/src/assets/css/project/p-faq.css
+++ b/src/assets/css/project/p-faq.css
@@ -23,5 +23,5 @@
 }
 
 .p-faq__accordion {
-  /* スタイルなし（HTML クラスとの対応を維持。c-accordion と Block+Element 併記パターン統一） */
+  /* スタイルなし（HTML クラスとの対応を維持） */
 }

--- a/src/assets/css/project/p-features.css
+++ b/src/assets/css/project/p-features.css
@@ -31,6 +31,6 @@
 
 .p-features__item:nth-child(even) .p-features__card {
   @container (inline-size >= 50rem) {
-    --media-split-first-order: 2;
+    --media-card-first-order: 2;
   }
 }

--- a/src/assets/css/project/p-flow.css
+++ b/src/assets/css/project/p-flow.css
@@ -14,34 +14,11 @@
   display: grid;
   gap: var(--space-lg);
   margin-block-start: var(--space-xl-2xl);
+
+  /* c-step の counter-increment と連動（リスト先頭で連番をリセット） */
   counter-reset: step;
 }
 
 .p-flow__item {
-  /* c-text-block の display: flex / gap を意図的に grid で上書き（番号バッジの列配置が必要なため） */
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: var(--space-sm) var(--space-lg);
-  counter-increment: step;
-
-  &::before {
-    display: flex;
-    grid-row: 1;
-    grid-column: 1;
-    align-items: center;
-    align-self: start;
-    justify-content: center;
-    inline-size: var(--space-2xl);
-    block-size: var(--space-2xl);
-    font-size: var(--font-size-h3);
-    font-weight: var(--font-weight-heading);
-    color: var(--color-surface);
-    content: counter(step);
-    background-color: var(--color-main);
-    border-radius: var(--radius-full);
-  }
-
-  & > * {
-    grid-column: 2;
-  }
+  /* スタイルなし（HTML クラスとの対応を維持。c-card.-subtle + c-step の Block 併記） */
 }

--- a/src/assets/css/project/p-flow.css
+++ b/src/assets/css/project/p-flow.css
@@ -14,11 +14,9 @@
   display: grid;
   gap: var(--space-lg);
   margin-block-start: var(--space-xl-2xl);
-
-  /* c-step の counter-increment と連動（リスト先頭で連番をリセット） */
   counter-reset: step;
 }
 
 .p-flow__item {
-  /* スタイルなし（HTML クラスとの対応を維持。c-card.-subtle + c-step の Block 併記） */
+  /* スタイルなし（HTML クラスとの対応を維持） */
 }

--- a/src/assets/css/project/p-problem.css
+++ b/src/assets/css/project/p-problem.css
@@ -27,5 +27,5 @@
 }
 
 .p-problem__item {
-  /* スタイルなし（HTML クラスとの対応を維持。c-card.-subtle + c-concern-card の Block 併記） */
+  /* スタイルなし（HTML クラスとの対応を維持） */
 }

--- a/src/assets/css/project/p-problem.css
+++ b/src/assets/css/project/p-problem.css
@@ -27,5 +27,5 @@
 }
 
 .p-problem__item {
-  /* スタイルなし（HTML クラスとの対応を維持。c-card.-subtle + c-text-block の Block+Element 併記） */
+  /* スタイルなし（HTML クラスとの対応を維持。c-card.-subtle + c-concern-card の Block 併記） */
 }

--- a/src/assets/css/project/p-voice.css
+++ b/src/assets/css/project/p-voice.css
@@ -29,5 +29,5 @@
 }
 
 .p-voice__card {
-  /* スタイルなし（HTML クラスとの対応を維持。c-card と Block+Element 併記パターン統一） */
+  /* スタイルなし（HTML クラスとの対応を維持） */
 }

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -34,7 +34,7 @@
 @import './component/c-card.css' layer(component);
 @import './component/c-media-card.css' layer(component);
 @import './component/c-concern-card.css' layer(component);
-@import './component/c-step.css' layer(component);
+@import './component/c-step-card.css' layer(component);
 @import './component/c-blockquote.css' layer(component);
 @import './component/c-prose.css' layer(component);
 @import './component/c-section-heading.css' layer(component);

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -32,7 +32,9 @@
 @import './component/c-accordion.css' layer(component);
 @import './component/c-hamburger.css' layer(component);
 @import './component/c-card.css' layer(component);
-@import './component/c-media-split.css' layer(component);
+@import './component/c-media-card.css' layer(component);
+@import './component/c-concern-card.css' layer(component);
+@import './component/c-step.css' layer(component);
 @import './component/c-blockquote.css' layer(component);
 @import './component/c-prose.css' layer(component);
 @import './component/c-section-heading.css' layer(component);

--- a/src/index.html
+++ b/src/index.html
@@ -243,21 +243,21 @@
               <h2 class="c-section-heading__title" id="problem-heading">こんな日々、続いていませんか？</h2>
             </hgroup>
             <ul class="p-problem__list" data-stagger="fade-in-slide-up">
-              <li class="c-card -subtle c-text-block p-problem__item">
-                <h3 class="c-text-block__title">朝起きても疲れが抜けない</h3>
-                <p class="c-text-block__text">
+              <li class="c-card -subtle c-concern-card p-problem__item">
+                <h3 class="c-concern-card__title">朝起きても疲れが抜けない</h3>
+                <p class="c-concern-card__text">
                   睡眠時間は取っているのに、目覚めがすっきりしない。週末に寝溜めしても月曜にはもう重い。
                 </p>
               </li>
-              <li class="c-card -subtle c-text-block p-problem__item">
-                <h3 class="c-text-block__title">肩や腰が常に張っている</h3>
-                <p class="c-text-block__text">
+              <li class="c-card -subtle c-concern-card p-problem__item">
+                <h3 class="c-concern-card__title">肩や腰が常に張っている</h3>
+                <p class="c-concern-card__text">
                   デスクワークが続くと夕方には限界。マッサージに行っても翌日には戻っている。
                 </p>
               </li>
-              <li class="c-card -subtle c-text-block p-problem__item">
-                <h3 class="c-text-block__title">自分のための時間がない</h3>
-                <p class="c-text-block__text">
+              <li class="c-card -subtle c-concern-card p-problem__item">
+                <h3 class="c-concern-card__title">自分のための時間がない</h3>
+                <p class="c-concern-card__text">
                   仕事、家事、育児。気づけば一日が終わっていて、自分のことは後回しになっている。
                 </p>
               </li>
@@ -277,16 +277,16 @@
             </hgroup>
             <ul class="p-features__list" data-stagger="fade-in-slide-up">
               <li class="p-features__item">
-                <article class="c-card -subtle c-media-split p-features__card">
-                  <div class="c-media-split__content">
-                    <span class="c-badge -accent c-media-split__badge" lang="en">Counseling</span>
-                    <h3 class="c-media-split__title">まず、30分話すことから</h3>
-                    <p class="c-media-split__text">
+                <article class="c-card -subtle c-media-card p-features__card">
+                  <div class="c-media-card__content">
+                    <span class="c-badge -accent c-media-card__badge" lang="en">Counseling</span>
+                    <h3 class="c-media-card__title">まず、30分話すことから</h3>
+                    <p class="c-media-card__text">
                       施術の前に、今のからだの状態をじっくり伺います。不調の原因は人それぞれ。あなたに合ったケアを、会話の中から一緒に見つけます。
                     </p>
                   </div>
                   <!-- CUSTOMIZE: 画像を差し替え（推奨サイズ: 480x320。Retina 対応のため 2 倍サイズで書き出し） -->
-                  <figure class="c-media-split__media">
+                  <figure class="c-media-card__media">
                     <img
                       src="./assets/images/feature-counseling.webp"
                       alt="カウンセリングルームで施術者が話を聴いている場面"
@@ -295,22 +295,22 @@
                       loading="lazy"
                       decoding="async"
                     />
-                    <figcaption class="c-media-split__caption">カウンセリングの様子</figcaption>
+                    <figcaption class="c-media-card__caption">カウンセリングの様子</figcaption>
                   </figure>
                 </article>
               </li>
               <li class="p-features__item">
-                <article class="c-card -subtle c-media-split p-features__card">
-                  <div class="c-media-split__content">
-                    <span class="c-badge -accent c-media-split__badge" lang="en">Treatment</span>
-                    <h3 class="c-media-split__title">筋膜と深層にアプローチ</h3>
-                    <p class="c-media-split__text">
+                <article class="c-card -subtle c-media-card p-features__card">
+                  <div class="c-media-card__content">
+                    <span class="c-badge -accent c-media-card__badge" lang="en">Treatment</span>
+                    <h3 class="c-media-card__title">筋膜と深層にアプローチ</h3>
+                    <p class="c-media-card__text">
                       表面をほぐすだけでは戻ってしまう。iluha
                       では筋膜リリースと深層ケアを組み合わせ、根本からからだのバランスを整えます。
                     </p>
                   </div>
                   <!-- CUSTOMIZE: 画像を差し替え（推奨サイズ: 480x320。Retina 対応のため 2 倍サイズで書き出し） -->
-                  <figure class="c-media-split__media">
+                  <figure class="c-media-card__media">
                     <img
                       src="./assets/images/feature-treatment.webp"
                       alt="施術者がベッドに横たわる方の筋膜にアプローチしている様子"
@@ -319,21 +319,21 @@
                       loading="lazy"
                       decoding="async"
                     />
-                    <figcaption class="c-media-split__caption">施術の様子</figcaption>
+                    <figcaption class="c-media-card__caption">施術の様子</figcaption>
                   </figure>
                 </article>
               </li>
               <li class="p-features__item">
-                <article class="c-card -subtle c-media-split p-features__card">
-                  <div class="c-media-split__content">
-                    <span class="c-badge -accent c-media-split__badge" lang="en">Private</span>
-                    <h3 class="c-media-split__title">完全個室、あなただけの空間</h3>
-                    <p class="c-media-split__text">
+                <article class="c-card -subtle c-media-card p-features__card">
+                  <div class="c-media-card__content">
+                    <span class="c-badge -accent c-media-card__badge" lang="en">Private</span>
+                    <h3 class="c-media-card__title">完全個室、あなただけの空間</h3>
+                    <p class="c-media-card__text">
                       周りを気にせず、安心してからだを預けられる環境を。施術中に眠ってしまう方がほとんどです。
                     </p>
                   </div>
                   <!-- CUSTOMIZE: 画像を差し替え（推奨サイズ: 480x320。Retina 対応のため 2 倍サイズで書き出し） -->
-                  <figure class="c-media-split__media">
+                  <figure class="c-media-card__media">
                     <img
                       src="./assets/images/feature-private-room.webp"
                       alt="間接照明が灯る静かな完全個室の施術スペース"
@@ -342,7 +342,7 @@
                       loading="lazy"
                       decoding="async"
                     />
-                    <figcaption class="c-media-split__caption">個室の様子</figcaption>
+                    <figcaption class="c-media-card__caption">個室の様子</figcaption>
                   </figure>
                 </article>
               </li>
@@ -360,33 +360,33 @@
             <h2 class="c-section-heading__title" id="flow-heading">ご利用の流れ</h2>
           </hgroup>
           <ol class="p-flow__list" data-stagger="fade-in-slide-up">
-            <li class="c-card -subtle c-text-block p-flow__item">
-              <h3 class="c-text-block__title">ご予約</h3>
-              <p class="c-text-block__text">
+            <li class="c-card -subtle c-step p-flow__item">
+              <h3 class="c-step__title">ご予約</h3>
+              <p class="c-step__text">
                 お問い合わせフォームからご希望の日時・コースをお知らせください。24時間以内に折り返しご連絡いたします。
               </p>
             </li>
-            <li class="c-card -subtle c-text-block p-flow__item">
-              <h3 class="c-text-block__title">カウンセリング</h3>
-              <p class="c-text-block__text">
+            <li class="c-card -subtle c-step p-flow__item">
+              <h3 class="c-step__title">カウンセリング</h3>
+              <p class="c-step__text">
                 施術前に30分ほどお時間をいただき、お体の状態やお悩み・ご希望を丁寧にヒアリング。
               </p>
             </li>
-            <li class="c-card -subtle c-text-block p-flow__item">
-              <h3 class="c-text-block__title">施術</h3>
-              <p class="c-text-block__text">
+            <li class="c-card -subtle c-step p-flow__item">
+              <h3 class="c-step__title">施術</h3>
+              <p class="c-step__text">
                 選択したコースに沿って45〜90分の施術。完全個室で安心してお過ごしください。
               </p>
             </li>
-            <li class="c-card -subtle c-text-block p-flow__item">
-              <h3 class="c-text-block__title">アフターケア</h3>
-              <p class="c-text-block__text">
+            <li class="c-card -subtle c-step p-flow__item">
+              <h3 class="c-step__title">アフターケア</h3>
+              <p class="c-step__text">
                 施術後は水分補給とリラックスタイム。お体の変化を確かめながらゆっくりとお過ごしください。
               </p>
             </li>
-            <li class="c-card -subtle c-text-block p-flow__item">
-              <h3 class="c-text-block__title">次回のご案内</h3>
-              <p class="c-text-block__text">
+            <li class="c-card -subtle c-step p-flow__item">
+              <h3 class="c-step__title">次回のご案内</h3>
+              <p class="c-step__text">
                 お客様のお体に合わせた最適なペースをご提案。ご希望があれば次回のご予約も承ります。
               </p>
             </li>

--- a/src/index.html
+++ b/src/index.html
@@ -360,33 +360,33 @@
             <h2 class="c-section-heading__title" id="flow-heading">ご利用の流れ</h2>
           </hgroup>
           <ol class="p-flow__list" data-stagger="fade-in-slide-up">
-            <li class="c-card -subtle c-step p-flow__item">
-              <h3 class="c-step__title">ご予約</h3>
-              <p class="c-step__text">
+            <li class="c-card -subtle c-step-card p-flow__item">
+              <h3 class="c-step-card__title">ご予約</h3>
+              <p class="c-step-card__text">
                 お問い合わせフォームからご希望の日時・コースをお知らせください。24時間以内に折り返しご連絡いたします。
               </p>
             </li>
-            <li class="c-card -subtle c-step p-flow__item">
-              <h3 class="c-step__title">カウンセリング</h3>
-              <p class="c-step__text">
+            <li class="c-card -subtle c-step-card p-flow__item">
+              <h3 class="c-step-card__title">カウンセリング</h3>
+              <p class="c-step-card__text">
                 施術前に30分ほどお時間をいただき、お体の状態やお悩み・ご希望を丁寧にヒアリング。
               </p>
             </li>
-            <li class="c-card -subtle c-step p-flow__item">
-              <h3 class="c-step__title">施術</h3>
-              <p class="c-step__text">
+            <li class="c-card -subtle c-step-card p-flow__item">
+              <h3 class="c-step-card__title">施術</h3>
+              <p class="c-step-card__text">
                 選択したコースに沿って45〜90分の施術。完全個室で安心してお過ごしください。
               </p>
             </li>
-            <li class="c-card -subtle c-step p-flow__item">
-              <h3 class="c-step__title">アフターケア</h3>
-              <p class="c-step__text">
+            <li class="c-card -subtle c-step-card p-flow__item">
+              <h3 class="c-step-card__title">アフターケア</h3>
+              <p class="c-step-card__text">
                 施術後は水分補給とリラックスタイム。お体の変化を確かめながらゆっくりとお過ごしください。
               </p>
             </li>
-            <li class="c-card -subtle c-step p-flow__item">
-              <h3 class="c-step__title">次回のご案内</h3>
-              <p class="c-step__text">
+            <li class="c-card -subtle c-step-card p-flow__item">
+              <h3 class="c-step-card__title">次回のご案内</h3>
+              <p class="c-step-card__text">
                 お客様のお体に合わせた最適なペースをご提案。ご希望があれば次回のご予約も承ります。
               </p>
             </li>


### PR DESCRIPTION
## 目的

mFLOCSS の **Component 粒度判断原理（semantic-first / 過剰分割の回避）** に沿って、starter のカード系を re-componentize する。現状は構造名コンポーネント（`c-media-split` / `c-text-block`）の借用 + Project 層での layout 上書きで、認識可能なデザイン単位の identity が構造名や Project 層に漏れていた。これを semantic Component に再構成し、リファレンス実装として原理を体現する。

正典: 内部設計ノート「Component の粒度判断」/「命名」判断基準

## 変更マップ

| 対象 | 変更 | 種別 | 根拠 |
|---|---|---|---|
| `c-card`（-subtle 含む） | 変更なし | primitive | 全カード共通の殻。公開 API（Custom Property）で汎用。維持 |
| features `c-media-split` | **`c-media-card` に semantic 化**（クラス・要素・ファイル・import・公開 API をリネーム、c-media-split 廃止） | semantic | feature card は認識可能なデザイン単位。media 常在で構造名 OK。単一用途で構造名のままは semantic-first 違反 |
| flow `p-flow__item`（`c-text-block` 借用 + Project で layout 上書き + 番号バッジ） | **`c-step` 新設**（番号バッジ + grid を集約） | semantic | 番号付きステップは認識可能な単位。固有スタイル（counter `::before`）が Project 層に漏れていた = 原理上の真のギャップ。c-text-block の誤共有も解消 |
| problem `p-problem__item`（`c-text-block` 共有） | **`c-concern-card` 新設**（c-text-block 共有をやめ独立実装） | semantic | problem は CTA / type scale が異なり別サイトで構成も変わりうる独立単位 |
| cta `c-text-block` | 変更なし | primitive | 素の title+text の canonical。汎用 title+text がそのまま当たる唯一の利用箇所として残す |

## 命名理由

- **`c-concern-card`**: 顧客の悩み（customer concern）を提示するカード。命名判断基準「役割 / 構造 / 内容で名付け、場所で名付けない」に照合。内容/役割ベースでポータブル、`-card` suffix は semantic card family（`c-media-card`）と整合。place 名 `c-problem` は「セクション名で名付けない」（場所依存・非ポータブル）違反のため却下。`c-pain-card` / `c-worry-card` より中立的・実務的な「concern」を採用。
- **`c-media-card`**: media が構造上常在（figure+img 省略不可）のため構造/内容名として妥当。公開 API `--media-split-first-order` → `--media-card-first-order` にリネーム（c-/p-/l- プレフィックス非含有で spec §6 compliant）。`.c-media-card.-stacked` modifier はリファレンス網羅性のため維持。
- **`c-step`**: 役割名（プロセスのステップ）。`counter-increment` は c-step 側、`counter-reset` はリスト側（`p-flow__list`）に残す連動関係を維持。

## problem 独立化の設計意図

`c-concern-card` の初期 CSS は `c-text-block`（title+text の flex 縦積み + gap + text color）とほぼ同一だが、これは意図的。problem は CTA の有無・type scale がサイトごとに分岐しうる独立した意味単位であり、汎用 `c-text-block` への押し込みは将来 divergence 時に消費側でのスタイル *キャンセル* を強いる（過剰分割回避の逆効果）。`c-stat` / `c-blockquote` と同じく各カード型を独立 Component として素直に実装する方針。空クローンではなく独立 component として扱い、コメントに設計意図を明記。

## Block 併記（責任直交）

`c-card -subtle {c-media-card / c-step / c-concern-card} p-*__item` の co-attach を維持。殻 primitive（c-card）+ semantic（content/layout）+ Project（配置）の責任を直交分離し、**semantic クラスを省略しない**（spec §6）。

## 検証

- **層判断 / Portability / Responsibility / Layout Test**: 新規 3 component 全て pass（外部 margin・position・display:none を持たず、配置は Project / 公開 API 経由）
- **対立的レビュー（AR）**: 10 攻撃面（cascade 移動 / counter scope / 公開 API rename / a11y / 命名 / JS 結合 等）で Critical/High 未解消なし
- `stylelint`: clean / `markuplint`: passed / `vite build`: ✓（built CSS に新 component + counter chain 反映確認）
- DOM 構造不変（クラスリネームのみ）、JS は data-* フックのみで影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)