### PR TITLE
style(html): index.html prettier 整形（v1.2 ドリフト解消）

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -208,7 +208,9 @@
           <div class="p-hero__stack">
             <!-- CUSTOMIZE: サービス名・キャッチコピーを差し替え -->
             <div class="p-hero__content" data-immediate="scale-in">
-              <h1 class="p-hero__title" id="hero-heading">からだの声を聴く、<br class="u-hidden-pc" />完全個室のボディケアサロン。</h1>
+              <h1 class="p-hero__title" id="hero-heading">
+                からだの声を聴く、<br class="u-hidden-pc" />完全個室のボディケアサロン。
+              </h1>
               <p class="p-hero__lead">
                 忙しい毎日の中で後回しにしてきた自分のケア。<br class="u-hidden-sp" />iluha
                 は、内側から整うボディケアサロンです。


### PR DESCRIPTION
## 変更内容

src/index.html を prettier で整形（h1 要素の展開のみ）。

## 背景

pnpm run check（prettier --write）が src/index.html を整形 = v1.2 の committed 状態が prettier 非準拠だった。PR #237（README docs）の AR でスコープ分離のため検出・切り出し。

## 変更詳細

h1.p-hero__title の内容が長くて prettier の printWidth を超えたため、prettier が複数行に展開。表示・セマンティクス・改行挙動は不変（br タグによる改行位置は維持）。

## 確認

- 整形のみ（表示変化なし）
- lint:html（markuplint）pass 確認済み
- 他ファイルへの影響なし

## 関連

PR #237（docs/readme-node-prerequisite）のスコープ分離で発生。
