### PR TITLE
fix(deps): 新 advisory 対応で brace-expansion / js-yaml の override 引き上げ（CI audit 復旧）

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,14 @@
   },
   "overrides": {
     "uuid": ">=14.0.0",
-    "js-yaml": ">=4.2.0"
+    "js-yaml": ">=5.2.1",
+    "brace-expansion": ">=5.0.7"
   },
   "pnpm": {
     "overrides": {
       "uuid": ">=14.0.0",
-      "js-yaml": ">=4.2.0"
+      "js-yaml": ">=5.2.1",
+      "brace-expansion": ">=5.0.7"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,8 @@ settings:
 
 overrides:
   uuid: '>=14.0.0'
-  js-yaml: '>=4.2.0'
+  js-yaml: '>=5.2.1'
+  brace-expansion: '>=5.0.7'
 
 importers:
 
@@ -434,8 +435,8 @@ packages:
   bcp-47@2.1.0:
     resolution: {integrity: sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -816,8 +817,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.1.0:
-    resolution: {integrity: sha512-s8VA5jkR8f22S3NAXmhKPFqGUduqZGlsufabVOgN14iTdw/RXcym7bKkbwjxLK9Yw2lEvvmJjFp119+KPeo8Kg==}
+  js-yaml@5.2.1:
+    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -1778,7 +1779,7 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -1814,7 +1815,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 5.1.0
+      js-yaml: 5.2.1
       parse-json: 5.2.0
 
   cross-spawn@7.0.6:
@@ -2131,7 +2132,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.1.0:
+  js-yaml@5.2.1:
     dependencies:
       argparse: 2.0.1
 
@@ -2278,7 +2279,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
Actions run 29826138402 / 29825922189 の失敗対応。原因はコード変更ではなく新規 advisory:

- brace-expansion DoS（GHSA-3jxr-9vmj-r5cp, **high**）: override `>=5.0.7` へ
- js-yaml quadratic DoS ×2（moderate）: override `>=5.2.1` へ

`pnpm dlx pnpm@11 audit` → **No known vulnerabilities found**、`pnpm run check` / `build` 通過を確認済み。

補足: pnpm v11 の「`pnpm` フィールドは読まれない」WARN が出るが、lockfile は v10 install（pnpm.overrides 有効）で生成されるため audit は override 後のバージョンを見る。恒久対応（設定の新ホームへの移行）は v11 主系統移行時に実施。