### PR TITLE
fix(drawer): 状態遷移バグ一括修正（世代ガード + アニメ待ち timeout + rem 統一 + aria-modal 削除 + form 堅牢化）

### DIFF
--- a/CODING_GUIDE.md
+++ b/CODING_GUIDE.md
@@ -152,7 +152,7 @@ Vite は `publicDir`（= `public/`）配下のファイルをそのまま `dist/
 ```html
 <header class="l-header p-header">...</header>
 <div class="c-overlay" data-drawer-overlay hidden></div>
-<dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title" aria-modal="true">
+<dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title">
   ...
 </dialog>
 <main ... data-drawer-inert>...</main>
@@ -166,7 +166,7 @@ starter 固有の設計判断: `--z-header` を `--z-drawer` より前面に置�
 
 ### show() 運用上の SR 実機検証手順
 
-`show()` は `showModal()` の自動 focus trap を持たないため、`inert` + `aria-modal` で同等の挙動を再現できているか実機検証が必要です。
+`show()` は `showModal()` の自動 focus trap を持たないため、`inert` で同等の挙動を再現できているか実機検証が必要です。`aria-modal="true"` は付与しません（`show()` は modeless であり、ブラウザ・SR はダイアログを modal として扱わないため、`aria-modal="true"` は実態と矛盾する。ダイアログとしての announce は `<dialog>` の暗黙 role="dialog" が担う）。
 
 | 環境 | 検証項目 |
 |------|---------|
@@ -180,7 +180,7 @@ starter 固有の設計判断: `--z-header` を `--z-drawer` より前面に置�
 - [ ] Tab で drawer 内のフォーカス可能要素のみを巡回する（drawer 外に脱出しない）
 - [ ] ハンバーガーボタン（trigger）は inert ではないので Tab で到達して閉じられる
 - [ ] Escape キーで close される（JS 実装）
-- [ ] `aria-modal="true"` により SR が「ダイアログ」として announce する
+- [ ] `<dialog>` の暗黙 role="dialog" により SR が「ダイアログ」として announce する
 - [ ] `aria-labelledby` で参照されるドロワータイトルが SR で読み上げられる
 
 `inert` 属性は WCAG 2.1.1 Keyboard (Level A) と 2.4.3 Focus Order に直結します。新規の自己配置型 Component を追加する際は、必ず `data-drawer-inert` の付与要否を確認してください（後述「data-drawer-inert」節と同じ運用）。

--- a/src/404.html
+++ b/src/404.html
@@ -63,7 +63,7 @@
 
     <!-- Drawer -->
     <div class="c-overlay" data-drawer-overlay hidden></div>
-    <dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title" aria-modal="true">
+    <dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title">
       <div class="p-drawer__stack">
         <span class="u-visually-hidden" id="drawer-title">ナビゲーションメニュー</span>
         <nav class="p-drawer__nav" aria-label="ドロワーナビゲーション">

--- a/src/assets/scripts/main.js
+++ b/src/assets/scripts/main.js
@@ -17,10 +17,10 @@
 /**
  * ドロワーメニュー（dialog show/close + inert）を初期化する。
  * @param {Object} [options] - カスタマイズオプション
- * @param {number} [options.breakpoint=768] - PC 判定のブレイクポイント (px)。p-header.css の `@media` と同値にすること（SP/PC 切替時にドロワーを自動で閉じる判定に使用）
+ * @param {string} [options.breakpoint='48rem'] - PC 判定のブレイクポイント。p-header.css の `@media (width >= ...)` と同値にすること（SP/PC 切替時にドロワーを自動で閉じる判定に使用）。CSS が rem 基準のため、JS 側も rem 表記で帯域ズレを防ぐ
  */
 function initDrawer(options = {}) {
-  const { breakpoint = 768 } = options;
+  const { breakpoint = '48rem' } = options;
 
   const drawer = document.querySelector('[data-drawer]');
   if (!drawer) return;
@@ -30,64 +30,82 @@ function initDrawer(options = {}) {
   const inertTargets = document.querySelectorAll('[data-drawer-inert]');
   const drawerLinks = drawer.querySelectorAll('a');
 
-  let isAnimating = false;
+  // 世代カウンター：open / close / PC 化の各操作が自分の世代番号を持ち、rAF やアニメ完了 await 後の
+  // 遅延処理は「自分の世代がまだ最新か」を確認してから状態を触る。古い操作の遅延コールバックが
+  // 新しい状態を上書きするのを防ぐ（アニメ中の breakpoint 越え resize / 連続トグルの取りこぼし対策）。
+  let generation = 0;
 
   function openDrawer() {
-    if (isAnimating) return;
-    isAnimating = true;
+    const gen = ++generation;
 
     if (overlay) overlay.hidden = false;
     drawer.show();
+    inertTargets.forEach((el) => el.setAttribute('inert', ''));
+    hamburgers.forEach((btn) => btn.setAttribute('aria-expanded', 'true'));
+
     // rAF 2段：show() 直後に付与すると初期状態が描画されずアニメーションが効かない
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
-        if (!drawer.open) {
-          isAnimating = false;
-          return;
-        }
+        if (gen !== generation || !drawer.open) return;
         drawer.dataset.open = '';
-        isAnimating = false;
       });
     });
-    inertTargets.forEach((el) => el.setAttribute('inert', ''));
-    hamburgers.forEach((btn) => btn.setAttribute('aria-expanded', 'true'));
 
     const firstFocusable = drawer.querySelector('a, button, [tabindex="0"]');
     firstFocusable?.focus({ preventScroll: true });
   }
 
+  // アニメ完了待ち。transition 無効化カスタマイズや無限アニメ同居では完了イベントが発火せず永久に
+  // close できなくなるため（Why not: 完了待ちが解決しない構成での恒久 deadlock 回避）、上限 800ms で
+  // 打ち切る（--duration-normal 0.3s + 余裕）。
+  function waitForDrawerAnimation() {
+    const TIMEOUT_MS = 800;
+    const timeout = new Promise((resolve) => setTimeout(resolve, TIMEOUT_MS));
+    const animations = drawer.getAnimations({ subtree: true });
+    const done =
+      animations.length > 0
+        ? Promise.all(animations.map((a) => a.finished)).catch(() => {})
+        : new Promise((resolve) => {
+            drawer.addEventListener('transitionend', resolve, { once: true });
+          });
+    return Promise.race([done, timeout]);
+  }
+
   async function closeDrawer() {
     if (!drawer.open) return;
-    if (isAnimating) return;
-    isAnimating = true;
+    const gen = ++generation;
 
     delete drawer.dataset.open;
     hamburgers.forEach((btn) => btn.setAttribute('aria-expanded', 'false'));
 
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      if (overlay) overlay.hidden = true;
-      drawer.close();
-      inertTargets.forEach((el) => el.removeAttribute('inert'));
-    } else {
-      const allAnimations = drawer.getAnimations({ subtree: true });
-      if (allAnimations.length > 0) {
-        await Promise.all(allAnimations.map((a) => a.finished)).catch(() => {});
-      } else {
-        await new Promise((resolve) => {
-          drawer.addEventListener('transitionend', resolve, { once: true });
-        });
-      }
-      if (overlay) overlay.hidden = true;
-      drawer.close();
-      inertTargets.forEach((el) => el.removeAttribute('inert'));
+    if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      await waitForDrawerAnimation();
+      // 待機中に新しい操作（別の open / close / PC 化）が始まっていたら後片付けを新世代に委ねる
+      if (gen !== generation) return;
     }
 
-    isAnimating = false;
+    if (overlay) overlay.hidden = true;
+    drawer.close();
+    inertTargets.forEach((el) => el.removeAttribute('inert'));
+  }
+
+  // PC 化時はドロワー自体が不可視になるためアニメ不要。世代を進めて進行中の open / close の残処理を
+  // 無効化し、状態を同期的に解除する（アニメ完了待ちの窓で close が取りこぼされる問題を回避）。
+  function closeImmediately() {
+    ++generation;
+    delete drawer.dataset.open;
+    hamburgers.forEach((btn) => btn.setAttribute('aria-expanded', 'false'));
+    if (overlay) overlay.hidden = true;
+    if (drawer.open) drawer.close();
+    inertTargets.forEach((el) => el.removeAttribute('inert'));
   }
 
   hamburgers.forEach((btn) => {
     btn.addEventListener('click', () => {
-      if (drawer.open) {
+      // トグル判定は「開く意図の状態」(data-open) を基準にする。アニメ中でも受け付けて世代を進める
+      // ため、閉じアニメ中の再クリックで開き直せる（native drawer.open は close() まで true のまま
+      // 残るのでトグル基準に使わない）。
+      if ('open' in drawer.dataset) {
         closeDrawer();
         btn.focus();
       } else {
@@ -119,8 +137,10 @@ function initDrawer(options = {}) {
     }
   });
 
-  window.matchMedia(`(min-width: ${breakpoint}px)`).addEventListener('change', (e) => {
-    if (e.matches) closeDrawer();
+  // p-header.css の @media (width >= 48rem) と同一表記。px 換算するとルートフォントサイズ変更時に
+  // CSS の rem 判定と帯域がズレるため、rem のまま matchMedia へ渡す。
+  window.matchMedia(`(width >= ${breakpoint})`).addEventListener('change', (e) => {
+    if (e.matches) closeImmediately();
   });
 }
 
@@ -223,12 +243,26 @@ function initFormValidation(options = {}) {
       return field;
     }
 
+    /**
+     * aria-describedby は複数 ID（ヒント文＋エラー文など）を空白区切りで持てるため、
+     * 各 ID を順に引いて `.c-form__error` を持つ要素をエラー表示先として採用する。
+     * 先頭 ID 決め打ちだとヒント文が先に来た場合にフィールド検証が黙って無効化される。
+     */
+    function getErrorElement(field) {
+      const describedby = field.getAttribute('aria-describedby');
+      if (!describedby) return null;
+      for (const id of describedby.trim().split(/\s+/)) {
+        const el = document.getElementById(id);
+        if (el?.classList.contains('c-form__error')) return el;
+      }
+      return null;
+    }
+
     form.addEventListener('submit', (event) => {
       let firstInvalid = null;
 
       fields.forEach((field) => {
-        const errorId = field.getAttribute('aria-describedby');
-        const errorEl = document.getElementById(errorId);
+        const errorEl = getErrorElement(field);
         if (!errorEl) return;
 
         const input = getRepresentativeInput(field);
@@ -253,9 +287,20 @@ function initFormValidation(options = {}) {
       }
     });
 
+    // reset 時にエラー表示 / aria-invalid が残留しないよう全フィールドをクリアする
+    form.addEventListener('reset', () => {
+      fields.forEach((field) => {
+        const errorEl = getErrorElement(field);
+        if (errorEl) {
+          errorEl.textContent = '';
+          errorEl.hidden = true;
+        }
+        field.removeAttribute('aria-invalid');
+      });
+    });
+
     fields.forEach((field) => {
-      const errorId = field.getAttribute('aria-describedby');
-      const errorEl = document.getElementById(errorId);
+      const errorEl = getErrorElement(field);
       if (!errorEl) return;
 
       const input = getRepresentativeInput(field);
@@ -285,7 +330,7 @@ initBackToTop();
 initFormValidation();
 
 // CUSTOMIZE 例:
-// initDrawer({ breakpoint: 1024 });
+// initDrawer({ breakpoint: '64rem' });
 // initStagger({ delayStep: 0.15 });
 // initScrollAnimation({ threshold: 0.3, rootMargin: '0px 0px -100px 0px' });
 // initBackToTop({ threshold: 500 });

--- a/src/index.html
+++ b/src/index.html
@@ -178,7 +178,7 @@
 
     <!-- Drawer -->
     <div class="c-overlay" data-drawer-overlay hidden></div>
-    <dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title" aria-modal="true">
+    <dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title">
       <div class="p-drawer__stack">
         <span class="u-visually-hidden" id="drawer-title">ナビゲーションメニュー</span>
         <nav class="p-drawer__nav" aria-label="ドロワーナビゲーション">

--- a/src/privacy/index.html
+++ b/src/privacy/index.html
@@ -103,7 +103,7 @@
 
     <!-- Drawer -->
     <div class="c-overlay" data-drawer-overlay hidden></div>
-    <dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title" aria-modal="true">
+    <dialog class="p-drawer" id="drawer" data-drawer aria-labelledby="drawer-title">
       <div class="p-drawer__stack">
         <span class="u-visually-hidden" id="drawer-title">ナビゲーションメニュー</span>
         <nav class="p-drawer__nav" aria-label="ドロワーナビゲーション">


### PR DESCRIPTION
## 概要

drawer / フォームバリデーションの状態遷移バグを一括修正。base = `v1.2`。

## 修正対応表

| # | 分類 | 内容 | 修正 |
|---|------|------|------|
| 1 | 実再現確定 | open アニメ中の breakpoint 越え resize で PC に drawer 残留 | 世代カウンター方式。`isAnimating` boolean を廃し、rAF / await 後の遅延処理を `gen === generation` でガード。PC 化は `closeImmediately()`（アニメなし即時 close、世代を進めて進行中処理を無効化） |
| 2 | 実再現確定 | アニメ完了待ちに timeout がなく transition 無効化で恒久 deadlock | `Promise.race([完了待ち, setTimeout 800ms])`。800ms = `--duration-normal` 0.3s + 余裕 |
| 3 | 静的確定 | JS breakpoint px vs CSS rem の帯域ズレ | `matchMedia('(width >= 48rem)')`（p-header.css の `@media` と同一表記）。option も `'48rem'` 文字列に変更 |
| 4 | 静的確定 | drawer の `aria-modal="true"` が modeless `show()` と矛盾 | 全 HTML から削除（index.html / 404.html + **privacy/index.html も同症状のため同時修正**）。暗黙 `role="dialog"` が announce を担う。CODING_GUIDE の該当記述も同期 |
| 5 | 堅牢化 | form reset でエラー表示 / aria-invalid が残留 | `form.addEventListener('reset', ...)` で全フィールドをクリア |
| 6 | 堅牢化 | `aria-describedby` 複数 ID でフィールド検証が黙って無効化 | `getErrorElement()` で空白 split → `.c-form__error` を持つ要素を採用 |

**#9（閉じアニメ中の再クリック無反応）も #1 の世代方式で同時解消**: トグル判定を native `drawer.open` から「開く意図の状態」`'open' in drawer.dataset` に変更し、閉じアニメ中の再クリックで開き直せる。

## 世代ガードのコードウォーク

- **open 中 → PC 化**: `closeImmediately` が `++gen`→2 で同期 close。openDrawer の rAF は `gen(1)!==2` で `data-open` 付与をスキップ → PC で閉じたまま
- **close 中 → open（再クリック）**: `data-open` は closeDrawer 冒頭で削除済 → openDrawer が `++gen`→2。closeDrawer は await 後 `gen(1)!==2` で `close()` をスキップ → 開き直る
- **open 中 → close**: openDrawer の rAF は gen 不一致でスキップ、closeDrawer が正常 close
- **transition:none deadlock**: getAnimations 空 → transitionend 発火せず → 800ms timeout が race で解決 → close 続行

## 検証

- `pnpm run check`（format + stylelint + eslint + markuplint）**全 green**
- `pnpm run build` **成功**（main.js 4.48 kB, 7 modules）
- ブラウザ実描画確認は本環境では**未実施**（dev/preview 起動なし）。#1 / #2 はコードウォークで担保。cortex 側での実描画検証を推奨

## AR 観点（本 PR 独立、レポートは公開リポに commit せず本文に記載）

- **層帰属**: JS フック（`main.js`）と HTML 属性のみ。CSS 層構造への影響なし
- **命名規則 / Custom Property**: 変更なし
- **コメント方針（CODING_GUIDE）**: 追加コメントは Why not（deadlock timeout）/ 非自明な設計意図（世代ガード / トグル基準）/ 値同期注意（rem 統一）に限定。How narration なし
- **a11y**: `aria-modal` 削除は modeless `show()` の実態整合（暗黙 role=dialog 維持）。inert focus trap は不変。form の aria-invalid / エラー残留を解消し WCAG 3.3.1 の情報一貫性を改善
- **副作用**: `data-open` はトグル基準に昇格したが CSS translate トリガーとしての役割は不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)