### PR TITLE
fix(ci): pnpm audit の legacy endpoint 廃止（410）に対応 + v1.0.1

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,7 +33,12 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Security audit
-        run: pnpm audit --audit-level high
+        # pnpm v10 系の `pnpm audit` は npm レジストリが廃止した legacy audit endpoint
+        # （/-/npm/v1/security/audits[/quick]、2026-07-15 廃止）を呼ぶため 410 で失敗する
+        # （pnpm/pnpm#13033、公式トリアージ済み: pnpm v11 で新 bulk advisory endpoint に移行済み）。
+        # インストール/ビルドの主系統は pnpm v10 のまま維持し、audit だけ `pnpm dlx` で
+        # pnpm v11 を一時的に呼び出す（公式ワークアラウンド `pnx pnpm@latest-11 audit` に準拠）。
+        run: pnpm dlx pnpm@11 audit --audit-level high
 
       - name: Run check (format + lint)
         run: pnpm run check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ mFLOCSS starter の変更履歴。[Keep a Changelog](https://keepachangelog.com/
 
 CHANGELOG はリリース（version-up）直前に差分をまとめて追記します（運用方針は [CONTRIBUTING.md「リリース時の手順」](./CONTRIBUTING.md#リリース時の手順) 参照）。
 
+## [1.0.1] - 2026-07-17
+
+### Fixed
+
+- CI: `pnpm audit` が npm レジストリの legacy audit endpoint 廃止（2026-07-15）により 410 で失敗する問題を修正。Security audit ステップのみ `pnpm dlx pnpm@11 audit` に切り替え、pnpm v11 の新 bulk advisory endpoint を利用するよう変更
+
 ## [1.0.0] - 2026-07-13
 
 初回正式リリース。
@@ -16,4 +22,5 @@ CHANGELOG はリリース（version-up）直前に差分をまとめて追記し
 - WCAG 2.2 AA 準拠 + Core Web Vitals 配慮 + Dark mode 対応（`prefers-color-scheme`）
 - Community health files + GitHub Actions CI + Issue テンプレート
 
+[1.0.1]: https://github.com/mflocss/starter/releases/tag/v1.0.1
 [1.0.0]: https://github.com/mflocss/starter/releases/tag/v1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mflocss-starter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

npm レジストリが 2026-07-15 に legacy audit endpoint（`/-/npm/v1/security/audits[/quick]`）を廃止し、pnpm v10 系の `pnpm audit` が 410（`ERR_PNPM_AUDIT_BAD_RESPONSE`）で fail する状態になっていました（公開 main の CI が Security audit ステップで常時赤）。

pnpm/pnpm#13033 で公式トリアージ済み（state: accepted）。ワークアラウンドは pnpm v11 の新 bulk advisory endpoint を `pnpm dlx` で一時的に呼び出す方式（`pnx pnpm@latest-11 audit` 準拠）。

## 変更内容

- `.github/workflows/check.yml`: Security audit ステップを `pnpm audit --audit-level high` → `pnpm dlx pnpm@11 audit --audit-level high` に変更（Why コメント付き）。pnpm 本体のメジャーアップグレードはせず、audit ステップのみ最小差分で切り替え
- v1.0.1 パッチリリース準備: `package.json` version `1.0.0` → `1.0.1` / `CHANGELOG.md` に `## [1.0.1]` セクション追記

## firsthand 検証

| 検証 | 結果 |
|---|---|
| `pnpm audit --audit-level high`（旧） | 410 `ERR_PNPM_AUDIT_BAD_RESPONSE` で再現確認 |
| `pnpm dlx pnpm@11 audit --audit-level high`（新） | exit 0, `No known vulnerabilities found` |
| `pnpm run check`（format + lint:css + lint:js + lint:html） | clean |
| `pnpm run build` | 成功 |

## リリースについて

- tag（`v1.0.1`）は **本 PR では作成しません**。マージ後にリポジトリ管理者が付与します
- CONTRIBUTING.md「リリース時の手順」準拠（CHANGELOG セクション追記 + link references 更新）

## Test plan

- [x] `pnpm dlx pnpm@11 audit --audit-level high` が 410 で落ちないことを firsthand 確認
- [x] `pnpm run check` clean
- [x] `pnpm run build` 成功
- [ ] CI（GitHub Actions）green
- [ ] マージ（本 PR は作成のみ、マージ・tag 付与はリポジトリ管理者承認 gate）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
