### PR TITLE
docs: CODING_GUIDE を doc-role で restructure + CHANGELOG v1.0 最小化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,24 +2,18 @@
 
 mFLOCSS starter の変更履歴。[Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) 形式に準拠し、[Semantic Versioning](https://semver.org/lang/ja/) に従う。
 
+CHANGELOG はリリース（version-up）直前に差分をまとめて追記します（運用方針は [CONTRIBUTING.md「リリース時の手順」](./CONTRIBUTING.md#リリース時の手順) 参照）。
+
 ## [Unreleased] (v1.0 リリース予定)
 
 初回正式リリース。
 
 ### Added
 
-- mFLOCSS 仕様書 v1.0 準拠のリファレンス実装（Vite + Native CSS + Native JS、ビルドレス・モダン CSS）
-- 8 層の `@layer` 構造（Token / Reset / Foundation / Layout / Component / Project / Animation / Utility）
-- Component 使い方の統一原則 13 項 + 例外 A/B/C
-- class 記載順 / HTML 属性順 / CSS 定義順 の 3 順序ルール
-- 統一 Block 併記パターン（責任直交合成）
-- Baseline 2024 対応（論理プロパティ / Container Queries / `:has()` / `@layer` / `oklch()` / `light-dark()` / `clamp()`）
-- WCAG 2.2 AA 準拠
-- Core Web Vitals 配慮（LCP preload / `fetchpriority` / `prefers-reduced-motion`）
-- Dark mode 対応（`prefers-color-scheme`）
-- Community health files（CHANGELOG / CONTRIBUTING / SECURITY / CODE_OF_CONDUCT）
-- GitHub Actions CI（starter 本体のみ発動、Fork / Clone 時は自動 skip）
-- Issue テンプレート（bug report / feature request）
-- ローカル `npm run preview` での 404 fallback 動作（`vite.config.ts` の `preview-404-fallback` plugin により本番ホスティング動作を完全再現、教材性向上）
+- mFLOCSS 仕様書 v1.0 準拠のリファレンス実装（Vite + Native CSS + Native JS、ビルドレス）
+- `@layer` によるカスケード制御（Token / Reset / Foundation / Layout / Component / Project / Animation / Utility）
+- モダン CSS 全面採用（論理プロパティ / Container Queries / `:has()` / `oklch()` / `light-dark()` / `clamp()`）
+- WCAG 2.2 AA 準拠 + Core Web Vitals 配慮 + Dark mode 対応（`prefers-color-scheme`）
+- Community health files + GitHub Actions CI + Issue テンプレート
 
 [Unreleased]: https://github.com/mflocss/starter/compare/v1.0.0...HEAD

--- a/CODING_GUIDE.md
+++ b/CODING_GUIDE.md
@@ -1,8 +1,10 @@
 # コーディングガイド
 
-**starter のコードを書く / 拡張する開発者向け**の運用ルールです（mFLOCSS の starter 固有の規約）。
-層の定義・命名規則・カスタムプロパティ参照ルール等の仕様は [mFLOCSS 仕様書](https://github.com/mflocss/spec) を参照してください。
-関連リンク（公式サイト / デモサイト / 書籍）は [README.md](./README.md) を参照してください。
+この starter を**使う（ビルド・カスタマイズ・メンテナンス・デプロイ）ときの運用ガイド**です。mFLOCSS 仕様書 v1.0 準拠のリファレンス実装として、パッケージ管理・CI・ビルド・アセット配置・コンポーネント運用の勘所をまとめています。
+
+- **mFLOCSS の設計そのもの**（層の定義・命名規則・カスタムプロパティ参照ルール等）は [mFLOCSS 仕様書](https://github.com/mflocss/spec) と [mFLOCSS 書籍](https://zenn.dev/shunei/books/mflocss-design) を参照してください。この starter は仕様を**コードで実証**します。
+- **starter 本体へ貢献するときのコード規約**（JS フックの分離・コミットメッセージ規約等）は [CONTRIBUTING.md](./CONTRIBUTING.md) を参照してください。
+- 関連リンク（公式サイト / デモサイト / 書籍）は [README.md](./README.md) を参照してください。
 
 ## パッケージマネージャー
 
@@ -72,34 +74,6 @@ chore(deps): 冗長 override を剪定 — fast-uri / brace-expansion を削除�
 詳細は **[mFLOCSS 書籍](https://zenn.dev/shunei/books/mflocss-design)** を参照してください。
 
 差し替えポイントはコード全体で `CUSTOMIZE` コメントを検索すると発見できます（HTML・CSS・vite.config.ts に記載）。
-
-## Modifier 記法
-
-Modifier は Block/Element 内に `&.-modifier` でネストして記述します（State セレクタ `&:hover` / `&[data-*]` と同じ書き味）。Block に属するルールはすべて `&` でネストし、関連性を示します。トップレベルのフラット `.c-block.-modifier {}` は使いません。
-
-```css
-/* ✅ Block 内にネスト */
-.c-card {
-  padding: var(--_padding);
-
-  &.-subtle {
-    --_bg: var(--card-bg, var(--color-bg-secondary));
-  }
-}
-
-/* ❌ トップレベルのフラット記法（使わない） */
-.c-card {
-  padding: var(--_padding);
-}
-
-.c-card.-subtle {
-  --_bg: var(--card-bg, var(--color-bg-secondary));
-}
-```
-
-**理由**: Block に属するルールをすべて `&` でネストすることで、State セレクタ（`&:hover` / `&[data-loading]`）と同じ書き味になり、Modifier も「その Block に関するルール」として一目で判別できます。コンパイル後の出力セレクタ（例: `.c-card.-subtle`）はネストの有無で変わりません。
-
-参考実装: `c-button.css`（`&.-ghost` / `&.-large`）/ `c-media-card.css`（`&.-stacked`）/ `c-card.css`（`&.-subtle`）/ `c-badge.css`（`&.-accent`）。
 
 ## ビルドと納品
 
@@ -213,42 +187,3 @@ Drawer と Hamburger トリガー**以外**の、フォーカス可能（= Tab �
 #### JS 側
 
 `querySelectorAll('[data-drawer-inert]')` で全対象要素を取得 → `openDrawer` で `inert` 属性付与、`closeDrawer` で削除するだけ。新規対象を追加しても JS 側の変更は不要です。
-
-## JS フックの分離
-
-JS で DOM 要素を取得する際は **`data-*` 属性** を使います。スタイルクラス（`c-` / `p-` / `l-` / `u-` プレフィックス）を JS フックに使ってはいけません。
-
-```js
-// ✅ data-* 属性で JS フック
-document.querySelectorAll('[data-validate]');
-
-// ❌ スタイルクラスを JS フックに使用（禁止）
-document.querySelectorAll('.c-form');
-```
-
-**理由**: スタイルクラスは CSS 設計の都合で変更・削除されることがあります。JS フックにスタイルクラスを使うと、デザイン変更が JS バグに直結します（スタイルと挙動の結合）。`data-*` 属性はスタイルとは独立しており、HTML の意味を壊さずに JS の選択対象を明示できます。
-
-## コミットメッセージ
-
-prefix で変更の種類を明示し、タイトルで変更の影響を日本語で伝えます。git log を一覧したときに「何が変わったか」が即座に分かり、差し戻しや cherry-pick の判断コストを削減できます。
-
-```
-<prefix>: 変更内容を日本語で簡潔に
-```
-
-### prefix
-
-| prefix | 用途 | 例 |
-|--------|------|-----|
-| `feat` | 新機能・新コンポーネント追加 | `feat: FAQ セクションにアコーディオンを追加` |
-| `fix` | バグ修正・表示崩れ修正 | `fix: SP でハンバーガーメニューが閉じない問題を修正` |
-| `refactor` | 動作を変えないコード改善 | `refactor: p-header の CSS 変数をトークン参照に統一` |
-| `style` | フォーマット・空白・セミコロン等 | `style: Prettier による自動整形` |
-| `docs` | ドキュメントのみの変更 | `docs: README にダークモード無効化手順を追加` |
-| `chore` | ビルド・設定・依存関係 | `chore: Stylelint を v17 に更新` |
-
-### ルール
-
-- prefix は英語、タイトルは日本語
-- 「何を変えたか」ではなく「何が変わるか」を書く
-- 1行目は 72 文字以内を目安に

--- a/CODING_GUIDE.md
+++ b/CODING_GUIDE.md
@@ -125,7 +125,7 @@ Vite は `publicDir`（= `public/`）配下のファイルをそのまま `dist/
 
 ## ブレークポイント値の CSS/JS 同期
 
-`public/assets/scripts/viewport.js` の `VIEWPORT_MIN` は、`token/structure.css` の `--viewport-min` と同じ値に合わせてください。この値を変更する場合は両方を更新する必要があります。CSS と JS の基準値を一致させることで、400px 未満の端末でもレイアウト崩れを防ぎ、変更時の修正漏れを防止できます。
+`public/assets/scripts/viewport.js` の `VIEWPORT_MIN` は、`src/assets/css/token/structure.css` の `--viewport-min` と同じ値に合わせてください。この値を変更する場合は両方を更新する必要があります。CSS と JS の基準値を一致させることで、400px 未満の端末でもレイアウト崩れを防ぎ、変更時の修正漏れを防止できます。
 
 ## ドロワー（p-drawer / c-overlay）
 

--- a/CODING_GUIDE.md
+++ b/CODING_GUIDE.md
@@ -73,7 +73,7 @@ chore(deps): 冗長 override を剪定 — fast-uri / brace-expansion を削除�
 
 詳細は **[mFLOCSS 書籍](https://zenn.dev/shunei/books/mflocss-design)** を参照してください。
 
-差し替えポイントはコード全体で `CUSTOMIZE` コメントを検索すると発見できます（HTML・CSS・vite.config.ts に記載）。
+差し替えポイントはコード全体で `CUSTOMIZE` コメントを検索すると発見できます。
 
 ## ビルドと納品
 
@@ -113,13 +113,12 @@ npm run preview
 
 ## アセット配置規約
 
-mFLOCSS starter family（static starter / wordpress-starter）共通の配置基準です。
+本 starter の静的アセット配置基準です。
 
 | 対象 | 配置先 | 理由 |
 |------|--------|------|
 | favicon / OGP / robots.txt / sitemap.xml | `public/` 直下 | ルートパス固定が必要な静的ファイル |
 | viewport.js 等の非バンドル JS | `public/assets/scripts/` | `src/assets/scripts/` と階層を対称に揃えつつ非バンドル維持 |
-| WP テーマメタファイル（style.css メタ / screenshot.png）| theme root | wordpress-starter のみ該当（静的 starter では不要） |
 
 Vite は `publicDir`（= `public/`）配下のファイルをそのまま `dist/` へコピーします。`public/assets/scripts/` に置くことで `dist/assets/scripts/` に出力され、バンドル対象の `src/assets/scripts/` の出力先と階層が一致します。
 
@@ -142,7 +141,7 @@ Vite は `publicDir`（= `public/`）配下のファイルをそのまま `dist/
 <main ... data-drawer-inert>...</main>
 ```
 
-### z-index 設計（starter 固有）
+### z-index 設計
 
 token は `src/assets/css/token/z-index.css` を参照。
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,31 +26,75 @@ pnpm install
 pnpm dev
 ```
 
-エンドユーザー向け手順は [README.md](./README.md) を、運用ルール（パッケージマネージャー / ビルド・納品 / 各種規約）は [CODING_GUIDE.md](./CODING_GUIDE.md) を参照してください。
+エンドユーザー向け手順は [README.md](./README.md) を、starter を使うときの運用ルール（パッケージマネージャー / ビルド・納品 / アセット配置 / ドロワー運用等）は [CODING_GUIDE.md](./CODING_GUIDE.md) を参照してください。
 
 ## 基本フロー
 
 1. Issue で議論（小さい修正は直接 PR でも OK）
 2. ブランチ名: `feat/` `fix/` `refactor/` `chore/` `docs/` のいずれか + 短い要約
-3. commit message: 詳細は [CODING_GUIDE.md「コミットメッセージ」](./CODING_GUIDE.md#コミットメッセージ) 参照
+3. commit message: 下記「[コード規約 > コミットメッセージ](#コミットメッセージ)」の規約に従う
 4. PR 作成前に `pnpm run check` + `pnpm run build` 通過確認
 5. PR 作成前に `pnpm run preview` で動作確認（404 ページの fallback 含む。詳細は [CODING_GUIDE.md「404 ページの動作確認」](./CODING_GUIDE.md#404-ページの動作確認) 参照）
 6. PR body に変更理由・spec 参照節・動作確認項目を記載
 
 ## コード規約
 
-詳細は [CODING_GUIDE.md](./CODING_GUIDE.md) 参照。基本原則:
+starter 本体のコードを書く / 拡張するときの規約です。
+
+### mFLOCSS 準拠
 
 - mFLOCSS spec § の該当節に準拠
 - 既存 Component / Project のパターンを踏襲
 - コメント方針は CSS 内コメント / PR body 参照
 
+### JS フックの分離
+
+JS で DOM 要素を取得する際は **`data-*` 属性** を使います。スタイルクラス（`c-` / `p-` / `l-` / `u-` プレフィックス）を JS フックに使ってはいけません。
+
+```js
+// ✅ data-* 属性で JS フック
+document.querySelectorAll('[data-validate]');
+
+// ❌ スタイルクラスを JS フックに使用（禁止）
+document.querySelectorAll('.c-form');
+```
+
+**理由**: スタイルクラスは CSS 設計の都合で変更・削除されることがあります。JS フックにスタイルクラスを使うと、デザイン変更が JS バグに直結します（スタイルと挙動の結合）。`data-*` 属性はスタイルとは独立しており、HTML の意味を壊さずに JS の選択対象を明示できます。
+
+### コミットメッセージ
+
+prefix で変更の種類を明示し、タイトルで変更の影響を日本語で伝えます。git log を一覧したときに「何が変わったか」が即座に分かり、差し戻しや cherry-pick の判断コストを削減できます。
+
+```
+<prefix>: 変更内容を日本語で簡潔に
+```
+
+#### prefix
+
+| prefix | 用途 | 例 |
+|--------|------|-----|
+| `feat` | 新機能・新コンポーネント追加 | `feat: FAQ セクションにアコーディオンを追加` |
+| `fix` | バグ修正・表示崩れ修正 | `fix: SP でハンバーガーメニューが閉じない問題を修正` |
+| `refactor` | 動作を変えないコード改善 | `refactor: p-header の CSS 変数をトークン参照に統一` |
+| `style` | フォーマット・空白・セミコロン等 | `style: Prettier による自動整形` |
+| `docs` | ドキュメントのみの変更 | `docs: README にダークモード無効化手順を追加` |
+| `chore` | ビルド・設定・依存関係 | `chore: Stylelint を v17 に更新` |
+
+#### ルール
+
+- prefix は英語、タイトルは日本語
+- 「何を変えたか」ではなく「何が変わるか」を書く
+- 1行目は 72 文字以内を目安に
+
 ## リリース時の手順
 
-1. `CHANGELOG.md` の `## [Unreleased]` セクション見出しを `## [x.y.z] - YYYY-MM-DD` に置換（リリース実日付を記入）
-2. `## [Unreleased]` セクションをファイル先頭に新設（空の状態で追加）
-3. ファイル末尾の link references を更新（`[Unreleased]` の比較 URL と `[x.y.z]` のタグ URL を追加）
-4. `git tag vx.y.z` でリリースタグを切る
+CHANGELOG は **per-PR で都度更新せず、リリース（version-up）直前に差分をまとめて追記**します（更新の手間と PR ノイズを減らすため）。リリース時に以下を行います:
+
+1. `CHANGELOG.md` の `## [Unreleased]` セクションに、前回リリース以降の差分をまとめて追記
+2. `## [Unreleased]` セクション見出しを `## [x.y.z] - YYYY-MM-DD` に置換（リリース実日付を記入）
+3. `## [Unreleased]` セクションをファイル先頭に新設（空の状態で追加）
+4. ファイル末尾の link references を更新（`[Unreleased]` の比較 URL と `[x.y.z]` のタグ URL を追加）
+5. `git tag vx.y.z` でリリースタグを切る
 
 ## 行動規範
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 mFLOCSS のリファレンス実装。**実装者 / Web 制作者 / AI agent** がモダンで高品質な CSS 設計を学び、テンプレートとしてそのまま案件に投入できます。架空の美容サロン「iluha」の LP をサンプルとして、テキストや画像を差し替えるだけで使い始められます。
 
-開発者向け運用ルール: [CODING_GUIDE.md](./CODING_GUIDE.md) / 設計判断の詳細: [mFLOCSS 書籍](https://zenn.dev/shunei/books/mflocss-design)
+使うときの運用ガイド: [CODING_GUIDE.md](./CODING_GUIDE.md) / 貢献・コード規約: [CONTRIBUTING.md](./CONTRIBUTING.md) / 設計判断の詳細: [mFLOCSS 書籍](https://zenn.dev/shunei/books/mflocss-design)
 
 ## クイックスタート
 
@@ -76,7 +76,8 @@ Baseline Newly Available（全モダンブラウザの最新安定版でサポ�
 
 リポ内ドキュメント:
 
-- [CODING_GUIDE.md](./CODING_GUIDE.md) — starter のコードを書く / 拡張する開発者向けの規約
+- [CODING_GUIDE.md](./CODING_GUIDE.md) — starter を使うときの運用ガイド（ビルド / カスタマイズ / メンテ / デプロイ）
+- [CONTRIBUTING.md](./CONTRIBUTING.md) — starter 本体への貢献フローとコード規約
 - [CHANGELOG.md](./CHANGELOG.md) — 変更履歴（Keep a Changelog 準拠）
 
 mFLOCSS エコシステム:


### PR DESCRIPTION
## 概要

公開リファレンス実装（starter）のドキュメント doc-role を整理し、各ドキュメントの責務を読者ロール別に明確化する。

## doc-role の考え方

- **README** — 概要 + クイックスタート
- **CODING_GUIDE** — starter を*使う*人向け（ビルド / カスタマイズ / メンテ / デプロイ / 運用の勘所）
- **CONTRIBUTING** — starter 本体へ*貢献する*人向け（貢献フロー + コード規約）
- **mFLOCSS の設計そのもの** — 仕様書 / 書籍へのポインタ（starter で再教育せず、コードで実証する）

## 変更

- **CODING_GUIDE**: intro を「利用者向け運用ガイド」に reframe。個人の authoring 選好にあたる `## Modifier 記法` 節を除去（CSS コードのネスト自体は維持）。`## JS フックの分離`・`## コミットメッセージ` を CONTRIBUTING「コード規約」へ移設。互換のためファイル名は `CODING_GUIDE.md` を維持。
- **CONTRIBUTING**: `## コード規約` を拡充し JS フックの分離 + コミットメッセージ規約を収容。CHANGELOG は per-PR で都度更新せず version-up 直前に一括追記する運用方針を「リリース時の手順」に明文化。
- **CHANGELOG**: v1.0 エントリを初回最小に凝縮。層数の数値表記を除去（層名の列挙は維持）。
- **README**: doc 一覧を doc-role に整合（CONTRIBUTING を追加、CODING_GUIDE の説明を「利用者向け運用ガイド」に訂正）。

## 検証

- `pnpm run check` PASS（Prettier 整形 + Stylelint / ESLint / markuplint）
- 独立レビュー PASS: cross-reference の dangling ゼロ / 家族規約（JS-CSS 分離）は保持 / 層数表記の除去を確認

## マージ方針

v1.0 一斉リリースの一環。**承認まで draft で保持**（base = `v1.2`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
