### PR TITLE
style: Modifier 記法を Block 内ネストへ統一 + CODING_GUIDE 明文化 (#247)

### DIFF
--- a/CODING_GUIDE.md
+++ b/CODING_GUIDE.md
@@ -73,6 +73,34 @@ chore(deps): 冗長 override を剪定 — fast-uri / brace-expansion を削除�
 
 差し替えポイントはコード全体で `CUSTOMIZE` コメントを検索すると発見できます（HTML・CSS・vite.config.ts に記載）。
 
+## Modifier 記法
+
+Modifier は Block/Element 内に `&.-modifier` でネストして記述します（State セレクタ `&:hover` / `&[data-*]` と同じ書き味）。Block に属するルールはすべて `&` でネストし、関連性を示します。トップレベルのフラット `.c-block.-modifier {}` は使いません。
+
+```css
+/* ✅ Block 内にネスト */
+.c-card {
+  padding: var(--_padding);
+
+  &.-subtle {
+    --_bg: var(--card-bg, var(--color-bg-secondary));
+  }
+}
+
+/* ❌ トップレベルのフラット記法（使わない） */
+.c-card {
+  padding: var(--_padding);
+}
+
+.c-card.-subtle {
+  --_bg: var(--card-bg, var(--color-bg-secondary));
+}
+```
+
+**理由**: Block に属するルールをすべて `&` でネストすることで、State セレクタ（`&:hover` / `&[data-loading]`）と同じ書き味になり、Modifier も「その Block に関するルール」として一目で判別できます。コンパイル後の出力セレクタ（例: `.c-card.-subtle`）はネストの有無で変わりません。
+
+参考実装: `c-button.css`（`&.-ghost` / `&.-large`）/ `c-media-card.css`（`&.-stacked`）/ `c-card.css`（`&.-subtle`）/ `c-badge.css`（`&.-accent`）。
+
 ## ビルドと納品
 
 ```bash

--- a/src/assets/css/component/c-button.css
+++ b/src/assets/css/component/c-button.css
@@ -48,23 +48,23 @@
     pointer-events: none;
     opacity: 0.7;
   }
+
+  /* Modifier: -ghost */
+  &.-ghost {
+    --_color: var(--button-color, var(--color-main));
+    --_bg-color: var(--button-bg-color, transparent);
+    --_border-color: var(--button-border-color, var(--color-main));
+    --_hover-bg-color: var(--button-hover-bg-color, oklch(from var(--color-main) l c h / 8%));
+  }
+
+  &.-large {
+    padding: var(--space-md) var(--space-xl);
+    font-size: var(--font-size-button-lg);
+  }
 }
 
 .c-button__icon {
   flex-shrink: 0;
   inline-size: 1em;
   block-size: 1em;
-}
-
-/* Modifier: -ghost */
-.c-button.-ghost {
-  --_color: var(--button-color, var(--color-main));
-  --_bg-color: var(--button-bg-color, transparent);
-  --_border-color: var(--button-border-color, var(--color-main));
-  --_hover-bg-color: var(--button-hover-bg-color, oklch(from var(--color-main) l c h / 8%));
-}
-
-.c-button.-large {
-  padding: var(--space-md) var(--space-xl);
-  font-size: var(--font-size-button-lg);
 }

--- a/src/assets/css/component/c-media-card.css
+++ b/src/assets/css/component/c-media-card.css
@@ -14,15 +14,15 @@
   > :first-child {
     order: var(--_first-order);
   }
-}
 
-/* Modifier: -stacked（投稿カード等の縦並び固定バリエーション） */
-.c-media-card.-stacked {
-  grid-template-columns: 1fr;
-  gap: var(--space-md);
-  align-items: start;
+  /* Modifier: -stacked（投稿カード等の縦並び固定バリエーション） */
+  &.-stacked {
+    grid-template-columns: 1fr;
+    gap: var(--space-md);
+    align-items: start;
 
-  /* @container クエリなしで常に縦並び（投稿カード一覧の小さなカード内で適合） */
+    /* @container クエリなしで常に縦並び（投稿カード一覧の小さなカード内で適合） */
+  }
 }
 
 .c-media-card__content {


### PR DESCRIPTION
## 背景

#247 で Modifier 記法がフラット / ネストで混在していた。裁定 = **ネスト統一**（Modifier は Block/Element 内に `&.-modifier` でネスト = State セレクタ `&:hover` / `&[data-*]` と同じ書き味。Block に属するルールを全て `&` でネストして関連を示す）。

## 変更

- `c-button`（`.-ghost` / `.-large`）+ `c-media-card`（`.-stacked`）をトップレベルのフラット `.c-block.-mod` から Block 内 `&.-mod` ネストへ移動（`c-card` / `c-badge` は既にネスト済みのため変更なし）
- `CODING_GUIDE.md` に「## Modifier 記法」節を追加（規約明文化 + ✅例 + 理由 + 参考実装）

## 検証（firsthand）

- `vite build` ✓ pass
- コンパイル後 `main.css` に `.c-button.-ghost` / `.c-button.-large` / `.c-media-card.-stacked` が出力（authoring ネスト → 出力フラット が正しく展開 = セレクタ不変）
- component 層にトップレベルのフラット Modifier 残存なし（grep 0）
- 作業ツリー汚染なし

## スコープ

本 PR は starter 本体のネスト統一 + CODING_GUIDE 明文化まで。spec §5.5 Example / 書籍コード例 / wordpress-starter / mflocss.dev への波及は別途のため #247 は open 維持。base = v1.2（v1.0 リファレンス実装ブランチ）。