### PR TITLE
fix(css): p-404__heading の空ルールセットを追加

### DIFF
--- a/src/assets/css/project/p-404.css
+++ b/src/assets/css/project/p-404.css
@@ -12,6 +12,10 @@
   justify-items: center;
 }
 
+.p-404__heading {
+  /* スタイルなし（HTML クラスとの対応を維持） */
+}
+
 .p-404__lead {
   line-height: var(--line-height-text);
   color: var(--color-text-light);


### PR DESCRIPTION
## 概要
src/404.html の `.p-404__heading` クラスに対応する CSS ルールセットが project 層に存在しなかったため、HTML クラスと CSS の 1:1 対応の維持を目的として空ルールセットを追加した。

## 検証結果
- `npm run check`（format / lint:css / lint:js / lint:html）すべて PASS