### PR TITLE
refactor(animation): --_duration を inline 化 + 公開 API コメント追加

### DIFF
--- a/src/assets/css/animation/fade-in-slide-up.css
+++ b/src/assets/css/animation/fade-in-slide-up.css
@@ -1,3 +1,4 @@
+/* 公開 API: --stagger-delay（順に現れる間隔） */
 @media (prefers-reduced-motion: no-preference) and (scripting: enabled) {
   @keyframes fade-in-slide-up {
     from {
@@ -7,9 +8,7 @@
   }
 
   [data-animate='fade-in-slide-up'] {
-    --_duration: 0.6s;
-
-    animation: fade-in-slide-up var(--_duration) var(--ease-out-quart) both;
+    animation: fade-in-slide-up 0.6s var(--ease-out-quart) both;
     animation-delay: var(--stagger-delay, 0s);
     animation-play-state: paused;
 


### PR DESCRIPTION
## Summary
- **S1**: `fade-in-slide-up.css` の単一使用 + Modifier なしの `--_duration` を削除し `0.6s` を inline（`scale-in.css` の duration 直書きと一貫、spec §7 `--_` = Modifier 差し替え用 MAY）
- **S2**: `--stagger-delay` の公開 API コメントをファイル先頭に追加（component 8 ファイルと同形、spec §5.7 概念名命名 SHOULD）
- book ch11（#221 merged）が教える形と reference 実装を一致（book/starter 乖離解消）

## 挙動不変の検証
- コンパイル後 CSS の差分は `--_duration: 0.6s;` 宣言削除 + `var(--_duration)` → `0.6s`（−29 bytes、LightningCSS は var を runtime 解決）。`var(--_duration)`（`--_duration: 0.6s`）は computed value で `0.6s` に解決されるため**描画挙動は完全に不変**
- S2 コメントは minify で除去 → compiled CSS への出力ゼロ
- scale-in.css は公開 API（外部入口）を持たないため未変更（コメント不要）

## レビュー
- `/ar` PASS（採用 0 / 不採用 1 / 保留 0、spec 違反ゼロ・回帰ゼロ・純度違反ゼロ）
- `/mflocss-css-check` PASS（spec §5.7/§7 整合）
- `/comment-audit` PASS（カテゴリ 6 公開 API、最小・抽象）

## Test plan
- [x] pnpm lint:css PASS
- [x] pnpm build PASS
- [x] コンパイル後 CSS の挙動不変確認（−29 bytes = var 解決の等価差分のみ）
- [x] scale-in.css と duration 直書きで一貫
- [x] book ch11（#221）が教える形と一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)
