### PR TITLE
chore: コメント監査の削除裁定 2 系統を適用（関数内チャンク見出し + fallback ナレーション）

### DIFF
--- a/src/assets/scripts/main.js
+++ b/src/assets/scripts/main.js
@@ -223,7 +223,6 @@ function initFormValidation(options = {}) {
       return field;
     }
 
-    // 送信時バリデーション
     form.addEventListener('submit', (event) => {
       let firstInvalid = null;
 
@@ -236,20 +235,17 @@ function initFormValidation(options = {}) {
         if (!input) return;
 
         if (!input.checkValidity()) {
-          // エラー表示
           errorEl.textContent = input.validationMessage;
           errorEl.hidden = false;
           field.setAttribute('aria-invalid', 'true');
           if (!firstInvalid) firstInvalid = input;
         } else {
-          // エラー解除
           errorEl.textContent = '';
           errorEl.hidden = true;
           field.removeAttribute('aria-invalid');
         }
       });
 
-      // 最初のエラーフィールドに focus
       if (firstInvalid) {
         event.preventDefault();
         firstInvalid.focus({ preventScroll: false });
@@ -257,7 +253,6 @@ function initFormValidation(options = {}) {
       }
     });
 
-    // input / change イベントで有効化時にエラー解除
     fields.forEach((field) => {
       const errorId = field.getAttribute('aria-describedby');
       const errorEl = document.getElementById(errorId);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -59,8 +59,6 @@ export default defineConfig({
             const distDir = resolve(__dirname, 'dist');
 
             // 既存ファイル / ディレクトリが存在する場合は Vite に処理を委譲する
-            // 候補 1: dist/{url}（静的ファイル直接 or ディレクトリ）
-            // 候補 2: dist/{url}/index.html（ディレクトリ配下の index.html）
             const candidates = [resolve(distDir, url.slice(1)), resolve(distDir, url.slice(1), 'index.html')];
 
             for (const candidate of candidates) {
@@ -69,7 +67,6 @@ export default defineConfig({
               }
             }
 
-            // どちらも存在しない → 404.html を 404 ステータスで返す
             const notFoundPath = resolve(distDir, '404.html');
             if (fs.existsSync(notFoundPath)) {
               res.statusCode = 404;


### PR DESCRIPTION
## Summary
- comment-audit で「残す 7 カテゴリ外」と裁定されたコメントを削除
  - `src/assets/scripts/main.js`: フォームバリデーション処理内のチャンク見出しコメント 5 件
  - `vite.config.ts`: 404 fallback 分岐の候補列挙 / 分岐結果ナレーションコメント 3 行
- WCAG 根拠・運用注意・Why not を含む行は維持（削除対象外）

## Test plan
- [x] `pnpm build` 成功
- [x] `pnpm run check`（stylelint / eslint / markuplint）全 green
- [x] 削除対象コメント文言の残存 grep ゼロ確認