### PR TITLE
fix(foundation): base.css nav-link 公開 API を Z パターンに統一（starter#222 convention 逸脱修正）

### DIFF
--- a/src/assets/css/foundation/base.css
+++ b/src/assets/css/foundation/base.css
@@ -35,7 +35,10 @@
      --link-color        (default: var(--color-link)、Project 層から非 hover 時の色を上書き)
      --link-hover-color  (default: var(--color-main)、Project 層から hover 時の色を上書き) */
 :where(a) {
-  color: var(--link-color, var(--color-link));
+  --_color: var(--link-color, var(--color-link));
+  --_hover-color: var(--link-hover-color, var(--color-main));
+
+  color: var(--_color);
 
   @media (prefers-reduced-motion: no-preference) {
     transition: color var(--duration-fast) var(--ease-out-cubic);
@@ -43,7 +46,7 @@
 
   @media (any-hover: hover) {
     &:hover {
-      color: var(--link-hover-color, var(--color-main));
+      color: var(--_hover-color);
     }
   }
 }


### PR DESCRIPTION
## 概要

base.css nav-link 公開 API を Z パターンに統一（starter#222 の convention 逸脱修正、ユーザーレビュー指摘）

## 変更内容

- `:where(a)` の公開 API（`--link-color` / `--link-hover-color`）を use-site で inline `var(--link-color, fallback)` 直書きしていた形から、**Z パターン**（Block 冒頭で public → private に fallback 付き代入、use-site は private 変数のみ参照）に統一
- c-card.css 等の既存 Z パターン（`--_padding` 等）に揃える
- レンダリング結果は不変（同値リファクタ）

## before / after

**BEFORE**（convention 逸脱）:
```css
:where(a) {
  color: var(--link-color, var(--color-link));

  @media (any-hover: hover) {
    &:hover {
      color: var(--link-hover-color, var(--color-main));
    }
  }
}
```

**AFTER**（Z パターン準拠）:
```css
:where(a) {
  --_color: var(--link-color, var(--color-link));
  --_hover-color: var(--link-hover-color, var(--color-main));

  color: var(--_color);

  @media (any-hover: hover) {
    &:hover {
      color: var(--_hover-color);
    }
  }
}
```

## 根拠

Z パターン採用理由（spec §7 / agent-reference AGENT_GUIDE.md）:
- 親継承 / 外部 override / Modifier 上書きの各経路がすべて動作
- Block 冒頭の private 変数宣言により fallback 値が一箇所に集約される
- 公開 API コメントブロック（`/* 公開 API: --link-color ... */`）は維持

## 検証

- `pnpm run build` ✅
- `pnpm run lint:css` ✅（stylelint エラーなし）
- 変更対象: `src/assets/css/foundation/base.css` 1 ファイルのみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)