### PR TITLE
fix(deps): 冗長 override を剪定（fast-uri / brace-expansion）+ CODING_GUIDE 剪定運用反映

### DIFF
--- a/CODING_GUIDE.md
+++ b/CODING_GUIDE.md
@@ -25,6 +25,7 @@ Starter 開発（Contribute）の場合は pnpm 推奨。詳細は [CONTRIBUTING
 - 脆弱性 pin の **追加・剪定時は両方を同時に更新**してください。片方だけの変更は禁止。
 - 純粋なバージョン制約（`">=x.y.z"` 等）は npm / pnpm で同形式互換のため、そのままミラーすれば動作します。
 - 同期確認: `npm install --package-lock-only` 後 `npm ls <pkg>` で pin 版に解決されることを検証。
+- **剪定の運用**: 上流が修正版を出した後の冗長判定は、対象 override を一時的に外して `pnpm install --lockfile-only` + `pnpm audit`（lockfile-only dry-run）→ 脆弱性が出なければ剪定可。**剪定時は commit メッセージに GHSA-ID を残す**（Dependabot 等で再 flag された際に出所を辿って re-add 判断するため）。
 
 ## GitHub Actions CI
 

--- a/package.json
+++ b/package.json
@@ -27,15 +27,11 @@
     "vite": "^8.0.5"
   },
   "overrides": {
-    "uuid": ">=14.0.0",
-    "fast-uri": ">=3.1.2",
-    "brace-expansion": ">=5.0.6"
+    "uuid": ">=14.0.0"
   },
   "pnpm": {
     "overrides": {
-      "uuid": ">=14.0.0",
-      "fast-uri": ">=3.1.2",
-      "brace-expansion": ">=5.0.6"
+      "uuid": ">=14.0.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,6 @@ settings:
 
 overrides:
   uuid: '>=14.0.0'
-  fast-uri: '>=3.1.2'
-  brace-expansion: '>=5.0.6'
 
 importers:
 


### PR DESCRIPTION
## 概要

冗長化した override `fast-uri` / `brace-expansion` を剪定し（uuid のみ実効維持）、CODING_GUIDE の同期注記に「剪定の運用」を反映する。

## 背景

- 過去 PR #234 / #240 で 3 件の override（uuid / fast-uri / brace-expansion）を npm 系統と pnpm 系統に両系統化済
- knowledge policy `expertise/development/dependency-override-lifecycle.md` で「追加 + audit dry-run 剪定 + GHSA コメント保全」のライフサイクルを明文化済（PR#81 マージ済）
- 本 PR は同 policy の **初回適用**

## 変更内容

### 1. package.json + pnpm-lock.yaml: override 剪定

| Override | 前 | 後 | 出所 | 判定 |
|---|---|---|---|---|
| uuid | `>=14.0.0` | `>=14.0.0` | GHSA-w5hq-g745-h8pq | **維持**（dry-run で moderate 復活確認）|
| fast-uri | `>=3.1.2` | 削除 | GHSA-v39h-62p7-jpjc | **剪定**（registry 最新が修正版以上で冗長）|
| brace-expansion | `>=5.0.6` | 削除 | GHSA-jxxr-4gwj-5jf2 | **剪定**（registry 最新が修正版以上で冗長）|

npm `overrides` と `pnpm.overrides` の **両系統を同一に保つ**（uuid のみ）。

### 2. CODING_GUIDE.md: 同期注記に剪定運用を 1 項追記

「### 脆弱性 pin（npm / pnpm 両系統の同期）」に以下を追加:

> - **剪定の運用**: 上流が修正版を出した後の冗長判定は、対象 override を一時的に外して `pnpm install --lockfile-only` + `pnpm audit`（lockfile-only dry-run）→ 脆弱性が出なければ剪定可。**剪定時は commit メッセージに GHSA-ID を残す**（Dependabot 等で再 flag された際に出所を辿って re-add 判断するため）。

## 検証（dry-run + 本リポ）

### 剪定前 dry-run（/tmp 隔離コピー）

- `fast-uri` / `brace-expansion` override を除いた package.json で `pnpm install --lockfile-only` + `pnpm audit`
- 結果: **No known vulnerabilities found** → 冗長確定
- `uuid` も外した版で audit → markuplint 経由の uuid 13.0.0 で **moderate (GHSA-w5hq-g745-h8pq) 復活** → uuid override は実効

### 剪定後 本リポ `pnpm audit`

- 検出 3 件: vite x2（GHSA-fx2h-pf6j-xcff / GHSA-v6wh-96g9-6wx3）+ js-yaml（GHSA-h67p-54hq-rp68）
- これらは `origin/v1.2` baseline でも **同じ 3 件** が出る既存課題 → 本剪定と因果なし
- fast-uri / brace-expansion 由来の **追加脆弱性なし**

baseline と完全一致を確認済みのため、剪定は audit 結果に影響なし。vite / js-yaml の 3 件は別途対処（本 PR のスコープ外）。

## AR（B 段階 / 周辺 8 軸）

- 段階: **B 段階**（変更中心 + 周辺 8 軸）
- 観点段階: **🟢 Essential**（Web プロダクトの品質保証だが目的直結致命ではない）
- リリース前 7 条件: 該当なし（v1.2 への通常修正 PR、main 非タッチ、PUBLIC 切替なし、メジャー破壊変更なし）
- 8 軸チェック:
  1. **直接修正ファイル**: package.json / pnpm-lock.yaml / CODING_GUIDE.md ✓（差分最小、3 ファイルのみ）
  2. **import 参照**: 該当なし（deps 自体の変更、コード側参照なし）
  3. **同 Layer 他ファイル**: 該当なし
  4. **横展開対象**: mflocss-wordpress-starter は `postcss` override のみで fast-uri / brace-expansion は元から無し → ミラー対象なし確認済。他リポへの波及なし
  5. **spec 対応条項**: 該当なし（spec とは無関係、starter ローカル運用注記）
  6. **テスト / Example**: 該当なし
  7. **ドキュメント**: CODING_GUIDE.md の脆弱性 pin 節を同 PR で更新済 ✓ / README / CHANGELOG は無関係
  8. **公開 API 互換性**: 該当なし（devDependencies の dep tree 整理、ユーザー API 影響なし）

**判定: PASS**（B 段階 8 軸すべてクリア、構造変更含有率 0%、採用件数 0 件 = 自己修正のみ）。独立検証パス。

## Dependabot 再 flag 時

本 PR の commit message から GHSA-ID + 旧 pin 値を辿り、上流修正版がまだ届いていない経路があれば re-add する。

## 関連

- knowledge `expertise/development/dependency-override-lifecycle.md`（policy）の初回適用
- 過去 PR: #234（pnpm.overrides → npm overrides 両系統化）/ #240（v1.2 cherry-pick）
- 別途対処予定: vite GHSA-fx2h-pf6j-xcff / GHSA-v6wh-96g9-6wx3 + js-yaml GHSA-h67p-54hq-rp68（既存課題、本 PR スコープ外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
