### PR TITLE
release: v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ CHANGELOG はリリース（version-up）直前に差分をまとめて追記し
 
 ### Changed
 
-- `main.js` の `getErrorElement` の JSDoc に「JS フックは class ではなく data-* 属性で判定する（CODING_GUIDE.md 規約）」の注記を追加
 - 依存の override を引き上げ: `brace-expansion` >=5.0.9 / `js-yaml` >=5.2.2 / `fast-uri` >=3.1.5 / `postcss` >=8.5.18 を追加（新規 advisory 対応、pnpm audit 全解消）
 
 ## [1.0.2] - 2026-07-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ CHANGELOG はリリース（version-up）直前に差分をまとめて追記し
 ### Changed
 
 - `main.js` の `getErrorElement` の JSDoc に「JS フックは class ではなく data-* 属性で判定する（CODING_GUIDE.md 規約）」の注記を追加
-- 依存の override を引き上げ: `brace-expansion` >=5.0.7 / `js-yaml` >=5.2.1（新規 advisory 対応、pnpm audit 全解消）
+- 依存の override を引き上げ: `brace-expansion` >=5.0.9 / `js-yaml` >=5.2.2 / `fast-uri` >=3.1.5 / `postcss` >=8.5.18 を追加（新規 advisory 対応、pnpm audit 全解消）
 
 ## [1.0.2] - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ mFLOCSS starter の変更履歴。[Keep a Changelog](https://keepachangelog.com/
 
 CHANGELOG はリリース（version-up）直前に差分をまとめて追記します（運用方針は [CONTRIBUTING.md「リリース時の手順」](./CONTRIBUTING.md#リリース時の手順) 参照）。
 
+## [1.0.3] - 2026-08-04
+
+### Added
+
+- `.p-404__heading` の空ルールセットを追加（HTML のクラスと CSS の 1:1 対応を維持するため）
+
+### Changed
+
+- `main.js` の `getErrorElement` の JSDoc に「JS フックは class ではなく data-* 属性で判定する（CODING_GUIDE.md 規約）」の注記を追加
+- 依存の override を引き上げ: `brace-expansion` >=5.0.7 / `js-yaml` >=5.2.1（新規 advisory 対応、pnpm audit 全解消）
+
 ## [1.0.2] - 2026-07-17
 
 ### Added
@@ -33,6 +44,7 @@ CHANGELOG はリリース（version-up）直前に差分をまとめて追記し
 - WCAG 2.2 AA 準拠 + Core Web Vitals 配慮 + Dark mode 対応（`prefers-color-scheme`）
 - Community health files + GitHub Actions CI + Issue テンプレート
 
+[1.0.3]: https://github.com/mflocss/starter/releases/tag/v1.0.3
 [1.0.2]: https://github.com/mflocss/starter/releases/tag/v1.0.2
 [1.0.1]: https://github.com/mflocss/starter/releases/tag/v1.0.1
 [1.0.0]: https://github.com/mflocss/starter/releases/tag/v1.0.0

--- a/package.json
+++ b/package.json
@@ -28,12 +28,14 @@
   },
   "overrides": {
     "uuid": ">=14.0.0",
-    "js-yaml": ">=4.2.0"
+    "js-yaml": ">=5.2.1",
+    "brace-expansion": ">=5.0.7"
   },
   "pnpm": {
     "overrides": {
       "uuid": ">=14.0.0",
-      "js-yaml": ">=4.2.0"
+      "js-yaml": ">=5.2.1",
+      "brace-expansion": ">=5.0.7"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,14 +28,18 @@
   },
   "overrides": {
     "uuid": ">=14.0.0",
-    "js-yaml": ">=5.2.1",
-    "brace-expansion": ">=5.0.7"
+    "js-yaml": ">=5.2.2",
+    "brace-expansion": ">=5.0.9",
+    "fast-uri": ">=3.1.5",
+    "postcss": ">=8.5.18"
   },
   "pnpm": {
     "overrides": {
       "uuid": ">=14.0.0",
-      "js-yaml": ">=5.2.1",
-      "brace-expansion": ">=5.0.7"
+      "js-yaml": ">=5.2.2",
+      "brace-expansion": ">=5.0.9",
+      "fast-uri": ">=3.1.5",
+      "postcss": ">=8.5.18"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mflocss-starter",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,8 @@ settings:
 
 overrides:
   uuid: '>=14.0.0'
-  js-yaml: '>=4.2.0'
+  js-yaml: '>=5.2.1'
+  brace-expansion: '>=5.0.7'
 
 importers:
 
@@ -434,8 +435,8 @@ packages:
   bcp-47@2.1.0:
     resolution: {integrity: sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -816,8 +817,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.1.0:
-    resolution: {integrity: sha512-s8VA5jkR8f22S3NAXmhKPFqGUduqZGlsufabVOgN14iTdw/RXcym7bKkbwjxLK9Yw2lEvvmJjFp119+KPeo8Kg==}
+  js-yaml@5.2.1:
+    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -1778,7 +1779,7 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -1814,7 +1815,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 5.1.0
+      js-yaml: 5.2.1
       parse-json: 5.2.0
 
   cross-spawn@7.0.6:
@@ -2131,7 +2132,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.1.0:
+  js-yaml@5.2.1:
     dependencies:
       argparse: 2.0.1
 
@@ -2278,7 +2279,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimist@1.2.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,10 @@ settings:
 
 overrides:
   uuid: '>=14.0.0'
-  js-yaml: '>=5.2.1'
-  brace-expansion: '>=5.0.7'
+  js-yaml: '>=5.2.2'
+  brace-expansion: '>=5.0.9'
+  fast-uri: '>=3.1.5'
+  postcss: '>=8.5.18'
 
 importers:
 
@@ -435,9 +437,9 @@ packages:
   bcp-47@2.1.0:
     resolution: {integrity: sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -614,8 +616,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -817,8 +819,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+  js-yaml@5.2.3:
+    resolution: {integrity: sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -1001,13 +1003,8 @@ packages:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
     hasBin: true
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1080,7 +1077,7 @@ packages:
     resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
     engines: {node: '>=18.0'}
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: '>=8.5.18'
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -1089,17 +1086,13 @@ packages:
   postcss-sorting@10.0.0:
     resolution: {integrity: sha512-TXbU+h6vVRW+86c/+ewhWq9k7pr7ijASTnepVhCQiC87zAOTkvB1v2dHyWP+ggstSTX/PNvjzS+IOqzejndz9w==}
     peerDependencies:
-      postcss: ^8.4.20
+      postcss: '>=8.5.18'
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -1753,7 +1746,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -1779,7 +1772,7 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -1815,7 +1808,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 5.2.1
+      js-yaml: 5.2.3
       parse-json: 5.2.0
 
   cross-spawn@7.0.6:
@@ -1956,7 +1949,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@4.1.2: {}
 
   fastest-levenshtein@1.0.16: {}
 
@@ -2132,7 +2125,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.2.1:
+  js-yaml@5.2.3:
     dependencies:
       argparse: 2.0.1
 
@@ -2279,7 +2272,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -2293,9 +2286,7 @@ snapshots:
 
   mustache@4.2.0: {}
 
-  nanoid@3.3.11: {}
-
-  nanoid@3.3.15: {}
+  nanoid@3.3.16: {}
 
   natural-compare@1.4.0: {}
 
@@ -2359,30 +2350,24 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss-safe-parser@7.0.1(postcss@8.5.10):
+  postcss-safe-parser@7.0.1(postcss@8.5.25):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.25
 
   postcss-selector-parser@7.1.1:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-sorting@10.0.0(postcss@8.5.15):
+  postcss-sorting@10.0.0(postcss@8.5.25):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.25
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.10:
+  postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.15:
-    dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2495,8 +2480,8 @@ snapshots:
 
   stylelint-order@8.1.1(stylelint@17.9.0):
     dependencies:
-      postcss: 8.5.15
-      postcss-sorting: 10.0.0(postcss@8.5.15)
+      postcss: 8.5.25
+      postcss-sorting: 10.0.0(postcss@8.5.25)
       stylelint: 17.9.0
 
   stylelint@17.9.0:
@@ -2528,8 +2513,8 @@ snapshots:
       micromatch: 4.0.8
       normalize-path: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.10
-      postcss-safe-parser: 7.0.1(postcss@8.5.10)
+      postcss: 8.5.25
+      postcss-safe-parser: 7.0.1(postcss@8.5.25)
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
       string-width: 8.2.0
@@ -2596,7 +2581,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.25
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/src/assets/css/project/p-404.css
+++ b/src/assets/css/project/p-404.css
@@ -12,6 +12,10 @@
   justify-items: center;
 }
 
+.p-404__heading {
+  /* スタイルなし（HTML クラスとの対応を維持） */
+}
+
 .p-404__lead {
   line-height: var(--line-height-text);
   color: var(--color-text-light);

--- a/src/assets/scripts/main.js
+++ b/src/assets/scripts/main.js
@@ -247,7 +247,6 @@ function initFormValidation(options = {}) {
      * aria-describedby は複数 ID（ヒント文＋エラー文など）を空白区切りで持てるため、
      * 各 ID を順に引いて `data-form-error` を持つ要素をエラー表示先として採用する。
      * 先頭 ID 決め打ちだとヒント文が先に来た場合にフィールド検証が黙って無効化される。
-     * JS フックは class ではなく data-* 属性で判定する（CODING_GUIDE.md 規約）。
      */
     function getErrorElement(field) {
       const describedby = field.getAttribute('aria-describedby');

--- a/src/assets/scripts/main.js
+++ b/src/assets/scripts/main.js
@@ -247,6 +247,7 @@ function initFormValidation(options = {}) {
      * aria-describedby は複数 ID（ヒント文＋エラー文など）を空白区切りで持てるため、
      * 各 ID を順に引いて `data-form-error` を持つ要素をエラー表示先として採用する。
      * 先頭 ID 決め打ちだとヒント文が先に来た場合にフィールド検証が黙って無効化される。
+     * JS フックは class ではなく data-* 属性で判定する（CODING_GUIDE.md 規約）。
      */
     function getErrorElement(field) {
       const describedby = field.getAttribute('aria-describedby');


### PR DESCRIPTION
v1.0.3 リリース。v1.0.2 以降の 3 件の変更をまとめて main に取り込む。

## 含まれる変更

- #260 `.p-404__heading` の空ルールセットを追加（HTML クラスと CSS の 1:1 対応維持）
- #261 `getErrorElement` の JSDoc に data-* フック規約の注記を追加
- #262 `brace-expansion` >=5.0.7 / `js-yaml` >=5.2.1 へ override 引き上げ（advisory 全解消）
- `chore(release): v1.0.3` — version bump + CHANGELOG 追記

## 確認

- CI: v1.0.3 ブランチで green
- CHANGELOG: 既存の体裁（link references は tag URL 形式）に準拠

マージ後に `v1.0.3` タグを main の該当コミットに切り、GitHub Release を作成する。