### PR TITLE
docs(scripts): main.js の JSDoc 注記 1 行を wordpress-starter と同一化

### DIFF
--- a/src/assets/scripts/main.js
+++ b/src/assets/scripts/main.js
@@ -247,6 +247,7 @@ function initFormValidation(options = {}) {
      * aria-describedby は複数 ID（ヒント文＋エラー文など）を空白区切りで持てるため、
      * 各 ID を順に引いて `data-form-error` を持つ要素をエラー表示先として採用する。
      * 先頭 ID 決め打ちだとヒント文が先に来た場合にフィールド検証が黙って無効化される。
+     * JS フックは class ではなく data-* 属性で判定する（CODING_GUIDE.md 規約）。
      */
     function getErrorElement(field) {
       const describedby = field.getAttribute('aria-describedby');


### PR DESCRIPTION
wordpress-starter 側の main.js に付いていた JSDoc 注記 1 行（JS フックは data-* 属性で判定する規約の明記）を取り込み、両リポの main.js を byte 同一に揃える。

- コード変更なし（コメントのみ）。eslint 通過
- 追加後、wordpress-starter tc の main.js と `cmp` で byte 一致を確認済み
- 背景: 両リポの drawer 挙動検証（#111 項目 2 = 誤検出と判定）の過程で、この 1 行だけが差分として残っていたため同期ノイズを除去する