### PR TITLE
refactor(v1.2): l-inner を公開API化 + p-cta を escape-hatch 整理（wp PR #78 横展開）

### DIFF
--- a/src/assets/css/component/c-form.css
+++ b/src/assets/css/component/c-form.css
@@ -4,6 +4,7 @@
      --form-link-color          (default: var(--color-link)) */
 .c-form {
   --_actions-margin-top: var(--form-actions-margin-top, var(--space-md));
+  --_required-mark: var(--form-required-mark, '*');
   --_link-color: var(--form-link-color, var(--color-link));
 
   display: flex;
@@ -39,7 +40,7 @@
 .c-form__field:has(:required) > .c-form__legend::after,
 .c-form__field:has(:required) > .c-form__choice-label::before {
   color: var(--color-error);
-  content: var(--form-required-mark, '*');
+  content: var(--_required-mark);
 }
 
 /* Element: 入力装飾（input / textarea / select 共通のビジュアル定義） */

--- a/src/assets/css/layout/l-inner.css
+++ b/src/assets/css/layout/l-inner.css
@@ -1,6 +1,9 @@
+/* 公開 API:
+     --inner-width      (default: var(--content-width))
+     --inner-padding    (default: var(--content-padding)) */
 .l-inner {
   box-sizing: content-box;
-  max-inline-size: var(--content-width);
-  padding-inline: var(--content-padding);
+  max-inline-size: var(--inner-width, var(--content-width));
+  padding-inline: var(--inner-padding, var(--content-padding));
   margin-inline: auto;
 }

--- a/src/assets/css/layout/l-inner.css
+++ b/src/assets/css/layout/l-inner.css
@@ -2,8 +2,11 @@
      --inner-width      (default: var(--content-width))
      --inner-padding    (default: var(--content-padding)) */
 .l-inner {
+  --_width: var(--inner-width, var(--content-width));
+  --_padding: var(--inner-padding, var(--content-padding));
+
   box-sizing: content-box;
-  max-inline-size: var(--inner-width, var(--content-width));
-  padding-inline: var(--inner-padding, var(--content-padding));
+  max-inline-size: var(--_width);
+  padding-inline: var(--_padding);
   margin-inline: auto;
 }

--- a/src/assets/css/project/p-cta.css
+++ b/src/assets/css/project/p-cta.css
@@ -6,9 +6,7 @@
 }
 
 .p-cta__inner {
-  max-inline-size: var(--content-width-narrow);
-  margin-inline: auto;
-  text-align: center;
+  --inner-width: var(--content-width-narrow);
 }
 
 .p-cta__stack {
@@ -16,6 +14,7 @@
   flex-direction: column;
   gap: var(--space-lg);
   align-items: center;
+  text-align: center;
 }
 
 .p-cta__message {

--- a/src/assets/css/token/color.css
+++ b/src/assets/css/token/color.css
@@ -16,9 +16,6 @@
   --_red-400: oklch(65% 0.18 15deg);
   --_red-500: oklch(50% 0.22 15deg);
 
-  /* CUSTOMIZE: ダークモード不要なら light のみに */
-  color-scheme: light dark;
-
   /* CUSTOMIZE: パレット → 用途のマッピング */
   --color-main: light-dark(var(--_sage-600), var(--_sage-400));
   --color-accent: light-dark(var(--_terracotta-500), var(--_terracotta-400));
@@ -36,4 +33,7 @@
   --color-heading: var(--color-text);
   --color-focus-ring: var(--color-main);
   --color-overlay: oklch(0% 0 0deg / 40%);
+
+  /* CUSTOMIZE: ダークモード不要なら light のみに */
+  color-scheme: light dark;
 }

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -1,6 +1,7 @@
 export default {
   extends: ['stylelint-config-standard', 'stylelint-config-recess-order'],
   rules: {
+    'order/order': ['custom-properties', 'declarations'],
     'block-no-empty': [true, { severity: 'warning' }],
     'selector-class-pattern': null,
     'custom-property-pattern': '^([a-z][a-z0-9]*(-[a-z0-9]+)*|_[a-z0-9]+(-[a-z0-9]+)*)$',


### PR DESCRIPTION
## 概要

wp PR #78 の `l-inner` 公開API化 + `p-cta` 整理を landing starter に横展開（順方向）。

---

## 変更

### `l-inner.css` — 公開 API (escape hatch) 追加 + ローカル変数化規約の統一

```css
/* 公開 API:
     --inner-width      (default: var(--content-width))
     --inner-padding    (default: var(--content-padding)) */
.l-inner {
  --_width: var(--inner-width, var(--content-width));
  --_padding: var(--inner-padding, var(--content-padding));

  box-sizing: content-box;
  max-inline-size: var(--_width);
  padding-inline: var(--_padding);
  margin-inline: auto;
}
```

- `--inner-width` / `--inner-padding` を公開 API として追加
- fallback default により **既存挙動は不変**
- 公開 API を `--_width` / `--_padding` ローカル変数に受ける形へ変更（l-section.css 等の規約に統一）

### `p-cta.css` — Layout 委譲 + content element 整理

**Before:**
```css
.p-cta__inner {
  max-inline-size: var(--content-width-narrow);
  margin-inline: auto;
  text-align: center;
}
.p-cta__stack {
  display: flex;
  flex-direction: column;
  gap: var(--space-lg);
  align-items: center;
}
```

**After:**
```css
.p-cta__inner {
  --inner-width: var(--content-width-narrow);
}
.p-cta__stack {
  display: flex;
  flex-direction: column;
  gap: var(--space-lg);
  align-items: center;
  text-align: center;
}
```

- `p-cta__inner`: `max-inline-size` / `margin-inline` を l-inner に委譲し `--inner-width` override 化
- `text-align: center` を content element (`__stack`) へ移設（Project 層は中身のみ・配置なし = 移植性向上）

### `c-form.css` — ローカル変数化規約の統一

- `--form-required-mark` を `--_required-mark` ローカル変数に受ける形へ追加（`--form-actions-margin-top` / `--form-link-color` と同形式に統一）
- 使用箇所 `content: var(--form-required-mark, '*')` → `content: var(--_required-mark)` に置換
- 宣言順（actions-margin-top → required-mark → link-color）は公開 API コメントの順序に対応

---

## ローカル変数化規約の統一（本 PR 追加コミット）

本リポの公開 API Block は **`--block-xxx` を Block プレフィックスを落とした `--_xxx` ローカル変数に受けてからプロパティで使う**規約（l-section.css / c-button.css / c-card.css 等）。本 PR の追加コミットで l-inner と c-form の漏れを補完し、**全公開 API Block を規約統一**。

`order/order` でカスタムプロパティ先頭を機械強制（将来の逸脱を lint 検出）。

---

## AR: PASS

mFLOCSS 層責任分離に準拠:
- **Layout 層** (`l-inner`) = 横コンテナ制御 + 中和 API 提供
- **Project 層** (`p-cta`) = 中身のみ・配置なし = 移植性確保

fallback default で既存レイアウト不変。`pnpm build` PASS。

---

## 逆方向（starter → wp）= 差分なし確定

共有 55 ファイルを content diff。差分 8 件のうち l-inner / p-cta は本 PR の順方向対象、残り 6 件は全て WP/コーポレート文脈 DEVIATION（l-header の `.admin-bar` offset / p-contact・p-privacy の `__breadcrumb`）または意図的設計差（token/typography の font stack = starter は pure system-font を維持 / style.css の WP 専用 import + 整列差 / c-button のコメント位置の些末差）。**starter に取り込むべき内容なし**。

---

## 検証

- `pnpm build`: ✅ PASS
- `pnpm lint:css`: ✅ エラーなし
- 変更ファイル: 5 ファイル（l-inner.css / p-cta.css / c-form.css / color.css / stylelint.config.mjs）
- HTML 構造: `<div class="l-inner p-cta__inner">` → `<div class="p-cta__stack">` 維持