### PR TITLE
feat: input 型ボタン（submit/button/reset）を c-button と視覚一致

### DIFF
--- a/src/assets/css/component/c-button.css
+++ b/src/assets/css/component/c-button.css
@@ -18,6 +18,7 @@
   font-weight: var(--font-weight-heading);
   line-height: var(--line-height-title);
   color: var(--_color);
+  text-align: center;
   text-decoration: none;
   cursor: pointer;
   background-color: var(--_bg-color);

--- a/src/assets/css/foundation/form.css
+++ b/src/assets/css/foundation/form.css
@@ -1,5 +1,6 @@
-:where(button) {
+:where(button, input[type='submit'], input[type='button'], input[type='reset']) {
   padding: 0;
+  appearance: none;
   touch-action: manipulation;
   cursor: pointer;
   background: none;


### PR DESCRIPTION
## 概要

input 型ボタン（`type="submit"` / `"button"` / `"reset"`）に `.c-button` を併用したとき、`button.c-button` と視覚的に一致させる。

## 変更内容

### Foundation — `foundation/form.css`

- ボタン系フォーム要素の reset 対象に `input[type='submit']` / `input[type='button']` / `input[type='reset']` を追加（従来は `button` のみ）。
- `appearance: none;` を追加し、input ボタン型のネイティブ chrome（OS デフォルトの枠・背景）を除去。

### Component — `component/c-button.css`

- `.c-button` に `text-align: center;` を 1 行追加。`appearance: none;` を当てた input の `value` テキストが左寄せになるのを防ぐ（`a` / `button` の flex レイアウトでは無害）。

## 効果

`input[type=submit|button|reset].c-button` が `button.c-button` と視覚一致する。`input[type=image]` は画像置換のため対象外。

## スコープ

本 PR の変更は上記 2 点に限定。`c-button.css` の `&:active` 周辺のコメント位置は本変更と無関係の既存状態であり、スコープを清潔に保つため変更していない（フル byte 整合が必要なら別途切り出す）。

## 検証

- `pnpm lint:css`（recess-order）PASS
- `pnpm build` PASS
- mFLOCSS 層判断チェック（Foundation reset の正当性 / Component 純度 / DRY）PASS
- コメント方針監査（新規コメント混入なし）PASS
- codex クロスレビュー: 優先修正すべき不具合なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
