### PR TITLE
fix(token): --font-family を opinionated default に整合（和文先頭 / 古環境保険削除 / Noto は CUSTOMIZE 降格）

### DIFF
--- a/src/assets/css/token/typography.css
+++ b/src/assets/css/token/typography.css
@@ -1,10 +1,7 @@
 :root {
-  /* CUSTOMIZE: フォント
-   * 既定は system-ui（先頭の Noto Sans JP は <head> で読み込めば自動適用）。
-   * カスタム Web フォントを使う場合は <head>（index.html）側で読み込む。 */
-  --font-family:
-    'Noto Sans JP', system-ui, -apple-system, blinkmacsystemfont, 'Hiragino Kaku Gothic ProN', 'Yu Gothic', meiryo,
-    sans-serif;
+  /* CUSTOMIZE: フォント（システムフォント = 外部依存なしで即動作）
+   * Web フォント（例: Noto Sans JP）を使う場合は先頭に足し、<head>（index.html）側で読み込む。 */
+  --font-family: 'Hiragino Kaku Gothic ProN', 'Yu Gothic', meiryo, system-ui, sans-serif;
 
   /* CUSTOMIZE: 流体タイポグラフィ（viewport-min → viewport-max の直線的な補間） */
   --font-size-h1: clamp(calc(32 * var(--px)), 2.308vi + 1.4231rem, calc(56 * var(--px)));


### PR DESCRIPTION
## 概要

`token/typography.css` の `--font-family` を opinionated default 原則（default = システムフォントで即動作、Web フォントは CUSTOMIZE 例示 1 本）に整合させる。Refs #226

## 変更

```diff
-  /* CUSTOMIZE: フォント
-   * 既定は system-ui（先頭の Noto Sans JP は <head> で読み込めば自動適用）。
-   * カスタム Web フォントを使う場合は <head>（index.html）側で読み込む。 */
-  --font-family:
-    'Noto Sans JP', system-ui, -apple-system, blinkmacsystemfont, 'Hiragino Kaku Gothic ProN', 'Yu Gothic', meiryo,
-    sans-serif;
+  /* CUSTOMIZE: フォント（システムフォント = 外部依存なしで即動作）
+   * Web フォント（例: Noto Sans JP）を使う場合は先頭に足し、<head>（index.html）側で読み込む。 */
+  --font-family: 'Hiragino Kaku Gothic ProN', 'Yu Gothic', meiryo, system-ui, sans-serif;
```

- **和文フォントを先頭に**: OS 同梱の和文フォント（Hiragino Kaku Gothic ProN / Yu Gothic / meiryo）を先頭に置き、外部依存なしで即動作。`system-ui` を後段に下げ、日本語環境での CJK 字形問題（Yu Gothic UI 等への解決でラテン字形が崩れる / `lang` が効かず中国語寄り字形になる相互運用問題）を回避。
- **古環境保険を削除**: `-apple-system` / `blinkmacsystemfont`（`system-ui` 未対応時代のレガシー）を削除。モダン前提では到達しないデッドコードで、運用方針「必要最小限」に反するため。
- **Noto Sans JP を CUSTOMIZE 降格**: default から外し、使う場合は先頭に足して `<head>` で読み込む例示 1 本に。

## 検証

- **mFLOCSS 層判断**: Token 層 Custom Property の値変更のみ。`@layer` 構造・命名・セレクタは不変。
- **カスケード監査**: `--font-family` 宣言は `token/typography.css` の 1 箇所のみ（単一ソース）、参照は `foundation/base.css` の `font-family: var(--font-family)` 1 箇所のみ。Component / Project 層での冗長 override なし。
- **prettier (printWidth=120)**: 新しい値は 1 行に収まる（reflow なし）。

## index.html について

`<head>` の Noto 読み込みは v1.2 時点で既に CUSTOMIZE 例示としてコメントアウト済（`<!-- CUSTOMIZE: Web フォントを使う場合のみ <head> で読み込み（例: Google Fonts） ... -->`）。本変更の「Noto は CUSTOMIZE 降格」方針と既に整合しているため、index.html の変更は不要。

## ecosystem 波及（別管理）

`consistency ≠ coupling` のため本 PR には含めず、別リポで追従:

- **mflocss/spec §5.1 Example** の `--font-family` 例の整合確認
- **mflocss/wordpress-starter** の typography 相当（同一デザイン追従）
