### PR TITLE
refactor(foundation→project): ドロワー背景固定を base.css から p-drawer へ scoped 移動（汎用 dialog[open] の過剰ロック解消）

### DIFF
--- a/src/assets/css/foundation/base.css
+++ b/src/assets/css/foundation/base.css
@@ -64,8 +64,7 @@
 :where(:root) {
   scroll-padding-block-start: var(--header-size);
 
-  &:has(:modal),
-  &:has(dialog[open]) {
+  &:has(:modal) {
     overflow: hidden;
   }
 }

--- a/src/assets/css/project/p-drawer.css
+++ b/src/assets/css/project/p-drawer.css
@@ -31,6 +31,14 @@
   }
 }
 
+/* 背景スクロール固定: ドロワーは show()（modeless）採用で :modal に非該当のため、Foundation の
+   汎用固定 :has(:modal) では対象外（modeless 採用理由は上記 show() コメント参照）。判定は表示中
+   ずっと真の native [open] を使用（[data-open] は閉じアニメ開始で外れ、閉じ途中にスクロールが
+   復帰するため不可。main.js closeDrawer 参照）。 */
+:root:has(.p-drawer[open]) {
+  overflow: hidden;
+}
+
 .p-drawer__stack {
   display: flex;
   flex-direction: column;

--- a/src/assets/css/project/p-header.css
+++ b/src/assets/css/project/p-header.css
@@ -6,7 +6,7 @@
   backdrop-filter: blur(var(--_blur));
 
   /* ドロワー表示時の背面透け防止 */
-  :root:has(dialog[open]) & {
+  :root:has(.p-drawer[open]) & {
     background-color: var(--color-bg);
     backdrop-filter: none;
   }

--- a/src/assets/css/project/p-header.css
+++ b/src/assets/css/project/p-header.css
@@ -6,7 +6,7 @@
   backdrop-filter: blur(var(--_blur));
 
   /* ドロワー表示時の背面透け防止 */
-  :root:has(.p-drawer[open]) & {
+  :root:has(dialog[open]) & {
     background-color: var(--color-bg);
     backdrop-filter: none;
   }


### PR DESCRIPTION
Closes #229

## 概要

Foundation（`base.css`）の `:root` スクロールロックが汎用 `:has(dialog[open])` で**ドロワー以外の任意の modeless `<dialog>` まで巻き込む**過剰ロックを解消。mFLOCSS の層帰属に従い、ドロワー固有の背景固定を Project（`p-drawer`）へ scoped 移動する。

## 変更（正味 2 ファイル）

| ファイル | 変更 |
|---|---|
| `foundation/base.css` | `:where(:root)` を `:has(:modal)` のみに narrow（汎用 `:has(dialog[open])` 除去）|
| `project/p-drawer.css` | `:root:has(.p-drawer[open]) { overflow: hidden }` を追加 + show()/modeless・`[open]` 採用理由コメント |

```css
/* base.css（after）*/
:where(:root) {
  scroll-padding-block-start: var(--header-size);
  &:has(:modal) { overflow: hidden; }
}

/* p-drawer.css（追加）*/
:root:has(.p-drawer[open]) { overflow: hidden; }
```

> **p-header.css は変更しない（汎用 `:has(dialog[open])` 据え置き）**。初版で「一貫性」のため p-header も `.p-drawer[open]` に narrow したが、p-header が p-drawer の class を直接参照する **Project Block 間の密結合**を生むためレビューで撤回（2 つ目のコミットで revert、正味差分には現れない）。スクロールロックは drawer 固有であるべき（無関係 dialog でロックしない = 本 Issue の主目的）だが、背面透け防止は任意の overlay 表示に反応すれば足り、特定 Block 参照は不要。**この非対称は意図的**。

## 確認事項（Issue 記載 3 点の検証結果）

### ① open 判定属性 → **`.p-drawer[open]`（native）を採用**

`main.js` の `initDrawer` をトレースして確定：

- `openDrawer`: `drawer.show()` で native `[open]` 付与 → 2×rAF 後に `[data-open]` 付与
- `closeDrawer`: `delete dataset.open`（`[data-open]` **即除去**）→ transition 完了待ち → `drawer.close()`（`[open]` 除去）

`[open]` は表示中ずっと真で、閉じアニメ完了（`close()`）まで背景固定を維持できる。`[data-open]` を使うと閉じアニメ開始時点で固定が外れ、**閉じ途中にスクロールバー復帰 → CLS** が発生するため不可。旧 `:has(dialog[open])` の native open 判定とも完全一致（挙動非破壊）。

### ② 他 modeless dialog の依存 → **なし**

starter 内で `show()` を使う `<dialog>` は `p-drawer` のみ（`main.js`）。`reset.css` の `:where(dialog, [popover])` は base reset。よって移動対象はドロワー固有分のみで、汎用 `dialog[open]` 除去による既存挙動への影響なし。

### ③ `:root` を Project 層で使う層帰属 → **spec 準拠（妥当）**

- spec §5.3 Foundation Test「全ページ共通の基本スタイルか？」= **No**（ドロワー開状態という context 依存）→ 上位層
- spec §5.6 Project（Portability Test 否定形、「ドロワー」明記）= `.p-drawer` 依存で **No → Project**
- subject が `:root` でも、rule の発火条件がサイト固有部品 `.p-drawer` に依存する以上、層判定は依存先で決まる。spec に `:root`-subject rule の Project 配置を禁ずる条項なし
- 先例: `p-header.css` も Project 層で `:root:has(...)` を使用

## 検証

- ✅ stylelint パス
- ✅ `vite build`（lightningcss）パス
- ✅ ドロワー markup 整合: `<dialog class="p-drawer" id="drawer" data-drawer>` に `.p-drawer` クラス存在 → `.p-drawer[open]` がマッチ
- ✅ @layer 順序 `... foundation, ..., project, ...` で project が foundation を上書き（カスケード成立）
- ✅ book ch7 整合: 書籍側 narrow 方針（`:has(:modal)`）と base.css が一致（DoD）

### ブラウザ実機検証（Playwright, 390×844）

| ケース | 計測（`:root` overflowY） | 判定 |
|---|---|---|
| ① ドロワー開 | `hidden` | ✅ 背景固定維持 |
| ① 閉じアニメ中（`[data-open]` 除去・`[open]` 残存） | `hidden` | ✅ CLS 防止 = `[open]` 採用の実証 |
| ① 閉じ完了後 | `visible` | ✅ 解除 |
| ② モーダル `showModal()` 開 | `hidden` | ✅ `:has(:modal)` 維持 |
| ③ 無関係 modeless dialog `show()` 開 | `visible` | ✅ 過剰ロック解消 |

## AR（対立的レビュー）結果

3 レビュアー並列 + 審判で実施。**採用必須 0 件**。推奨①「`scrollbar-gutter` 追加」は**既に `reset.css:10` に存在のため不採用**、推奨②「p-drawer コメント圧縮」採用、推奨③「p-header コメント拡張」不採用（過剰）。

## Follow-up

- **wordpress-starter 横展開**: `mflocss-wordpress-starter` の `base.css:67-68` に同一の `:has(dialog[open])` が残存。family consistency により別 PR で同様の scoped 移動が必要（[wordpress-starter#80](https://github.com/mflocss/wordpress-starter/issues/80)）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
