### PR TITLE
refactor(css): CSS Nesting を shunei流に統一 + CODING_GUIDE に方針節追加（#89）

### DIFF
--- a/CODING_GUIDE.md
+++ b/CODING_GUIDE.md
@@ -141,6 +141,25 @@ Drawer と Hamburger トリガー**以外**の、フォーカス可能（= Tab �
 
 `querySelectorAll('[data-drawer-inert]')` で全対象要素を取得 → `openDrawer` で `inert` 属性付与、`closeDrawer` で削除するだけ。新規対象を追加しても JS 側の変更は不要です。
 
+## CSS Nesting の `&` 方針（shunei流）
+
+starter は shunei流として **ネストの子孫は `&` を省略**します（クリーン・読みやすさ重視）。
+
+```css
+.c-card {
+  .c-card__title { } /* = .c-card .c-card__title（子孫、& 省略）*/
+  th { }             /* = .c-card th（型セレクタも & 不要、Baseline WA 2026-06-11）*/
+  &.-subtle { }      /* 複合（同一要素）は & 必須 */
+  &:hover { }        /* 擬似クラスも & 必須 */
+}
+```
+
+**`&` が必須な箇所**（仕様上の必然、好みでない）: State/Modifier（同一要素の複合 `&.-active`）/ 擬似（`&:hover`）/ 属性（`&[...]`）。これらで `&` を省くと**別要素の子孫**になる（`.c-card { .-active {} }` は `.c-card .-active` になり `.c-card.-active` にならない）か、擬似は無効になります。
+
+**⚠️ BEM 連結は不可**: Sass の `&__title` のような文字列連結は CSS Nesting ではできません。Element は**フルのクラス名**を書いてください（`.c-card__title`）。
+
+**mFLOCSS spec（mFLOCSS流）は Nesting の `&` 方針を規定しません**（任意）。本 `&` 省略は starter が採る shunei流であり spec 規範ではありません。プロジェクトで `&` を明示しても mFLOCSS 準拠は変わりません。
+
 ## JS フックの分離
 
 JS で DOM 要素を取得する際は **`data-*` 属性** を使います。スタイルクラス（`c-` / `p-` / `l-` / `u-` プレフィックス）を JS フックに使ってはいけません。

--- a/src/assets/css/component/c-media-card.css
+++ b/src/assets/css/component/c-media-card.css
@@ -11,7 +11,7 @@
     grid-template-columns: 1fr 1fr;
   }
 
-  & > :first-child {
+  > :first-child {
     order: var(--_first-order);
   }
 }
@@ -44,7 +44,7 @@
 }
 
 .c-media-card__media {
-  & img {
+  img {
     inline-size: 100%;
     border-radius: var(--radius-md);
   }

--- a/src/assets/css/component/c-prose.css
+++ b/src/assets/css/component/c-prose.css
@@ -11,28 +11,28 @@
   max-inline-size: var(--_max-inline-size);
   line-height: var(--line-height-text);
 
-  & h2 {
+  h2 {
     margin-block-start: var(--space-xl);
     font-weight: var(--font-weight-heading);
   }
 
-  & :is(p, ul) {
+  :is(p, ul) {
     margin-block-start: var(--space-md);
   }
 
-  & h2 + :is(p, ul) {
+  h2 + :is(p, ul) {
     margin-block-start: var(--space-sm);
   }
 
-  & ul {
+  ul {
     padding-inline-start: var(--space-lg);
   }
 
-  & li + li {
+  li + li {
     margin-block-start: var(--space-xs);
   }
 
-  & a {
+  a {
     color: var(--color-main);
     text-decoration: underline;
     text-underline-offset: 0.2em;

--- a/src/assets/css/component/c-step-card.css
+++ b/src/assets/css/component/c-step-card.css
@@ -22,7 +22,7 @@
     border-radius: var(--radius-full);
   }
 
-  & > * {
+  > * {
     grid-column: 2;
   }
 }

--- a/src/assets/css/component/c-table.css
+++ b/src/assets/css/component/c-table.css
@@ -1,19 +1,19 @@
 .c-table {
   inline-size: 100%;
 
-  & th,
-  & td {
+  th,
+  td {
     padding: var(--space-sm) var(--space-md);
     text-align: start;
     border-block-end: var(--border-width) solid var(--color-border);
   }
 
-  & thead th {
+  thead th {
     font-weight: var(--font-weight-heading);
     background-color: var(--color-bg-secondary);
   }
 
-  & tbody th {
+  tbody th {
     font-weight: var(--font-weight-body);
   }
 }

--- a/src/assets/css/project/p-hero.css
+++ b/src/assets/css/project/p-hero.css
@@ -68,7 +68,7 @@
     background: linear-gradient(to bottom, var(--_overlay-top) 0%, var(--_overlay-bottom) 100%);
   }
 
-  & img {
+  img {
     inline-size: 100%;
     block-size: 100%;
     object-fit: cover;


### PR DESCRIPTION
## 概要

Baseline Widely Available 2026-06-11 に合わせて、starter 全 CSS の Nesting 記法を **shunei流** に統一し、`CODING_GUIDE.md` に方針節を追加します。

**shunei流**: ネスト内の子孫は `&` を省略（クリーン・読みやすさ重視）。複合/擬似/属性セレクタは `&` 必須のまま維持。

## 変換 CSS ファイル（5 件）

| ファイル | 変換内容 |
|---|---|
| `component/c-step-card.css` | `& > *` → `> *` |
| `component/c-table.css` | `& th`, `& td`, `& thead th`, `& tbody th` → `&` 除去 |
| `component/c-media-card.css` | `& > :first-child`, `& img` → `&` 除去 |
| `component/c-prose.css` | `& h2`, `& :is(p,ul)`, `& h2 + :is(p,ul)`, `& ul`, `& li + li`, `& a` → `&` 除去 |
| `project/p-hero.css` | `& img` → `img` |

## CODING_GUIDE.md 追加節

`## JS フックの分離` 直前に「`## CSS Nesting の & 方針（shunei流）`」を追加（敬体・css コードフェンス・既存文体に準拠）。

内容: 子孫省略ルール / `&` 必須箇所（複合/擬似/属性）/ BEM 連結不可注意 / spec 任意性の明示。

## 検証

```
# 子孫 & 残存 0 件（変換漏れなし）
grep -rnE '^\s*&\s+' src/assets/css/ → 0 件 ✅

# 複合・擬似・属性 & 残存（誤除去なし）
grep -rnE '^\s*&[.:&\[\-]' src/assets/css/ → 30 件 ✅

# ビルド pass
pnpm run build → ✓ built in 68ms ✅

# lint pass
pnpm run lint → ESLint: No issues found ✅
```

## AR 確認

| 観点 | 結果 |
|---|---|
| spec 任意性維持 | CODING_GUIDE に「spec は規定しない（任意）」を明示 ✅ |
| `&` 必須箇所の誤除去なし | 30 件残存確認 ✅ |
| Baseline 日付 2026-06-11 の事実正確性 | Issue #89 記載と一致 ✅ |

## 関連

- Closes 対象: Issue #89（Nesting 統一化 checkbox に相当）
- wp-starter との sync 照合は cortex 側で実施予定

## 変換ファイルパス一覧（wp-starter sync 照合用）

```
src/assets/css/component/c-step-card.css
src/assets/css/component/c-table.css
src/assets/css/component/c-media-card.css
src/assets/css/component/c-prose.css
src/assets/css/project/p-hero.css
CODING_GUIDE.md
```