### PR TITLE
fix(drawer): close 時の focus に preventScroll を指定（Safari の微スクロール解消）

### DIFF
--- a/src/assets/scripts/main.js
+++ b/src/assets/scripts/main.js
@@ -107,7 +107,7 @@ function initDrawer(options = {}) {
       // 残るのでトグル基準に使わない）。
       if ('open' in drawer.dataset) {
         closeDrawer();
-        btn.focus();
+        btn.focus({ preventScroll: true });
       } else {
         openDrawer();
       }


### PR DESCRIPTION
## Summary
- drawer のハンバーガー再クリック close 経路にある `btn.focus();`（main.js:110）に `preventScroll: true` を追加
- 同ファイル内の他の focus 呼び出しは既に preventScroll 指定済みで、この 1 箇所だけが取り残しだった
- Safari で drawer close 時に発生していた微スクロールを解消

## Test plan
- [x] `npm run check`（stylelint / eslint / markuplint）green
- [x] `npm run build` 成功
- [x] `grep -nF "focus()" src/assets/scripts/main.js` で未指定の focus() が残っていないこと確認