### PR TITLE
fix(deps): fast-uri を >=3.1.2 に固定して high 脆弱性 2 件を解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
   },
   "pnpm": {
     "overrides": {
-      "uuid": ">=14.0.0"
+      "uuid": ">=14.0.0",
+      "fast-uri": ">=3.1.2",
+      "brace-expansion": ">=5.0.6"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   uuid: '>=14.0.0'
+  fast-uri: '>=3.1.2'
+  brace-expansion: '>=5.0.6'
 
 importers:
 
@@ -433,8 +435,8 @@ packages:
   bcp-47@2.1.0:
     resolution: {integrity: sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -612,8 +614,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -1746,7 +1748,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -1772,7 +1774,7 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -1949,7 +1951,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastest-levenshtein@1.0.16: {}
 
@@ -2272,7 +2274,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## 概要

`pnpm audit` で検出された npm 依存脆弱性 3 件（high×2 / moderate×1）を `pnpm.overrides` による強制固定で解消します。

## 対応した脆弱性

### 🔴 HIGH: fast-uri — path traversal（GHSA-q3j6-qgpj-74h6）

- **影響バージョン**: <=3.1.0
- **修正バージョン**: >=3.1.1
- **概要**: percent-encoded dot segments によるパストラバーサル

### 🔴 HIGH: fast-uri — host confusion（GHSA-v39h-62p7-jpjc）

- **影響バージョン**: <=3.1.1
- **修正バージョン**: >=3.1.2
- **概要**: percent-encoded authority delimiters によるホスト混同

### 🟡 MODERATE: brace-expansion — DoS（GHSA-jxxr-4gwj-5jf2）

- **影響バージョン**: >=5.0.0 <5.0.6
- **修正バージョン**: >=5.0.6
- **概要**: large numeric range が documented `max` DoS 保護を迂回

## 依存パス

```
fast-uri:        . > stylelint > table > ajv > fast-uri
brace-expansion: . > eslint > minimatch > brace-expansion
```

直接依存ではないため `pnpm.overrides` による強制固定が確実な解消方法です。

## 変更方針

```json
"pnpm": {
  "overrides": {
    "uuid": ">=14.0.0",     // 既存
    "fast-uri": ">=3.1.2",  // 追加: high×2 を両方カバー
    "brace-expansion": ">=5.0.6"  // 追加: moderate×1 を解消
  }
}
```

## audit before / after

**修正前**:
```
3 vulnerabilities found
Severity: 1 moderate | 2 high
```

**修正後**:
```
No known vulnerabilities found
```

## 検証

- `pnpm audit --audit-level=high`: **0 件** ✅
- `pnpm audit --audit-level=info`: **0 件** ✅
- `pnpm run lint:css` (stylelint 配下の回帰確認): **pass** ✅
- `pnpm run lint:js` (eslint 配下の回帰確認): **pass** ✅
- `pnpm run build` (vite build): **pass** ✅

## 変更ファイル

- `package.json` — `pnpm.overrides` に 2 キー追加
- `pnpm-lock.yaml` — `fast-uri` 3.1.0→3.1.2 / `brace-expansion` 5.0.5→5.0.6 に更新