### PR TITLE
fix(form): エラー要素の JS フックを data-form-error 属性へ（class 判定の規約違反是正）

### DIFF
--- a/src/assets/scripts/main.js
+++ b/src/assets/scripts/main.js
@@ -245,7 +245,7 @@ function initFormValidation(options = {}) {
 
     /**
      * aria-describedby は複数 ID（ヒント文＋エラー文など）を空白区切りで持てるため、
-     * 各 ID を順に引いて `.c-form__error` を持つ要素をエラー表示先として採用する。
+     * 各 ID を順に引いて `data-form-error` を持つ要素をエラー表示先として採用する。
      * 先頭 ID 決め打ちだとヒント文が先に来た場合にフィールド検証が黙って無効化される。
      */
     function getErrorElement(field) {
@@ -253,7 +253,7 @@ function initFormValidation(options = {}) {
       if (!describedby) return null;
       for (const id of describedby.trim().split(/\s+/)) {
         const el = document.getElementById(id);
-        if (el?.classList.contains('c-form__error')) return el;
+        if (el?.hasAttribute('data-form-error')) return el;
       }
       return null;
     }

--- a/src/index.html
+++ b/src/index.html
@@ -641,7 +641,7 @@
                 required
                 aria-describedby="name-error"
               />
-              <p class="c-form__error" id="name-error" role="alert" hidden></p>
+              <p class="c-form__error" data-form-error id="name-error" role="alert" hidden></p>
             </div>
 
             <div class="c-form__field">
@@ -657,7 +657,7 @@
                 required
                 aria-describedby="email-error"
               />
-              <p class="c-form__error" id="email-error" role="alert" hidden></p>
+              <p class="c-form__error" data-form-error id="email-error" role="alert" hidden></p>
             </div>
 
             <div class="c-form__field">
@@ -670,7 +670,7 @@
                 autocomplete="tel"
                 aria-describedby="tel-error"
               />
-              <p class="c-form__error" id="tel-error" role="alert" hidden></p>
+              <p class="c-form__error" data-form-error id="tel-error" role="alert" hidden></p>
             </div>
 
             <div class="c-form__field">
@@ -683,7 +683,7 @@
                 <option value="inquiry">施術に関するお問い合わせ</option>
                 <option value="other">その他</option>
               </select>
-              <p class="c-form__error" id="category-error" role="alert" hidden></p>
+              <p class="c-form__error" data-form-error id="category-error" role="alert" hidden></p>
             </div>
 
             <fieldset class="c-form__field" aria-describedby="plan-error">
@@ -706,7 +706,7 @@
                   リラクゼーション（90分）
                 </label>
               </div>
-              <p class="c-form__error" id="plan-error" role="alert" hidden></p>
+              <p class="c-form__error" data-form-error id="plan-error" role="alert" hidden></p>
             </fieldset>
 
             <fieldset class="c-form__field">
@@ -739,7 +739,7 @@
                 required
                 aria-describedby="message-error"
               ></textarea>
-              <p class="c-form__error" id="message-error" role="alert" hidden></p>
+              <p class="c-form__error" data-form-error id="message-error" role="alert" hidden></p>
             </div>
 
             <div class="c-form__field">
@@ -751,7 +751,7 @@
                   ></span
                 >
               </label>
-              <p class="c-form__error" id="agree-error" role="alert" hidden></p>
+              <p class="c-form__error" data-form-error id="agree-error" role="alert" hidden></p>
             </div>
 
             <div class="c-form__actions">


### PR DESCRIPTION
## 概要
フォームエラー表示要素の JS フックが `classList.contains('c-form__error')` という class 判定になっていた。本リポの規約は「JS フックは data-*、class は styling 専用」（CODING_GUIDE の `data-drawer-*` パターン参照）であり違反していたため是正する。

## 変更内容
- `src/index.html`: 7 箇所のエラー要素 (`<p class="c-form__error" ...>`) に `data-form-error` 属性を追加（class は styling 用にそのまま維持、属性順は `class → data-* → id → role → hidden` で既存 `data-drawer-*` パターンに準拠）
- `src/assets/scripts/main.js`: `getErrorElement()` の判定を `classList.contains('c-form__error')` → `hasAttribute('data-form-error')` に変更、関連コメントを同期

## 検証
- [x] `npm run check`（stylelint / eslint / markuplint）all green
- [x] `npm run build` 成功
- [x] `classList.contains` によるフック判定の残存ゼロ（grep 確認）
- [x] `data-form-error` が 7 箇所全てに付与され JS 側と対応することを grep で確認
- [x] AR: 既存 `data-drawer-*` 命名・属性順パターンとの整合を確認済み

## 起動時 / 完了時ブランチ
- 起動時: v1.2（統合ブランチ）から分岐
- 完了時: v1.2 に復帰予定（マージは cortex 側で実施）