### PR TITLE
refactor(css): CSS Nesting で子孫セレクタの `&` を省略（#89）

### DIFF
--- a/src/assets/css/component/c-media-card.css
+++ b/src/assets/css/component/c-media-card.css
@@ -11,7 +11,7 @@
     grid-template-columns: 1fr 1fr;
   }
 
-  & > :first-child {
+  > :first-child {
     order: var(--_first-order);
   }
 }
@@ -44,7 +44,7 @@
 }
 
 .c-media-card__media {
-  & img {
+  img {
     inline-size: 100%;
     border-radius: var(--radius-md);
   }

--- a/src/assets/css/component/c-prose.css
+++ b/src/assets/css/component/c-prose.css
@@ -11,28 +11,28 @@
   max-inline-size: var(--_max-inline-size);
   line-height: var(--line-height-text);
 
-  & h2 {
+  h2 {
     margin-block-start: var(--space-xl);
     font-weight: var(--font-weight-heading);
   }
 
-  & :is(p, ul) {
+  :is(p, ul) {
     margin-block-start: var(--space-md);
   }
 
-  & h2 + :is(p, ul) {
+  h2 + :is(p, ul) {
     margin-block-start: var(--space-sm);
   }
 
-  & ul {
+  ul {
     padding-inline-start: var(--space-lg);
   }
 
-  & li + li {
+  li + li {
     margin-block-start: var(--space-xs);
   }
 
-  & a {
+  a {
     color: var(--color-main);
     text-decoration: underline;
     text-underline-offset: 0.2em;

--- a/src/assets/css/component/c-step-card.css
+++ b/src/assets/css/component/c-step-card.css
@@ -22,7 +22,7 @@
     border-radius: var(--radius-full);
   }
 
-  & > * {
+  > * {
     grid-column: 2;
   }
 }

--- a/src/assets/css/component/c-table.css
+++ b/src/assets/css/component/c-table.css
@@ -1,19 +1,19 @@
 .c-table {
   inline-size: 100%;
 
-  & th,
-  & td {
+  th,
+  td {
     padding: var(--space-sm) var(--space-md);
     text-align: start;
     border-block-end: var(--border-width) solid var(--color-border);
   }
 
-  & thead th {
+  thead th {
     font-weight: var(--font-weight-heading);
     background-color: var(--color-bg-secondary);
   }
 
-  & tbody th {
+  tbody th {
     font-weight: var(--font-weight-body);
   }
 }

--- a/src/assets/css/project/p-hero.css
+++ b/src/assets/css/project/p-hero.css
@@ -68,7 +68,7 @@
     background: linear-gradient(to bottom, var(--_overlay-top) 0%, var(--_overlay-bottom) 100%);
   }
 
-  & img {
+  img {
     inline-size: 100%;
     block-size: 100%;
     object-fit: cover;


### PR DESCRIPTION
## 概要

CSS Nesting の子孫セレクタ（`& .foo` / `& th` 等）から `&` を省略してクリーンにする。複合（`&.-active`）・擬似（`&:hover`）・属性（`&[...]`）は CSS 仕様上 `&` を保持。

対象: c-table / c-media-card / c-prose / c-step-card / p-hero（5 ファイル）

## 検証

コンパイル後の出力 CSS（`dist/assets/css/main.css`）は base(v1.2) と **byte 完全一致**（lightningcss が `& th` と `th` を同一の flat selector に解決）= 表示・プロパティは完全に同一。build / lint pass。

Closes #89