### PR TITLE
docs(starter): README クイックスタートに Node.js 前提を 1 行追記（書籍 ch13 環境構築委譲に対応）

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ mFLOCSS のリファレンス実装。**実装者 / Web 制作者 / AI agent** �
 
 ## クイックスタート
 
-> **前提**: 実行には Node.js が必要です（本リポジトリは `.nvmrc` で v24 を指定）。未導入なら [nodejs.org](https://nodejs.org/) から入れてください（パッケージ管理コマンドの `npm` も同梱されます）。
+> **前提**: 実行には Node.js が必要です（v24 で動作確認）。未導入なら [nodejs.org](https://nodejs.org/) から LTS 版を入れてください（パッケージ管理コマンドの `npm` も同梱されます）。
 
 1. GitHub の「**Use this template**」ボタンから新しいリポジトリを作成
 2. 作成したリポジトリをクローン:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ mFLOCSS のリファレンス実装。**実装者 / Web 制作者 / AI agent** �
 
 ## クイックスタート
 
+> **前提**: 実行には Node.js が必要です（本リポジトリは `.nvmrc` で v24 を指定）。未導入なら [nodejs.org](https://nodejs.org/) から入れてください（パッケージ管理コマンドの `npm` も同梱されます）。
+
 1. GitHub の「**Use this template**」ボタンから新しいリポジトリを作成
 2. 作成したリポジトリをクローン:
    ```bash

--- a/src/index.html
+++ b/src/index.html
@@ -208,9 +208,7 @@
           <div class="p-hero__stack">
             <!-- CUSTOMIZE: サービス名・キャッチコピーを差し替え -->
             <div class="p-hero__content" data-immediate="scale-in">
-              <h1 class="p-hero__title" id="hero-heading">
-                からだの声を聴く、<br class="u-hidden-pc" />完全個室のボディケアサロン。
-              </h1>
+              <h1 class="p-hero__title" id="hero-heading">からだの声を聴く、<br class="u-hidden-pc" />完全個室のボディケアサロン。</h1>
               <p class="p-hero__lead">
                 忙しい毎日の中で後回しにしてきた自分のケア。<br class="u-hidden-sp" />iluha
                 は、内側から整うボディケアサロンです。

--- a/src/index.html
+++ b/src/index.html
@@ -208,7 +208,9 @@
           <div class="p-hero__stack">
             <!-- CUSTOMIZE: サービス名・キャッチコピーを差し替え -->
             <div class="p-hero__content" data-immediate="scale-in">
-              <h1 class="p-hero__title" id="hero-heading">からだの声を聴く、<br class="u-hidden-pc" />完全個室のボディケアサロン。</h1>
+              <h1 class="p-hero__title" id="hero-heading">
+                からだの声を聴く、<br class="u-hidden-pc" />完全個室のボディケアサロン。
+              </h1>
               <p class="p-hero__lead">
                 忙しい毎日の中で後回しにしてきた自分のケア。<br class="u-hidden-sp" />iluha
                 は、内側から整うボディケアサロンです。


### PR DESCRIPTION
## 変更内容

クイックスタート見出し直下に Node.js 前提を 1 行追記（callout 形式）。

## 背景

書籍 ch13（buildability G3）が環境構築を README に委譲する設計が確定。README は「実装者 / Web 制作者 / AI agent」に加え書籍読者（§1-4 = HTML/CSS は書けるが Node に不慣れな層）のクイックリファレンスにもなる。

## 問題

クイックスタートは npm install 直行で Node.js 前提が暗黙。ch13 も「Use this template → npm run dev」と進むが Node インストールは教えない（書籍 ch13 側で確認済み）。

## 対応

見出し直下に最小（1 行 callout）の前提注記。

- バージョンは実物 .nvmrc（=24）を確認の上、README には「v24 で動作確認」と記載（Node 未経験読者に .nvmrc jargon を出さない）
- nodejs.org は LTS 版を案内（LTS/Current 2 択での初学者の迷いを解消）
- npm 表記維持（運用方針「README は npm 表記維持/最低障壁」準拠）

## 整合

書籍 ch13 は npm 使用 = README と一致（pnpm 齟齬なし）。本 PR はパッケージマネージャ方針に触れず Issue #234 と直交。

## AR 結果（PASS WITH MINOR、採用済み）

| 指摘 | 採用 | 対応 |
|---|---|---|
| .nvmrc 表記は Node 未経験者に届かず「最低要件」と誤読リスク | 採用 | 「v24 で動作確認」に変更 |
| LTS 版を明示すべき | 採用 | 「LTS 版を入れてください」に変更 |
| index.html prettier 整形をスコープ外に分離 | 採用 | 別 PR（style/v1.2-prettier-drift）に分離 |

## 書籍側 follow-up（本 PR スコープ外）

ch13 に「環境構築は starter README 参照」の明示ポインタを置くと往復が完結。

## net diff

README.md +2 行のみ（前提 callout 1 行 + 空行）。README 以外のファイルに変更なし。
