### PR TITLE
fix(deps): security pin の両系統化 — npm overrides を pnpm.overrides と同内容で併記 (#234)

### DIFF
--- a/CODING_GUIDE.md
+++ b/CODING_GUIDE.md
@@ -18,6 +18,14 @@
 
 Starter 開発（Contribute）の場合は pnpm 推奨。詳細は [CONTRIBUTING.md](./CONTRIBUTING.md) 参照。
 
+### 脆弱性 pin（npm / pnpm 両系統の同期）
+
+`package.json` の **npm `overrides`** と **`pnpm.overrides`** は同一内容に保ちます（npm は `pnpm.overrides` を読まないため、npm 利用者にも pin を効かせるためのミラー）。
+
+- 脆弱性 pin の **追加・剪定時は両方を同時に更新**してください。片方だけの変更は禁止。
+- 純粋なバージョン制約（`">=x.y.z"` 等）は npm / pnpm で同形式互換のため、そのままミラーすれば動作します。
+- 同期確認: `npm install --package-lock-only` 後 `npm ls <pkg>` で pin 版に解決されることを検証。
+
 ## GitHub Actions CI
 
 `.github/workflows/check.yml` 参照。Fork / Clone 後は自動 skip（自分のプロジェクトで有効化する場合は `jobs.check.if` 行を削除）。

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ mFLOCSS のリファレンス実装。**実装者 / Web 制作者 / AI agent** �
    npm install
    npm run dev
    ```
+   pnpm でも可（推奨: `pnpm install` で同梱 `pnpm-lock.yaml` による再現ビルド。詳細は [CODING_GUIDE.md](./CODING_GUIDE.md#パッケージマネージャー) 参照）。
 3. ターミナルに表示された URL をブラウザで開き、LP が表示されることを確認
 
 ## ファイル構成

--- a/package.json
+++ b/package.json
@@ -26,6 +26,11 @@
     "stylelint-config-standard": "^40.0.0",
     "vite": "^8.0.5"
   },
+  "overrides": {
+    "uuid": ">=14.0.0",
+    "fast-uri": ">=3.1.2",
+    "brace-expansion": ">=5.0.6"
+  },
   "pnpm": {
     "overrides": {
       "uuid": ">=14.0.0",


### PR DESCRIPTION
## 概要

`package.json` の `pnpm.overrides`（脆弱性 pin）を npm `overrides` キーにも同内容でミラーし、npm 利用者にも security pin が効くようにする（両系統化）。`mflocss/starter#234`。

## 背景

- `pnpm.overrides` は pnpm 専用キー。**npm はこれを読まない**ため、`npm install` した利用者には pin が一切効かない状態だった。
- 実証（task brief より）: `pnpm.overrides` を外して `pnpm audit` すると **uuid に 1 moderate（GHSA-w5hq-g745-h8pq、parser-utils 経由で uuid 13.0.0 が引き込まれる）** が発生。npm 利用者は現状この穴を踏む。
- fast-uri / brace-expansion は現時点で registry 最新が修正版以上のため pin は冗長だが、**本 PR では剪定せず 3 件すべてミラー**（security pin 削除は意図的な別アクションで、本タスクに含めない確定方針）。

## 変更

| ファイル | 内容 |
|---|---|
| `package.json` | 既存 `pnpm.overrides` の真上に **npm `overrides`** キーを追加（同一の 3 件・同一バージョン制約） |
| `CODING_GUIDE.md` | §パッケージマネージャー 配下に「脆弱性 pin（npm / pnpm 両系統の同期）」サブ section を追加。両系統同期ルール + 検証手順を明文化（JSON はインラインコメント不可のため、同期注記の唯一の責任者として CODING_GUIDE に置く） |
| `README.md` | クイックスタートに 1 行「pnpm でも可（推奨: 同梱 `pnpm-lock.yaml` による再現ビルド）」+ CODING_GUIDE 内部リンク |

### GHSA-ID（commit message にも記載）

- uuid: `GHSA-w5hq-g745-h8pq`
- fast-uri: `GHSA-v39h-62p7-jpjc`
- brace-expansion: `GHSA-jxxr-4gwj-5jf2`

## 検証（AR 自己適用）

### Critical 観点

- [x] **JSON 構文正当性**: `npm install --package-lock-only` が成功（arborist の依存解決が成立）
- [x] **pin 反映（npm 系）**: 生成された `package-lock.json` で resolved version 確認:
  - `node_modules/uuid` → **14.0.1**（>=14.0.0 ✅）
  - `node_modules/fast-uri` → **4.0.0**（>=3.1.2 ✅）
  - `node_modules/brace-expansion` → **5.0.6**（>=5.0.6 ✅）
- [x] **pin 反映（pnpm 系）**: `pnpm.overrides` 未変更 → 既存の `pnpm-lock.yaml` で pin 継続（CI `pnpm install --frozen-lockfile` 経路は影響なし）
- [x] **audit クリーン（npm）**: `npm audit` → `found 0 vulnerabilities`
- [x] **剪定していない**: fast-uri / brace-expansion を含む 3 件すべてミラー（task brief の「3 件すべて」要件遵守）
- [x] **両系統同内容**: npm `overrides` と `pnpm.overrides` が 3 件・同一バージョン制約・同一順序
- [x] **main 不可触**: base = `v1.2`（mflocss/starter は private で v1.2 dev マージ自律可）

### Essential 観点

- [x] **CI 影響なし**: `.github/workflows/check.yml` は `pnpm install --frozen-lockfile` 経由で `pnpm-lock.yaml` を source of truth とする。`pnpm.overrides` 未変更のため CI は安定
- [x] **`.npmrc` 互換**: `.npmrc` の `minimum-release-age-exclude[]=` は pnpm 専用設定で npm は警告のみ（エラーなし）
- [x] **`package-lock.json` 非同梱**: 既存方針（lock 2 本 drift 回避）を守り、検証用に生成した lockfile は commit 前に削除済み
- [x] **ドキュメント整合**: README → CODING_GUIDE → package.json の三者で「両系統サポート + pnpm 推奨 + pin は両系統同期」のメッセージが一貫
- [x] **既存 §パッケージマネージャー との整合**: 既存の「npm でも動作」「pnpm 推奨」の趣旨を破壊せず、サブ section 追加で補完
- [x] **検証手順を文書化**: CODING_GUIDE サブ section に「同期確認: \`npm install --package-lock-only\` 後 \`npm ls <pkg>\` で pin 版に解決されることを検証」と記載 → 将来のメンテナが同じ検証を再現可能

### 既知の制約 / 残課題

- **wp-starter（mflocss/wordpress-starter）横展開**: 同型適用が #234 完了条件に含まれる。本 PR は starter 単独で、wp-starter への同型適用は別途実施。**#234 close は wp-starter 側 PR マージ完了後**に実施

## 関連

- Issue: mflocss/starter#234
- 起源: mflocss エコシステム監査（2026-06-11）
- 方針確定: 2026-06-11 しゅんえい判断「現方針維持」+ 2026-06-27 「剪定せず 3 件すべてミラー」確定