### PR TITLE
fix(css): flat セレクタ 4 箇所をネスト統一 + tsconfig 新設

### DIFF
--- a/src/assets/css/component/c-hamburger.css
+++ b/src/assets/css/component/c-hamburger.css
@@ -46,18 +46,18 @@
   &::after {
     translate: 0 var(--_line-gap);
   }
-}
 
-.c-hamburger[aria-expanded='true'] .c-hamburger__line {
-  background-color: transparent;
+  .c-hamburger[aria-expanded='true'] & {
+    background-color: transparent;
 
-  &::before {
-    rotate: 45deg;
-    translate: 0 0;
-  }
+    &::before {
+      rotate: 45deg;
+      translate: 0 0;
+    }
 
-  &::after {
-    rotate: -45deg;
-    translate: 0 0;
+    &::after {
+      rotate: -45deg;
+      translate: 0 0;
+    }
   }
 }

--- a/src/assets/css/component/c-section-heading.css
+++ b/src/assets/css/component/c-section-heading.css
@@ -11,9 +11,7 @@
 }
 
 .c-section-heading__title {
-  /* スタイルなし（HTML クラスとの対応を維持） */
-}
-
-.c-section-heading__eyebrow + .c-section-heading__title {
-  margin-block-start: var(--space-sm);
+  .c-section-heading__eyebrow + & {
+    margin-block-start: var(--space-sm);
+  }
 }

--- a/src/assets/css/layout/l-page.css
+++ b/src/assets/css/layout/l-page.css
@@ -4,8 +4,8 @@
   display: flex;
   flex-direction: column;
   min-block-size: 100dvb;
-}
 
-.l-page > main {
-  flex: 1;
+  > main {
+    flex: 1;
+  }
 }

--- a/src/assets/css/project/p-features.css
+++ b/src/assets/css/project/p-features.css
@@ -26,11 +26,9 @@
 }
 
 .p-features__card {
-  /* スタイルなし（HTML クラスとの対応を維持） */
-}
-
-.p-features__item:nth-child(even) .p-features__card {
-  @container (inline-size >= 50rem) {
-    --media-card-first-order: 2;
+  .p-features__item:nth-child(even) & {
+    @container (inline-size >= 50rem) {
+      --media-card-first-order: 2;
+    }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "strict": true,
+    "noEmit": true,
+    "types": ["node"],
+    "allowJs": true,
+    "skipLibCheck": true
+  },
+  "include": ["vite.config.ts"]
+}


### PR DESCRIPTION
## Summary
- flat セレクタ 4 箇所を既存の `&` ネスト記法に統一（詳細度は変更なし、ビルド後 CSS のセレクタ展開が変更前と一致することを確認済み）
  - `src/assets/css/layout/l-page.css`: `.l-page > main` → `.l-page` ブロック内 `> main`
  - `src/assets/css/component/c-hamburger.css`: `.c-hamburger[aria-expanded='true'] .c-hamburger__line` → `.c-hamburger__line` ブロック内 `.c-hamburger[aria-expanded='true'] &`
  - `src/assets/css/component/c-section-heading.css`: `.c-section-heading__eyebrow + .c-section-heading__title` → `.c-section-heading__title` ブロック内 `.c-section-heading__eyebrow + &`
  - `src/assets/css/project/p-features.css`: `.p-features__item:nth-child(even) .p-features__card` → `.p-features__card` ブロック内 `.p-features__item:nth-child(even) &`
- ルートに `tsconfig.json` を新設し `vite.config.ts` の型エラーを解消（`@types/node` は既存 devDependencies に存在済み、追加不要）

## Test plan
- [x] `pnpm exec tsc --noEmit` → No errors found
- [x] `pnpm build` → 成功
- [x] `pnpm run lint:css` (stylelint --fix) → エラーなし
- [x] `pnpm run lint:js` (eslint --fix) → エラーなし
- [x] `pnpm run lint:html` (markuplint) → 3 ファイル全て passed
- [x] ビルド出力 CSS の grep で該当 4 箇所のセレクタ展開が従前と同一であることを確認